### PR TITLE
[MRG + 1] ENH: try making HNN GUI with ipywidgets

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Install HNN-core
         shell: bash -el {0}
         run: |
-          python setup.py --verbose install
+          python -m pip install --upgrade pip
+          pip install -e .[gui]
       - name: Lint with flake8
         shell: bash -el {0}
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -36,6 +36,7 @@ jobs:
           pip install flake8 pytest pytest-cov
           pip install mne psutil joblib
           pip install NEURON
+          pip install ipywidgets voila
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
             pip install mpi4py
           else
@@ -44,8 +45,7 @@ jobs:
       - name: Install HNN-core
         shell: bash -el {0}
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .[gui]
+          python setup.py --verbose install
       - name: Lint with flake8
         shell: bash -el {0}
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ recursive-include hnn_core/mod/x86_64 *
 recursive-include hnn_core/mod/x86_64/.libs *
 
 recursive-include hnn_core *.py
+recursive-include hnn_core *.ipynb
 
 ### Exclude
 

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ hnn-core
 	:target: https://codecov.io/gh/jonescompneurolab/hnn-core
 	:alt: Test coverage
 
+.. image:: https://user-images.githubusercontent.com/15852194/115123685-2df1ef00-9f8c-11eb-8f3b-663486466193.png
+   :target: https://user-images.githubusercontent.com/15852194/115123685-2df1ef00-9f8c-11eb-8f3b-663486466193.png
+   :alt: HNN-core GUI
+
 This is a leaner and cleaner version of the code based off the `HNN repository <https://github.com/jonescompneurolab/hnn>`_.
 
 It is early Work in Progress. Contributors are very welcome.

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ hnn-core
 	:target: https://codecov.io/gh/jonescompneurolab/hnn-core
 	:alt: Test coverage
 
-This is a leaner and cleaner version of the code based off the `HNN repository <https://github.com/jonescompneurolab/hnn>`_. However, a Graphical User Interface is not supported at the moment in this repository.
+This is a leaner and cleaner version of the code based off the `HNN repository <https://github.com/jonescompneurolab/hnn>`_.
 
 It is early Work in Progress. Contributors are very welcome.
 
@@ -27,6 +27,15 @@ Dependencies
 
 Optional dependencies
 ---------------------
+
+GUI
+~~~
+
+* ipywidgets
+* voila
+
+Parallel processing
+~~~~~~~~~~~~~~~~~~~
 
 * joblib (for simulating trials simultaneously)
 * mpi4py (for simulating the cells in parallel for a single trial). Also depends on:
@@ -57,6 +66,12 @@ To check if everything worked fine, you can do::
 	$ python -c 'import hnn_core'
 
 and it should not give any error messages.
+
+**GUI installation**
+
+To install the GUI dependencies along with ``hnn-core``, a simple tweak to the above command is needed::
+
+   $ pip install hnn_core[gui]
 
 **Parallel backends**
 

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ hnn-core
 	:target: https://codecov.io/gh/jonescompneurolab/hnn-core
 	:alt: Test coverage
 
-.. image:: https://user-images.githubusercontent.com/15852194/115123685-2df1ef00-9f8c-11eb-8f3b-663486466193.png
-   :target: https://user-images.githubusercontent.com/15852194/115123685-2df1ef00-9f8c-11eb-8f3b-663486466193.png
+.. image:: https://user-images.githubusercontent.com/11160442/178095018-35d2619a-6a82-4e27-91c9-ff2796fab435.png
+   :target: https://user-images.githubusercontent.com/11160442/178095018-35d2619a-6a82-4e27-91c9-ff2796fab435.png
    :alt: HNN-core GUI
 
 This is a leaner and cleaner version of the code based off the `HNN repository <https://github.com/jonescompneurolab/hnn>`_.

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,10 @@ To install the GUI dependencies along with ``hnn-core``, a simple tweak to the a
 
    $ pip install hnn_core[gui]
 
+To start the GUI, please do::
+
+   $ hnn-gui
+
 **Parallel backends**
 
 For further instructions on installation and usage of parallel backends for using more

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,3 @@
+set -e
+
+python setup.py build_mod

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,5 @@
+NEURON
+voila
+ipywidgets
+matplotlib
+scipy

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -8,12 +8,13 @@ import logging
 import multiprocessing
 import os
 import os.path as op
+import sys
 
 import matplotlib.pyplot as plt
 import numpy as np
 from IPython.display import display
-from ipywidgets import (HTML, Accordion, AppLayout, BoundedIntText,
-                        BoundedFloatText, Button, Dropdown, FileUpload,
+from ipywidgets import (HTML, Accordion, AppLayout, BoundedFloatText,
+                        BoundedIntText, Button, Dropdown, FileUpload,
                         FloatLogSlider, FloatText, GridspecLayout, HBox,
                         IntText, Layout, Output, RadioButtons, Tab, Text, VBox,
                         interactive_output)
@@ -24,7 +25,6 @@ from hnn_core import (JoblibBackend, MPIBackend, jones_2009_model, read_params,
 from hnn_core.params import (_extract_drive_specs_from_hnn_params, _read_json,
                              _read_legacy_params)
 from hnn_core.viz import plot_dipole
-
 
 log_file = os.getenv("HNNGUI_LOGFILE", None)
 debug_gui = os.getenv("DEBUG_HNNGUI", "0")
@@ -935,16 +935,14 @@ def run_hnn_gui():
         description='Layout:',
     )
     # initialize
-    initialize_viz_window(
-        viz_window,
-        variables,
-        plot_outputs_list,
-        plot_dropdowns_list,
-        viz_width,
-        viz_height,
-        layout_option=viz_layout_selection.value,
-        init=True
-    )
+    initialize_viz_window(viz_window,
+                          variables,
+                          plot_outputs_list,
+                          plot_dropdowns_list,
+                          viz_width,
+                          viz_height,
+                          layout_option=viz_layout_selection.value,
+                          init=True)
 
     def handle_viz_layout_change(layout_option):
         return initialize_viz_window(
@@ -1108,4 +1106,4 @@ def run_hnn_gui():
 def launch():
     from voila.app import main
     notebook_path = op.join(op.dirname(__file__), '..', 'hnn_widget.ipynb')
-    main([notebook_path])
+    main([notebook_path, *sys.argv[1:]])

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -932,9 +932,9 @@ def run_hnn_gui():
         'Layer 2/3 Pyramidal', 'Layer 5 Pyramidal', 'Layer 2 Basket',
         'Layer 5 Basket'
     ]
-    accordian = Accordion(children=boxes)
+    cell_connectivity = Accordion(children=boxes)
     for idx, title in enumerate(titles):
-        accordian.set_title(idx, title)
+        cell_connectivity.set_title(idx, title)
 
     # Dropdown for different drives
     layout = Layout(width='200px', height='100px')
@@ -971,7 +971,7 @@ def run_hnn_gui():
 
     # Tabs for left pane
     left_tab = Tab()
-    left_tab.children = [simulation_box, accordian, drives_options]
+    left_tab.children = [simulation_box, cell_connectivity, drives_options]
     titles = ['Simulation', 'Cell connectivity', 'Drives']
     for idx, title in enumerate(titles):
         left_tab.set_title(idx, title)

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -533,17 +533,12 @@ def run_button_clicked(log_out, drive_widgets, variables, tstep, tstop,
             # add_drives_from_params=add_drive_from_params.value,
             add_drives_from_params=False,
         )
+        # add connections here
 
-    try:
+
         for drive in drive_widgets:
-            weights_ampa = {
-                k: v.value
-                for k, v in drive['weights_ampa'].items()
-            }
-            weights_nmda = {
-                k: v.value
-                for k, v in drive['weights_nmda'].items()
-            }
+            weights_ampa = {k: v.value for k, v in drive['weights_ampa'].items()}
+            weights_nmda = {k: v.value for k, v in drive['weights_nmda'].items()}
             synaptic_delays = {k: v.value for k, v in drive['delays'].items()}
             if drive['type'] == 'Poisson':
                 rate_constant = {
@@ -597,80 +592,10 @@ def run_button_clicked(log_out, drive_widgets, variables, tstep, tstop,
                     weights_nmda=weights_nmda,
                     synaptic_delays=synaptic_delays,
                     seedcore=drive['seedcore'].value)
-    except Exception as e:
-        with log_out:
-            print(f"error in reading drives {e}")
 
+    log_out.clear_output()
     with log_out:
-        log_out.clear_output()
         print("start simulation")
-
-        variables['net'] = jones_2009_model()
-
-        weights_ampa_d1 = {
-            'L2_basket': 0.006562,
-            'L2_pyramidal': .000007,
-            'L5_pyramidal': 0.142300
-        }
-        weights_nmda_d1 = {
-            'L2_basket': 0.019482,
-            'L2_pyramidal': 0.004317,
-            'L5_pyramidal': 0.080074
-        }
-        synaptic_delays_d1 = {
-            'L2_basket': 0.1,
-            'L2_pyramidal': 0.1,
-            'L5_pyramidal': 0.1
-        }
-        variables['net'].add_evoked_drive('evdist1',
-                                          mu=63.53,
-                                          sigma=3.85,
-                                          numspikes=1,
-                                          weights_ampa=weights_ampa_d1,
-                                          weights_nmda=weights_nmda_d1,
-                                          location='distal',
-                                          synaptic_delays=synaptic_delays_d1,
-                                          event_seed=4)
-
-        weights_ampa_p1 = {
-            'L2_basket': 0.08831,
-            'L2_pyramidal': 0.01525,
-            'L5_basket': 0.19934,
-            'L5_pyramidal': 0.00865
-        }
-        synaptic_delays_prox = {
-            'L2_basket': 0.1,
-            'L2_pyramidal': 0.1,
-            'L5_basket': 1.,
-            'L5_pyramidal': 1.
-        }
-        # all NMDA weights are zero; pass None explicitly
-        variables['net'].add_evoked_drive('evprox1',
-                                          mu=26.61,
-                                          sigma=2.47,
-                                          numspikes=1,
-                                          weights_ampa=weights_ampa_p1,
-                                          weights_nmda=None,
-                                          location='proximal',
-                                          synaptic_delays=synaptic_delays_prox,
-                                          event_seed=4)
-
-        # Second proximal evoked drive. NB: only AMPA weights differ from first
-        weights_ampa_p2 = {
-            'L2_basket': 0.000003,
-            'L2_pyramidal': 1.438840,
-            'L5_basket': 0.008958,
-            'L5_pyramidal': 0.684013
-        }
-        # all NMDA weights are zero; omit weights_nmda (defaults to None)
-        variables['net'].add_evoked_drive('evprox2',
-                                          mu=137.12,
-                                          sigma=8.33,
-                                          numspikes=1,
-                                          weights_ampa=weights_ampa_p2,
-                                          location='proximal',
-                                          synaptic_delays=synaptic_delays_prox,
-                                          event_seed=4)
 
         if backend_selection.value == "MPI":
             variables['backend'] = MPIBackend(

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -147,11 +147,13 @@ def _get_rhythmic_widget(
     tstart_std = FloatText(value=default_data['tstart_std'],
                            description='Start time dev (ms)',
                            **kwargs)
-    tstop = BoundedFloatText(value=tstop_widget.value if default_data['tstop']
-                             == 0 else default_data['tstop'],
-                             description='Stop time (ms)',
-                             max=tstop_widget.value,
-                             **kwargs)
+    tstop = BoundedFloatText(
+        value=tstop_widget.value
+        if default_data['tstop'] == 0 else default_data['tstop'],
+        description='Stop time (ms)',
+        max=tstop_widget.value,
+        **kwargs,
+    )
     burst_rate = FloatText(value=default_data['burst_rate'],
                            description='Burst rate (Hz)',
                            **kwargs)
@@ -219,12 +221,14 @@ def _get_poisson_widget(
                        description='Start time (ms)',
                        layout=layout,
                        style=style)
-    tstop = BoundedFloatText(value=tstop_widget.value if default_data['tstop']
-                             == 0 else default_data['tstop'],
-                             max=tstop_widget.value,
-                             description='Stop time (ms)',
-                             layout=layout,
-                             style=style)
+    tstop = BoundedFloatText(
+        value=tstop_widget.value
+        if default_data['tstop'] == 0 else default_data['tstop'],
+        max=tstop_widget.value,
+        description='Stop time (ms)',
+        layout=layout,
+        style=style,
+    )
     seedcore = IntText(value=default_data['seedcore'],
                        description='Seed',
                        layout=layout,
@@ -782,7 +786,7 @@ def initialize_viz_window(viz_window,
         elif layout_option == "U-D":
             grid = init_UD_viz_layout(plot_outputs, plot_dropdowns,
                                       window_height, variables, plot_options)
-        # TODO: 2x2 grids
+        # TODO: 2x2
 
         display(grid)
 

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -174,6 +174,8 @@ def update_plot_window(variables, plot_out, plot_type):
             variables['dpls'][0].plot()
         elif plot_type['new'] == 'input histogram':
             variables['net'].cell_response.plot_spikes_hist()
+        elif plot_type['new'] == 'PSD':
+            variables['dpls'][0].plot_psd(fmin=0, fmax=50)
         elif plot_type['new'] == 'spectogram':
             freqs = np.arange(20., 100., 1.)
             variables['dpls'][0].plot_tfr_morlet(freqs)
@@ -305,7 +307,7 @@ def run_hnn_gui():
     layout = Layout(width='200px', height='auto')
     drives_dropdown = Dropdown(
         options=['Evoked', 'Poisson', 'Rhythmic', ''],
-        value='', description='Drive:',disabled=False,
+        value='', description='Drive:', disabled=False,
         layout=layout)
 
     # XXX: should be simpler to use Stacked class starting
@@ -323,11 +325,10 @@ def run_hnn_gui():
 
     # Dropdown menu to switch between plots
     plot_dropdown = Dropdown(
-        options=['input histogram', 'current dipole', 'spikes', 'spectogram'],
-        value='current dipole',
-        description='Plot:',
-        disabled=False,
-    )
+        options=['input histogram', 'current dipole',
+                 'spikes', 'PSD', 'spectogram'],
+        value='current dipole', description='Plot:',
+        disabled=False)
     interactive(_update_plot_window, plot_type='current dipole')
     plot_dropdown.observe(_update_plot_window, 'value')
 
@@ -335,7 +336,8 @@ def run_hnn_gui():
     run_button = create_expanded_button('Run', 'success', height='30px')
     style = {'button_color': '#8A2BE2', 'font_color': 'white'}
     load_button = FileUpload(accept='.json', multiple=False, style=style,
-                             description='Load network', button_style='success')
+                             description='Load network',
+                             button_style='success')
 
     load_button.observe(_on_upload_change)
     run_button.on_click(_on_button_clicked)

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -1,30 +1,37 @@
 """IPywidgets GUI."""
 
 # Authors: Mainak Jas <mjas@mgh.harvard.edu>
-
-import json
 import codecs
+import json
 import os.path as op
+import subprocess
 from functools import partial, update_wrapper
 
+import matplotlib.pyplot as plt
 import numpy as np
+from IPython.display import display
+from ipywidgets import (HTML, Accordion, AppLayout, BoundedFloatText, Button,
+                        Dropdown, FileUpload, FloatLogSlider, FloatText, Text,
+                        HBox, IntText, Layout, Output, RadioButtons, Tab, VBox,
+                        fixed, interact, interactive, interactive_output)
 
 import hnn_core
-from hnn_core import simulate_dipole, read_params, Network
-from hnn_core.params import _read_legacy_params, _read_json
+from hnn_core import Network, read_params, simulate_dipole, MPIBackend
+from hnn_core.params import _read_json, _read_legacy_params
+import multiprocessing
 
-from IPython.display import display
 
-from ipywidgets import (FloatLogSlider, Dropdown, Button, RadioButtons,
-                        fixed, interactive_output, interactive, interact,
-                        FloatText, BoundedFloatText, IntText, FileUpload,
-                        HTML, Output, HBox, VBox, Tab, Accordion,
-                        Layout, AppLayout)
+def cmd_exists(cmd):
+    return subprocess.call("type " + cmd,
+                           shell=True,
+                           stdout=subprocess.PIPE,
+                           stderr=subprocess.PIPE) == 0
 
 
 def create_expanded_button(description, button_style, height):
     style = {'button_color': '#8A2BE2'}
-    return Button(description=description, button_style=button_style,
+    return Button(description=description,
+                  button_style=button_style,
                   layout=Layout(height=height, width='auto'),
                   style=style)
 
@@ -34,11 +41,17 @@ def _get_sliders(params, param_keys):
     style = {'description_width': '150px'}
     sliders = list()
     for d in param_keys:
-        slider = FloatLogSlider(
-            value=params[d], min=-5, max=1, step=0.2,
-            description=d.split('gbar_')[1],
-            disabled=False, continuous_update=False, orientation='horizontal',
-            readout=True, readout_format='.2e', style=style)
+        slider = FloatLogSlider(value=params[d],
+                                min=-5,
+                                max=1,
+                                step=0.2,
+                                description=d.split('gbar_')[1],
+                                disabled=False,
+                                continuous_update=False,
+                                orientation='horizontal',
+                                readout=True,
+                                readout_format='.2e',
+                                style=style)
         sliders.append(slider)
 
     def _update_params(variables, **updates):
@@ -50,22 +63,27 @@ def _get_sliders(params, param_keys):
 
 def _get_cell_specific_widgets(layout, style, location):
     kwargs = dict(layout=layout, style=style)
-    cell_types = ['L5_pyramidal', 'L2_pyramidal', 'L5_basket',
-                  'L2_basket']
+    cell_types = ['L5_pyramidal', 'L2_pyramidal', 'L5_basket', 'L2_basket']
     if location == "distal":
         cell_types.remove('L5_basket')
 
     weights_ampa, weights_nmda, delays = dict(), dict(), dict()
     for cell_type in cell_types:
-        weights_ampa[f'{cell_type}'] = FloatText(
-            value=0., description=f'{cell_type}:', **kwargs)
-        weights_nmda[f'{cell_type}'] = FloatText(
-            value=0., description=f'{cell_type}:', **kwargs)
-        delays[f'{cell_type}'] = FloatText(
-            value=0.1, description=f'{cell_type}:', **kwargs)
+        weights_ampa[f'{cell_type}'] = FloatText(value=0.,
+                                                 description=f'{cell_type}:',
+                                                 **kwargs)
+        weights_nmda[f'{cell_type}'] = FloatText(value=0.,
+                                                 description=f'{cell_type}:',
+                                                 **kwargs)
+        delays[f'{cell_type}'] = FloatText(value=0.1,
+                                           description=f'{cell_type}:',
+                                           **kwargs)
 
-    widgets_dict = {'weights_ampa': weights_ampa,
-                    'weights_nmda': weights_nmda, 'delays': delays}
+    widgets_dict = {
+        'weights_ampa': weights_ampa,
+        'weights_nmda': weights_nmda,
+        'delays': delays
+    }
     widgets_list = ([HTML(value="<b>AMPA weights</b>")] +
                     list(weights_ampa.values()) +
                     [HTML(value="<b>NMDA weights</b>")] +
@@ -79,57 +97,73 @@ def _get_rhythmic_widget(name, tstop_widget, layout, style, location):
 
     kwargs = dict(layout=layout, style=style)
     tstart = FloatText(value=0., description='Start time (s)', **kwargs)
-    tstart_std = FloatText(value=0, description='Start time dev (s)',
-                           **kwargs)
+    tstart_std = FloatText(value=0, description='Start time dev (s)', **kwargs)
     tstop = BoundedFloatText(value=tstop_widget.value,
                              description='Stop time (s)',
-                             max=tstop_widget.value, **kwargs)
+                             max=tstop_widget.value,
+                             **kwargs)
     burst_rate = FloatText(value=7.5, description='Burst rate (Hz)', **kwargs)
     burst_std = FloatText(value=0, description='Burst std dev (Hz)', **kwargs)
     repeats = FloatText(value=1, description='Repeats', **kwargs)
     seedcore = IntText(value=14, description='Seed', **kwargs)
 
-    widgets_list, widgets_dict = _get_cell_specific_widgets(layout, style, location)
-    drive_box = VBox([tstart, tstart_std, tstop, burst_rate, burst_std,
-                      repeats, seedcore] + widgets_list)
-    drive = dict(type='Rhythmic', name=name,
-                 tstart=tstart, tstart_std=tstart_std,
-                 burst_rate=burst_rate, burst_std=burst_std,
-                 repeats=repeats, seedcore=seedcore,
+    widgets_list, widgets_dict = _get_cell_specific_widgets(
+        layout, style, location)
+    drive_box = VBox(
+        [tstart, tstart_std, tstop, burst_rate, burst_std, repeats, seedcore] +
+        widgets_list)
+    drive = dict(type='Rhythmic',
+                 name=name,
+                 tstart=tstart,
+                 tstart_std=tstart_std,
+                 burst_rate=burst_rate,
+                 burst_std=burst_std,
+                 repeats=repeats,
+                 seedcore=seedcore,
                  tstop=tstop)
     drive.update(widgets_dict)
     return drive, drive_box
 
 
 def _get_poisson_widget(name, tstop_widget, layout, style, location):
-    tstart = FloatText(value=0.0, description='Start time (s)',
-                       layout=layout, style=style)
+    tstart = FloatText(value=0.0,
+                       description='Start time (s)',
+                       layout=layout,
+                       style=style)
     tstop = BoundedFloatText(value=tstop_widget.value,
                              max=tstop_widget.value,
                              description='Stop time (s)',
-                             layout=layout, style=style)
-    seedcore = IntText(value=14, description='Seed',
-                       layout=layout, style=style)
+                             layout=layout,
+                             style=style)
+    seedcore = IntText(value=14,
+                       description='Seed',
+                       layout=layout,
+                       style=style)
     location = RadioButtons(options=['proximal', 'distal'])
 
-    cell_types = ['L5_pyramidal', 'L2_pyramidal', 'L5_basket',
-                  'L2_basket']
+    cell_types = ['L5_pyramidal', 'L2_pyramidal', 'L5_basket', 'L2_basket']
     rate_constant = dict()
     for cell_type in cell_types:
-        rate_constant[f'{cell_type}'] = FloatText(
-            value=8.5, description=f'{cell_type}:',
-            layout=layout, style=style)
+        rate_constant[f'{cell_type}'] = FloatText(value=8.5,
+                                                  description=f'{cell_type}:',
+                                                  layout=layout,
+                                                  style=style)
 
-    widgets_list, widgets_dict = _get_cell_specific_widgets(layout, style, location)
+    widgets_list, widgets_dict = _get_cell_specific_widgets(
+        layout, style, location)
     widgets_dict.update({'rate_constant': rate_constant})
     widgets_list.extend([HTML(value="<b>Rate constants</b>")] +
                         list(widgets_dict['rate_constant'].values()))
 
     drive_box = VBox([tstart, tstop, seedcore] + widgets_list)
-    drive = dict(type='Poisson', name=name, tstart=tstart,
-                 tstop=tstop, rate_constant=rate_constant,
-                 seedcore=seedcore,
-                  )
+    drive = dict(
+        type='Poisson',
+        name=name,
+        tstart=tstart,
+        tstop=tstop,
+        rate_constant=rate_constant,
+        seedcore=seedcore,
+    )
     drive.update(widgets_dict)
     return drive, drive_box
 
@@ -137,26 +171,27 @@ def _get_poisson_widget(name, tstop_widget, layout, style, location):
 def _get_evoked_widget(name, layout, style, location):
     kwargs = dict(layout=layout, style=style)
     mu = FloatText(value=0, description='Mean time:', **kwargs)
-    sigma = FloatText(value=1, description='Std dev time:',
-                      **kwargs)
-    numspikes = IntText(value=1, description='No. Spikes:',
-                        **kwargs)
+    sigma = FloatText(value=1, description='Std dev time:', **kwargs)
+    numspikes = IntText(value=1, description='No. Spikes:', **kwargs)
     seedcore = IntText(value=14, description='Seed: ', **kwargs)
 
-    widgets_list, widgets_dict = _get_cell_specific_widgets(layout, style, location)
+    widgets_list, widgets_dict = _get_cell_specific_widgets(
+        layout, style, location)
 
-    drive_box = VBox([mu, sigma, numspikes, seedcore] +
-                     widgets_list)
-    drive = dict(type='Evoked', name=name,
-                 mu=mu, sigma=sigma, numspikes=numspikes,
+    drive_box = VBox([mu, sigma, numspikes, seedcore] + widgets_list)
+    drive = dict(type='Evoked',
+                 name=name,
+                 mu=mu,
+                 sigma=sigma,
+                 numspikes=numspikes,
                  seedcore=seedcore,
                  sync_within_trial=False)
     drive.update(widgets_dict)
     return drive, drive_box
 
 
-def add_drive_widget(drive_type, drive_boxes, drive_widgets,
-                     drives_out, tstop_widget, location):
+def add_drive_widget(drive_type, drive_boxes, drive_widgets, drives_out,
+                     tstop_widget, location):
     """Add a widget for a new drive."""
     layout = Layout(width='270px', height='auto')
     style = {'description_width': '150px'}
@@ -165,13 +200,14 @@ def add_drive_widget(drive_type, drive_boxes, drive_widgets,
         name = drive_type + str(len(drive_boxes))
 
         if drive_type == 'Rhythmic':
-            drive, drive_box = _get_rhythmic_widget(name, tstop_widget,
-                                                    layout, style, location)
+            drive, drive_box = _get_rhythmic_widget(name, tstop_widget, layout,
+                                                    style, location)
         elif drive_type == 'Poisson':
-            drive, drive_box = _get_poisson_widget(name, tstop_widget,
-                                                   layout, style, location)
+            drive, drive_box = _get_poisson_widget(name, tstop_widget, layout,
+                                                   style, location)
         elif drive_type == 'Evoked':
-            drive, drive_box = _get_evoked_widget(name, layout, style, location)
+            drive, drive_box = _get_evoked_widget(name, layout, style,
+                                                  location)
 
         if drive_type in ['Evoked', 'Poisson', 'Rhythmic']:
             drive_boxes.append(drive_box)
@@ -184,27 +220,59 @@ def add_drive_widget(drive_type, drive_boxes, drive_widgets,
         display(accordion)
 
 
-def update_plot_window(variables, plot_out, plot_type):
-    plot_out.clear_output()
+def update_plot_window(variables, _plot_out, plot_type):
+    _plot_out.clear_output()
 
     if not (plot_type['type'] == 'change' and plot_type['name'] == 'value'):
         return
 
-    with plot_out:
-        if plot_type['new'] == 'spikes': # BUG: got warning from matplotlib and numpy
-            variables['net'].cell_response.plot_spikes_raster()
+    with _plot_out:
+        fig, ax = plt.subplots()
+        if plot_type[
+                'new'] == 'spikes':  # BUG: got warning from matplotlib and numpy
+            if variables['net'] is not None and sum(
+                [len(_)
+                 for _ in variables['net'].cell_response._spike_times]) > 0:
+                variables['net'].cell_response.plot_spikes_raster(ax=ax)
+            else:
+                print("No data")
+
         elif plot_type['new'] == 'current dipole':
-            variables['dpls'][0].plot()
-        elif plot_type['new'] == 'input histogram': # BUG: got error here
-            variables['net'].cell_response.plot_spikes_hist()
+            if variables['dpls'] is not None:
+                variables['dpls'][0].plot(ax=ax)
+            else:
+                print("No data")
+
+        elif plot_type['new'] == 'input histogram':
+            # BUG: got error here, need a better way to handle exception
+            if variables['net'] is not None and sum(
+                [len(_)
+                 for _ in variables['net'].cell_response._spike_times]) > 0:
+                variables['net'].cell_response.plot_spikes_hist(ax=ax)
+            else:
+                print("No data")
+
         elif plot_type['new'] == 'PSD':
-            variables['dpls'][0].plot_psd(fmin=0, fmax=50)
+            if variables['dpls'] is not None:
+                variables['dpls'][0].plot_psd(fmin=0, fmax=50, ax=ax)
+            else:
+                print("No data")
+
         elif plot_type['new'] == 'spectogram':
             freqs = np.arange(10., 100., 1.)
             n_cycles = freqs / 8.
-            variables['dpls'][0].plot_tfr_morlet(freqs, n_cycles=n_cycles)
+            if variables['dpls'] is not None:
+                variables['dpls'][0].plot_tfr_morlet(freqs,
+                                                     n_cycles=n_cycles,
+                                                     ax=ax)
+            else:
+                print("No data")
+
         elif plot_type['new'] == 'network':
-            variables['net'].plot_cells()
+            if variables['net'] is not None:
+                variables['net'].plot_cells(ax=ax)
+            else:
+                print("No data")
 
 
 def on_upload_change(change, sliders, params, tstop, tstep, log_out):
@@ -238,7 +306,7 @@ def on_upload_change(change, sliders, params, tstop, tstep, log_out):
 
 
 def run_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
-                       tstop, ntrials, params, b):
+                       tstop, ntrials, mpi_cmd, params, b):
     """Run the simulation and plot outputs."""
     plot_out.clear_output()
     log_out.clear_output()
@@ -249,16 +317,28 @@ def run_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
 
     try:
         for drive in drive_widgets:
-            weights_ampa = {k: v.value for k, v in drive['weights_ampa'].items()}
-            weights_nmda = {k: v.value for k, v in drive['weights_nmda'].items()}
+            weights_ampa = {
+                k: v.value
+                for k, v in drive['weights_ampa'].items()
+            }
+            weights_nmda = {
+                k: v.value
+                for k, v in drive['weights_nmda'].items()
+            }
             synaptic_delays = {k: v.value for k, v in drive['delays'].items()}
             if drive['type'] == 'Poisson':
-                rate_constant = {k: v.value for k, v in
-                                drive['rate_constant'].items() if v.value > 0}
-                weights_ampa = {k: v for k, v in weights_ampa.items() if k in
-                                rate_constant}
-                weights_nmda = {k: v for k, v in weights_nmda.items() if k in
-                                rate_constant}
+                rate_constant = {
+                    k: v.value
+                    for k, v in drive['rate_constant'].items() if v.value > 0
+                }
+                weights_ampa = {
+                    k: v
+                    for k, v in weights_ampa.items() if k in rate_constant
+                }
+                weights_nmda = {
+                    k: v
+                    for k, v in weights_nmda.items() if k in rate_constant
+                }
                 variables['net'].add_poisson_drive(
                     name=drive['name'],
                     tstart=drive['tstart'].value,
@@ -269,8 +349,7 @@ def run_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
                     weights_nmda=weights_nmda,
                     synaptic_delays=synaptic_delays,
                     space_constant=100.0,
-                    seedcore=drive['seedcore'].value
-                )
+                    seedcore=drive['seedcore'].value)
             elif drive['type'] == 'Evoked':
                 variables['net'].add_evoked_drive(
                     name=drive['name'],
@@ -283,8 +362,7 @@ def run_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
                     weights_nmda=weights_nmda,
                     synaptic_delays=synaptic_delays,
                     space_constant=3.0,
-                    seedcore=drive['seedcore'].value
-                )
+                    seedcore=drive['seedcore'].value)
             elif drive['type'] == 'Rhythmic':
                 variables['net'].add_bursty_drive(
                     name=drive['name'],
@@ -298,8 +376,7 @@ def run_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
                     weights_ampa=weights_ampa,
                     weights_nmda=weights_nmda,
                     synaptic_delays=synaptic_delays,
-                    seedcore=drive['seedcore'].value
-                )
+                    seedcore=drive['seedcore'].value)
     except Exception as e:
         with log_out:
             print(f"error in reading drives {e}")
@@ -307,17 +384,44 @@ def run_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
     with log_out:
         log_out.clear_output()
         print("start simulation")
-        variables['dpls'] = simulate_dipole(variables['net'], tstop=tstop.value, n_trials=ntrials.value)
+        if cmd_exists(mpi_cmd.value):
+            # should further allow users to adjust cores to use
+            # with MPIBackend(n_procs=multiprocessing.cpu_count() - 1,
+            #                 mpi_cmd=mpi_cmd.value):
+            # variables['dpls'] = simulate_dipole(variables['net'],
+            #                                     tstop=tstop.value,
+            #                                     n_trials=ntrials.value)
+            variables['backend'] = MPIBackend(
+                n_procs=multiprocessing.cpu_count() - 1, mpi_cmd=mpi_cmd.value)
+            variables['dpls'] = variables['backend'].simulate(
+                variables['net'],
+                tstop.value,
+                tstep.value,
+                n_trials=ntrials.value)
+
+        else:
+            variables['dpls'] = simulate_dipole(variables['net'],
+                                                tstop=tstop.value,
+                                                n_trials=ntrials.value)
+
+    # Default case
     with plot_out:
-        variables['dpls'][0].plot()
+        fig, ax = plt.subplots()
+        variables['dpls'][0].plot(ax=ax)
 
 
-def stop_button_clicked(log_out, b):
+def stop_button_clicked(variables, log_out, b):
     with log_out:
-        print("Terminating simulation...")
-    
-    pass
+        if "backend" in variables:
+            print("Terminating simulation...")
+            variables["backend"].terminate()
+        else:
+            print("No Backends or running simulations. Cannot terminate")
 
+
+def test_del_widget(plot_out_1):
+    del plot_out_1
+    pass
 
 def run_hnn_gui():
     """Create the HNN GUI."""
@@ -333,10 +437,10 @@ def run_hnn_gui():
 
     def _run_button_clicked(b):
         return run_button_clicked(log_out, plot_out, drive_widgets, variables,
-                                  tstep, tstop, ntrials, params, b)
+                                  tstep, tstop, ntrials, mpi_cmd, params, b)
 
     def _stop_button_clicked(b):
-        return stop_button_clicked(log_out, b)
+        return stop_button_clicked(variables, log_out, b)
 
     def _on_upload_change(change):
         return on_upload_change(change, sliders, params, tstop, tstep, log_out)
@@ -344,6 +448,9 @@ def run_hnn_gui():
 
     def _update_plot_window(plot_type):
         return update_plot_window(variables, plot_out, plot_type)
+
+    def _update_plot_window_1(plot_type):
+        return update_plot_window(variables, plot_out_1, plot_type)
 
     def _delete_drives_clicked(b):
         drives_out.clear_output()
@@ -353,39 +460,68 @@ def run_hnn_gui():
             drive_widgets.pop()
             drive_boxes.pop()
 
+    def _debug_change(b):
+        test_del_widget(plot_out_1)
+
+        with log_out:
+            log_out.clear_output()
+            print("file uploaded")
+        pass
+
     # Output windows
     drives_out = Output()  # window to add new drives
-    log_out = Output(layout={'border': '1px solid gray', 'height': '150px',
-                             'overflow_y': 'auto'})
-    plot_out = Output(layout={'border': '1px solid gray', 'height': '350px'})
+    log_out = Output(layout={
+        'border': '1px solid gray',
+        'height': '150px',
+        'overflow_y': 'auto'
+    })
+    height_plot = '350px'
+    plot_out = Output(layout={
+        'border': '1px solid gray',
+        'height': height_plot
+    })
+    plot_out_1 = Output(layout={
+        'border': '1px solid gray',
+        'height': height_plot
+    })
 
     # header_button
     header_button = create_expanded_button('HUMAN NEOCORTICAL NEUROSOLVER',
-                                           'success', height='40px')
+                                           'success',
+                                           height='40px')
 
     # Simulation parameters
     tstop = FloatText(value=170, description='tstop (s):', disabled=False)
     tstep = FloatText(value=0.025, description='tstep (s):', disabled=False)
     ntrials = IntText(value=1, description='Trials:', disabled=False)
-    simulation_box = VBox([tstop, tstep, ntrials])
+    mpi_cmd = Text(value='mpiexec',
+                   placeholder='Fill if applies',
+                   description='MPI cmd:',
+                   disabled=False)
+    simulation_box = VBox([tstop, tstep, ntrials, mpi_cmd])
 
     # Sliders to change local-connectivity params
-    sliders = [_get_sliders(params,
-               ['gbar_L2Pyr_L2Pyr_ampa', 'gbar_L2Pyr_L2Pyr_nmda',
-                'gbar_L2Basket_L2Pyr_gabaa', 'gbar_L2Basket_L2Pyr_gabab']),
-               _get_sliders(params,
-               ['gbar_L2Pyr_L5Pyr', 'gbar_L2Basket_L5Pyr',
-                'gbar_L5Pyr_L5Pyr_ampa', 'gbar_L5Pyr_L5Pyr_nmda',
-                'gbar_L5Basket_L5Pyr_gabaa', 'gbar_L5Basket_L5Pyr_gabab']),
-               _get_sliders(params,
-               ['gbar_L2Pyr_L2Basket', 'gbar_L2Basket_L2Basket']),
-               _get_sliders(params,
-               ['gbar_L2Pyr_L5Pyr', 'gbar_L2Basket_L5Pyr'])]
+    sliders = [
+        _get_sliders(params, [
+            'gbar_L2Pyr_L2Pyr_ampa', 'gbar_L2Pyr_L2Pyr_nmda',
+            'gbar_L2Basket_L2Pyr_gabaa', 'gbar_L2Basket_L2Pyr_gabab'
+        ]),
+        _get_sliders(params, [
+            'gbar_L2Pyr_L5Pyr', 'gbar_L2Basket_L5Pyr', 'gbar_L5Pyr_L5Pyr_ampa',
+            'gbar_L5Pyr_L5Pyr_nmda', 'gbar_L5Basket_L5Pyr_gabaa',
+            'gbar_L5Basket_L5Pyr_gabab'
+        ]),
+        _get_sliders(params,
+                     ['gbar_L2Pyr_L2Basket', 'gbar_L2Basket_L2Basket']),
+        _get_sliders(params, ['gbar_L2Pyr_L5Pyr', 'gbar_L2Basket_L5Pyr'])
+    ]
 
     # accordians to group local-connectivity by cell type
     boxes = [VBox(slider) for slider in sliders]
-    titles = ['Layer 2/3 Pyramidal', 'Layer 5 Pyramidal', 'Layer 2 Basket',
-              'Layer 5 Basket']
+    titles = [
+        'Layer 2/3 Pyramidal', 'Layer 5 Pyramidal', 'Layer 2 Basket',
+        'Layer 5 Basket'
+    ]
     accordian = Accordion(children=boxes)
     for idx, title in enumerate(titles):
         accordian.set_title(idx, title)
@@ -406,7 +542,9 @@ def run_hnn_gui():
                                       disabled=False,
                                       layout=layout)
 
-    add_drive_button = create_expanded_button('Add drive', 'primary', height='30px')
+    add_drive_button = create_expanded_button('Add drive',
+                                              'primary',
+                                              height='30px')
 
     def _add_drive_button_clicked(b):
         return add_drive_widget(drive_type_selection.value, drive_boxes,
@@ -414,7 +552,8 @@ def run_hnn_gui():
                                 location_selection.value)
 
     add_drive_button.on_click(_add_drive_button_clicked)
-    drive_selections = VBox([HBox([drive_type_selection, location_selection]), add_drive_button])
+    drive_selections = VBox(
+        [HBox([drive_type_selection, location_selection]), add_drive_button])
 
     # XXX: should be simpler to use Stacked class starting
     # from IPywidgets > 8.0
@@ -428,47 +567,67 @@ def run_hnn_gui():
         left_tab.set_title(idx, title)
 
     # Dropdown menu to switch between plots
-    plot_dropdown = Dropdown(
-        options=['input histogram', 'current dipole',
-                 'spikes', 'PSD', 'spectogram', 'network'],
-        value='current dipole', description='Plot:',
-        disabled=False)
+    plot_options = [
+        'input histogram', 'current dipole', 'spikes', 'PSD', 'spectogram',
+        'network'
+    ]
+    plot_dropdown = Dropdown(options=plot_options,
+                             value='current dipole',
+                             description='Plot:',
+                             disabled=False)
+
     interactive(_update_plot_window, plot_type='current dipole')
     plot_dropdown.observe(_update_plot_window, 'value')
+
+    plot_dropdown_1 = Dropdown(options=plot_options,
+                               value='current dipole',
+                               description='Plot:',
+                               disabled=False)
+    interactive(_update_plot_window_1, plot_type='current dipole')
+    plot_dropdown_1.observe(_update_plot_window_1, 'value')
 
     # Run, delete drives and load button
     run_button = create_expanded_button('Run', 'success', height='30px')
     stop_button = create_expanded_button('Stop', 'danger', height='30px')
     style = {'button_color': '#8A2BE2', 'font_color': 'white'}
-    load_button = FileUpload(accept='.json,.param', multiple=False,
-                             style=style, description='Load network',
+    load_button = FileUpload(accept='.json,.param',
+                             multiple=False,
+                             style=style,
+                             description='Load network',
                              button_style='success')
-    delete_button = create_expanded_button('Delete drives', 'success',
+    delete_button = create_expanded_button('Delete drives',
+                                           'success',
                                            height='30px')
     debug_button = create_expanded_button('Debug', 'success', height='30px')
 
-    def _debug_change(b):
-        with log_out:
-            log_out.clear_output()
-            print("file uploaded")
-        pass
+
     debug_button.on_click(_debug_change)
     # load_button.observe(_debug_change)
 
     # run_button.on_click(_debug_change)
     load_button.observe(_on_upload_change)
     run_button.on_click(_run_button_clicked)
+    # Not working currently
     stop_button.on_click(_stop_button_clicked)
     delete_button.on_click(_delete_drives_clicked)
-    footer = HBox([run_button, stop_button, load_button, delete_button, debug_button, plot_dropdown])
+    footer = HBox(
+        [run_button, stop_button, load_button, delete_button, debug_button])
 
-    right_sidebar = VBox([plot_out, log_out])
+    plot_dropdown_1.layout.width = "500px"
+    plot_out.layout.width = "500px"
+    right_sidebar = VBox([
+        HBox([
+            VBox([plot_dropdown, plot_out]),
+            VBox([plot_dropdown_1, plot_out_1])
+        ]), log_out
+    ])
 
     # Final layout of the app
-    hnn_gui = AppLayout(header=header_button,
-                        left_sidebar=left_tab,
-                        right_sidebar=right_sidebar,
-                        footer=footer,
-                        pane_widths=['380px', '500px', '500px'],
-                        pane_heights=[1, '500px', 1])
+    hnn_gui = AppLayout(
+        header=header_button,
+        left_sidebar=left_tab,
+        right_sidebar=right_sidebar,
+        footer=footer,
+        pane_widths=['380px', '0px', '1000px'],
+        pane_heights=[1, '500px', 1])
     return hnn_gui

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -41,8 +41,7 @@ def _get_sliders(params, param_keys):
             value=params[d], min=-5, max=1, step=0.2,
             description=d.split('gbar_')[1],
             disabled=False, continuous_update=False, orientation='horizontal',
-            readout=True, readout_format='.2e',
-            style=style)
+            readout=True, readout_format='.2e', style=style)
         sliders.append(slider)
 
     _update_params = partial(update_params, params)
@@ -51,19 +50,17 @@ def _get_sliders(params, param_keys):
 
 
 def _get_cell_specific_widgets(layout, style):
+    kwargs = dict(layout=layout, style=style)
     cell_types = ['L5_pyramidal', 'L2_pyramidal', 'L5_basket',
                   'L2_basket']
     weights_ampa, weights_nmda, delays = dict(), dict(), dict()
     for cell_type in cell_types:
         weights_ampa[f'{cell_type}'] = FloatText(
-            value=0., description=f'{cell_type}:',
-            layout=layout, style=style)
+            value=0., description=f'{cell_type}:', **kwargs)
         weights_nmda[f'{cell_type}'] = FloatText(
-            value=0., description=f'{cell_type}:', layout=layout,
-            style=style)
+            value=0., description=f'{cell_type}:', **kwargs)
         delays[f'{cell_type}'] = FloatText(
-            value=0.1, description=f'{cell_type}:', layout=layout,
-            style=style)
+            value=0.1, description=f'{cell_type}:', **kwargs)
 
     widgets_dict = {'weights_ampa': weights_ampa,
                     'weights_nmda': weights_nmda, 'delays': delays}
@@ -78,21 +75,16 @@ def _get_cell_specific_widgets(layout, style):
 
 def _get_rhythmic_widget(drive_title, tstop_widget, layout, style):
 
-    tstart = FloatText(value=0., description='Start time:',
-                       layout=layout, style=style)
+    kwargs = dict(layout=layout, style=style)
+    tstart = FloatText(value=0., description='Start time:', **kwargs)
     tstart_std = FloatText(value=0, description='Start time dev:',
-                           layout=layout, style=style)
+                           **kwargs)
     tstop = BoundedFloatText(value=tstop_widget.value, description='Stop time:',
-                             max=tstop_widget.value,
-                             layout=layout, style=style)
-    burst_rate = FloatText(value=7.5, description='Burst rate:',
-                           layout=layout, style=style)
-    burst_std = FloatText(value=0, description='Burst std dev:',
-                          layout=layout, style=style)
-    repeats = FloatText(value=1, description='Spikes/burst:',
-                        layout=layout, style=style)
-    seedcore = IntText(value=14, description='Seed: ',
-                       layout=layout, style=style)
+                             max=tstop_widget.value, **kwargs)
+    burst_rate = FloatText(value=7.5, description='Burst rate:', **kwargs)
+    burst_std = FloatText(value=0, description='Burst std dev:', **kwargs)
+    repeats = FloatText(value=1, description='Spikes/burst:', **kwargs)
+    seedcore = IntText(value=14, description='Seed: ', **kwargs)
     location = RadioButtons(options=['proximal', 'distal'])
 
     widgets_list, widgets_dict = _get_cell_specific_widgets(layout, style)
@@ -140,14 +132,13 @@ def _get_poisson_widget(drive_title, tstop_widget, layout, style):
 
 
 def _get_evoked_widget(drive_title, layout, style):
-    mu = FloatText(value=0, description='Mean time:',
-                   layout=layout)
+    kwargs = dict(layout=layout, style=style)
+    mu = FloatText(value=0, description='Mean time:', **kwargs)
     sigma = FloatText(value=1, description='Std dev time:',
-                      layout=layout)
+                      **kwargs)
     numspikes = IntText(value=1, description='No. Spikes:',
-                        layout=layout)
-    seedcore = IntText(value=14, description='Seed: ',
-                       layout=layout, style=style)
+                        **kwargs)
+    seedcore = IntText(value=14, description='Seed: ', **kwargs)
     location = RadioButtons(options=['proximal', 'distal'])
 
     widgets_list, widgets_dict = _get_cell_specific_widgets(layout, style)

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -229,8 +229,8 @@ def update_plot_window(variables, _plot_out, plot_type):
 
     with _plot_out:
         fig, ax = plt.subplots()
-        if plot_type[
-                'new'] == 'spikes':  # BUG: got warning from matplotlib and numpy
+
+        if plot_type['new'] == 'spikes':
             if variables['net'] is not None and sum(
                 [len(_)
                  for _ in variables['net'].cell_response._spike_times]) > 0:
@@ -357,7 +357,8 @@ def run_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
                     mu=drive['mu'].value,
                     sigma=drive['sigma'].value,
                     numspikes=drive['numspikes'].value,
-                    # sync_within_trial=False, # BUG it seems this is something unnecessary
+                    # sync_within_trial=False,
+                    # BUG it seems this is something unnecessary
                     location=drive['location'].value,
                     weights_ampa=weights_ampa,
                     weights_nmda=weights_nmda,
@@ -412,6 +413,7 @@ def run_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
 
 
 def stop_button_clicked(variables, log_out, b):
+    # BUG: this cannot work properly now.
     with log_out:
         if "backend" in variables:
             print("Terminating simulation...")
@@ -423,6 +425,7 @@ def stop_button_clicked(variables, log_out, b):
 def test_del_widget(plot_out_1):
     del plot_out_1
     pass
+
 
 def run_hnn_gui():
     """Create the HNN GUI."""
@@ -445,7 +448,8 @@ def run_hnn_gui():
 
     def _on_upload_change(change):
         return on_upload_change(change, sliders, params, tstop, tstep, log_out)
-        # return on_upload_change(change, sliders, params) # BUG: capture does not work, use log_out explicitly
+        # BUG: capture does not work, use log_out explicitly
+        # return on_upload_change(change, sliders, params)
 
     def _update_plot_window(plot_type):
         return update_plot_window(variables, plot_out, plot_type)
@@ -601,7 +605,6 @@ def run_hnn_gui():
                                            height='30px')
     debug_button = create_expanded_button('Debug', 'success', height='30px')
 
-
     debug_button.on_click(_debug_change)
     # load_button.observe(_debug_change)
 
@@ -624,11 +627,10 @@ def run_hnn_gui():
     ])
 
     # Final layout of the app
-    hnn_gui = AppLayout(
-        header=header_button,
-        left_sidebar=left_tab,
-        right_sidebar=right_sidebar,
-        footer=footer,
-        pane_widths=['380px', '0px', '1000px'],
-        pane_heights=[1, '500px', 1])
+    hnn_gui = AppLayout(header=header_button,
+                        left_sidebar=left_tab,
+                        right_sidebar=right_sidebar,
+                        footer=footer,
+                        pane_widths=['380px', '0px', '1000px'],
+                        pane_heights=[1, '500px', 1])
     return hnn_gui

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -1,11 +1,11 @@
 """IPywidgets GUI."""
 
 # Authors: Mainak Jas <mjas@mgh.harvard.edu>
+#          Huzi Cheng <hzcheng15@icloud.com>
+
 import codecs
-import json
 import os.path as op
 import subprocess
-from functools import partial, update_wrapper
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -13,7 +13,7 @@ from IPython.display import display
 from ipywidgets import (HTML, Accordion, AppLayout, BoundedFloatText, Button,
                         Dropdown, FileUpload, FloatLogSlider, FloatText, Text,
                         HBox, IntText, Layout, Output, RadioButtons, Tab, VBox,
-                        fixed, interact, interactive, interactive_output)
+                        interactive, interactive_output)
 
 import hnn_core
 from hnn_core import Network, read_params, simulate_dipole, MPIBackend
@@ -221,6 +221,7 @@ def add_drive_widget(drive_type, drive_boxes, drive_widgets, drives_out,
 
 
 def update_plot_window(variables, _plot_out, plot_type):
+    # TODO need to add more informaion about "no data"
     _plot_out.clear_output()
 
     if not (plot_type['type'] == 'change' and plot_type['name'] == 'value'):

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -200,6 +200,8 @@ def update_plot_window(variables, plot_out, plot_type):
             freqs = np.arange(10., 100., 1.)
             n_cycles = freqs / 8.
             variables['dpls'][0].plot_tfr_morlet(freqs, n_cycles=n_cycles)
+        elif plot_type['new'] == 'network':
+            variables['net'].plot_cells()
 
 
 def on_upload_change(change, sliders, variables):
@@ -374,7 +376,7 @@ def run_hnn_gui():
     # Dropdown menu to switch between plots
     plot_dropdown = Dropdown(
         options=['input histogram', 'current dipole',
-                 'spikes', 'PSD', 'spectogram'],
+                 'spikes', 'PSD', 'spectogram', 'network'],
         value='current dipole', description='Plot:',
         disabled=False)
     interactive(_update_plot_window, plot_type='current dipole')

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -333,22 +333,20 @@ def _get_evoked_widget(
     return drive, drive_box
 
 
-def add_drive_widget(
-    drive_type,
-    drive_boxes,
-    drive_widgets,
-    drives_out,
-    tstop_widget,
-    location,
-    prespecified_drive_name=None,
-    prespecified_drive_data=None,
-    prespecified_weights_ampa=None,
-    prespecified_weights_nmda=None,
-    prespecified_delays=None,
-    render=True,
-    expand_last_drive=True,
-    event_seed=14
-):
+def add_drive_widget(drive_type,
+                     drive_boxes,
+                     drive_widgets,
+                     drives_out,
+                     tstop_widget,
+                     location,
+                     prespecified_drive_name=None,
+                     prespecified_drive_data=None,
+                     prespecified_weights_ampa=None,
+                     prespecified_weights_nmda=None,
+                     prespecified_delays=None,
+                     render=True,
+                     expand_last_drive=True,
+                     event_seed=14):
     """Add a widget for a new drive."""
     layout = Layout(width='270px', height='auto')
     style = {'description_width': '150px'}
@@ -477,6 +475,7 @@ def load_drives(variables, params, log_out, drives_out, drive_widgets,
         drive_names = sorted(drive_specs.keys())
         for idx, drive_name in enumerate(drive_names):  # order matters
             specs = drive_specs[drive_name]
+            should_render = idx == (len(drive_names) - 1)
             print(f"""load drive:
                 (name={drive_name},
                 type={specs['type']},
@@ -496,7 +495,7 @@ def load_drives(variables, params, log_out, drives_out, drive_widgets,
                 prespecified_weights_ampa=specs['weights_ampa'],
                 prespecified_weights_nmda=specs['weights_nmda'],
                 prespecified_delays=specs['synaptic_delays'],
-                render=idx == len(drive_names) - 1,
+                render=should_render,
                 expand_last_drive=False,
                 event_seed=specs['event_seed'],
             )

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -29,21 +29,23 @@ def create_expanded_button(description, button_style, height):
                   style=style)
 
 
-def _get_sliders(params, param_keys):
+def _get_sliders(variables, param_keys):
     """Get sliders"""
     style = {'description_width': '150px'}
     sliders = list()
     for d in param_keys:
         slider = FloatLogSlider(
-            value=params[d], min=-5, max=1, step=0.2,
+            value=variables['net']._params[d], min=-5, max=1, step=0.2,
             description=d.split('gbar_')[1],
             disabled=False, continuous_update=False, orientation='horizontal',
             readout=True, readout_format='.2e', style=style)
         sliders.append(slider)
 
-    def _update_params(params, **updates):
-        params.update(dict(**updates))
-        return params
+    def _update_params(variables, **updates):
+        variables['net']._params.update(dict(**updates))
+        variables['net'].connectivity = list()
+        # XXX: hack until there is a proper API
+        variables['net'].self._set_default_connections()
 
     interactive_output(_update_params, {s.description: s for s in sliders})
     return sliders
@@ -339,16 +341,16 @@ def run_hnn_gui():
     simulation_box = VBox([tstop, tstep])
 
     # Sliders to change local-connectivity params
-    sliders = [_get_sliders(variables['net']._params,
+    sliders = [_get_sliders(variables,
                ['gbar_L2Pyr_L2Pyr_ampa', 'gbar_L2Pyr_L2Pyr_nmda',
                 'gbar_L2Basket_L2Pyr_gabaa', 'gbar_L2Basket_L2Pyr_gabab']),
-               _get_sliders(variables['net']._params,
+               _get_sliders(variables,
                ['gbar_L2Pyr_L5Pyr', 'gbar_L2Basket_L5Pyr',
                 'gbar_L5Pyr_L5Pyr_ampa', 'gbar_L5Pyr_L5Pyr_nmda',
                 'gbar_L5Basket_L5Pyr_gabaa', 'gbar_L5Basket_L5Pyr_gabab']),
-               _get_sliders(variables['net']._params,
+               _get_sliders(variables,
                ['gbar_L2Pyr_L2Basket', 'gbar_L2Basket_L2Basket']),
-               _get_sliders(variables['net']._params,
+               _get_sliders(variables,
                ['gbar_L2Pyr_L5Pyr', 'gbar_L2Basket_L5Pyr'])]
 
     # accordians to group local-connectivity by cell type

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -77,7 +77,7 @@ def _get_rhythmic_widget(drive_title, tstop_widget, layout, style):
     tstart = FloatText(value=0., description='Start time:', **kwargs)
     tstart_std = FloatText(value=0, description='Start time dev:',
                            **kwargs)
-    tstop = BoundedFloatText(value=tstop_widget.value, description='Stop time:',
+    tstop = BoundedFloatText(value=tstop_widget.value, description='Stop time',
                              max=tstop_widget.value, **kwargs)
     burst_rate = FloatText(value=7.5, description='Burst rate:', **kwargs)
     burst_std = FloatText(value=0, description='Burst std dev:', **kwargs)
@@ -196,8 +196,9 @@ def update_plot_window(variables, plot_out, plot_type):
         elif plot_type['new'] == 'PSD':
             variables['dpls'][0].plot_psd(fmin=0, fmax=50)
         elif plot_type['new'] == 'spectogram':
-            freqs = np.arange(20., 100., 1.)
-            variables['dpls'][0].plot_tfr_morlet(freqs)
+            freqs = np.arange(10., 100., 1.)
+            n_cycles = freqs / 8.
+            variables['dpls'][0].plot_tfr_morlet(freqs, n_cycles=n_cycles)
 
 
 def on_upload_change(change, sliders, variables):

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -1040,3 +1040,8 @@ def run_hnn_gui():
         pane_heights=['50px', viz_height, "1"],
     )
     return hnn_gui
+
+def launch():
+    from voila.app import main
+    notebook_path = op.join(op.dirname(__file__), '..', 'hnn_widget.ipynb')
+    main([notebook_path])

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -656,7 +656,7 @@ def handle_backend_change(backend_type, mpi_cmd_config, mpi_cmd):
             display(mpi_cmd)
 
 
-def init_LR_viz_layout(plot_outputs,
+def init_left_right_viz_layout(plot_outputs,
                        plot_dropdowns,
                        window_height,
                        variables,
@@ -710,7 +710,7 @@ def init_LR_viz_layout(plot_outputs,
     return grid
 
 
-def init_UD_viz_layout(plot_outputs,
+def init_upper_down_viz_layout(plot_outputs,
                        plot_dropdowns,
                        window_height,
                        variables,
@@ -787,11 +787,11 @@ def initialize_viz_window(viz_window,
     with viz_window:
         # Left-Rright configuration
         if layout_option == "L-R":
-            grid = init_LR_viz_layout(plot_outputs, plot_dropdowns,
+            grid = init_left_right_viz_layout(plot_outputs, plot_dropdowns,
                                       window_height, variables, plot_options)
         # Upper-Down configuration
         elif layout_option == "U-D":
-            grid = init_UD_viz_layout(plot_outputs, plot_dropdowns,
+            grid = init_upper_down_viz_layout(plot_outputs, plot_dropdowns,
                                       window_height, variables, plot_options)
         # TODO: 2x2
 

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -15,8 +15,8 @@ from IPython.display import display
 
 from ipywidgets import (FloatLogSlider, Dropdown, Button, RadioButtons,
                         fixed, interactive_output, interactive, interact,
-                        FloatText, IntText, FileUpload, HTML, Output,
-                        HBox, VBox, Tab, Accordion,
+                        FloatText, BoundedFloatText, IntText, FileUpload,
+                        HTML, Output, HBox, VBox, Tab, Accordion,
                         Layout, AppLayout)
 
 
@@ -76,14 +76,15 @@ def _get_cell_specific_widgets(layout, style):
     return widgets_list, widgets_dict
 
 
-def _get_rhythmic_widget(drive_title, layout, style):
+def _get_rhythmic_widget(drive_title, tstop_widget, layout, style):
 
     tstart = FloatText(value=0., description='Start time:',
                        layout=layout, style=style)
     tstart_std = FloatText(value=0, description='Start time dev:',
                            layout=layout, style=style)
-    tstop = FloatText(value=200, description='Stop time:',
-                      layout=layout, style=style)
+    tstop = BoundedFloatText(value=tstop_widget.value, description='Stop time:',
+                             max=tstop_widget.value,
+                             layout=layout, style=style)
     burst_rate = FloatText(value=7.5, description='Burst rate:',
                            layout=layout, style=style)
     burst_std = FloatText(value=0, description='Burst std dev:',
@@ -106,11 +107,13 @@ def _get_rhythmic_widget(drive_title, layout, style):
     return drive, drive_box
 
 
-def _get_poisson_widget(drive_title, layout, style):
+def _get_poisson_widget(drive_title, tstop_widget, layout, style):
     tstart = FloatText(value=0.0, description='Start time:',
                        layout=layout, style=style)
-    tstop = FloatText(value=8.5, description='Stop time:',
-                      layout=layout, style=style)
+    tstop = BoundedFloatText(value=tstop_widget.value,
+                             max=tstop_widget.value,
+                             description='Stop time:',
+                             layout=layout, style=style)
     seedcore = IntText(value=14, description='Seed: ',
                        layout=layout, style=style)
     location = RadioButtons(options=['proximal', 'distal'])
@@ -159,7 +162,7 @@ def _get_evoked_widget(drive_title, layout, style):
 
 
 def add_drive_widget(drive_type, drive_titles, drive_boxes, drive_widgets,
-                     drives_out):
+                     drives_out, tstop_widget):
     """Add a widget for a new drive."""
     layout = Layout(width='270px', height='auto')
     style = {'description_width': '150px'}
@@ -168,9 +171,11 @@ def add_drive_widget(drive_type, drive_titles, drive_boxes, drive_widgets,
         drive_title = drive_type['new'] + str(len(drive_boxes))
 
         if drive_type['new'] == 'Rhythmic':
-            drive, drive_box = _get_rhythmic_widget(drive_title, layout, style)
+            drive, drive_box = _get_rhythmic_widget(drive_title, tstop_widget,
+                                                    layout, style)
         elif drive_type['new'] == 'Poisson':
-            drive, drive_box = _get_poisson_widget(drive_title, layout, style)
+            drive, drive_box = _get_poisson_widget(drive_title, tstop_widget,
+                                                   layout, style)
         elif drive_type['new'] == 'Evoked':
             drive, drive_box = _get_evoked_widget(drive_title, layout, style)
 
@@ -306,7 +311,7 @@ def run_hnn_gui():
 
     def _add_drive_widget(drive_type):
         return add_drive_widget(drive_type, drive_titles, drive_boxes,
-                                drive_widgets, drives_out)
+                                drive_widgets, drives_out, tstop)
 
     def _on_button_clicked(b):
         return on_button_clicked(log_out, plot_out, drive_widgets, variables,

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -397,7 +397,8 @@ def run_hnn_gui():
     load_button = FileUpload(accept='.json,.param', multiple=False,
                              style=style, description='Load network',
                              button_style='success')
-    delete_button = create_expanded_button('Delete drives', 'success', height='30px')
+    delete_button = create_expanded_button('Delete drives', 'success',
+                                           height='30px')
 
     load_button.observe(_on_upload_change)
     run_button.on_click(_run_button_clicked)
@@ -411,6 +412,6 @@ def run_hnn_gui():
                         left_sidebar=left_tab,
                         right_sidebar=right_sidebar,
                         footer=footer,
-                        pane_widths=['380px', 1, 1],
+                        pane_widths=['380px', '500px', '500px'],
                         pane_heights=[1, '500px', 1])
     return hnn_gui

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -74,15 +74,16 @@ def _get_cell_specific_widgets(layout, style):
 def _get_rhythmic_widget(drive_title, tstop_widget, layout, style):
 
     kwargs = dict(layout=layout, style=style)
-    tstart = FloatText(value=0., description='Start time:', **kwargs)
-    tstart_std = FloatText(value=0, description='Start time dev:',
+    tstart = FloatText(value=0., description='Start time (s)', **kwargs)
+    tstart_std = FloatText(value=0, description='Start time dev (s)',
                            **kwargs)
-    tstop = BoundedFloatText(value=tstop_widget.value, description='Stop time',
+    tstop = BoundedFloatText(value=tstop_widget.value,
+                             description='Stop time (s)',
                              max=tstop_widget.value, **kwargs)
-    burst_rate = FloatText(value=7.5, description='Burst rate:', **kwargs)
-    burst_std = FloatText(value=0, description='Burst std dev:', **kwargs)
-    repeats = FloatText(value=1, description='Spikes/burst:', **kwargs)
-    seedcore = IntText(value=14, description='Seed: ', **kwargs)
+    burst_rate = FloatText(value=7.5, description='Burst rate (Hz)', **kwargs)
+    burst_std = FloatText(value=0, description='Burst std dev (Hz)', **kwargs)
+    repeats = FloatText(value=1, description='Repeats', **kwargs)
+    seedcore = IntText(value=14, description='Seed', **kwargs)
     location = RadioButtons(options=['proximal', 'distal'])
 
     widgets_list, widgets_dict = _get_cell_specific_widgets(layout, style)
@@ -92,19 +93,19 @@ def _get_rhythmic_widget(drive_title, tstop_widget, layout, style):
                  tstart=tstart, tstart_std=tstart_std,
                  burst_rate=burst_rate, burst_std=burst_std,
                  repeats=repeats, seedcore=seedcore,
-                 location=location)
+                 location=location, tstop=tstop)
     drive.update(widgets_dict)
     return drive, drive_box
 
 
 def _get_poisson_widget(drive_title, tstop_widget, layout, style):
-    tstart = FloatText(value=0.0, description='Start time:',
+    tstart = FloatText(value=0.0, description='Start time (s)',
                        layout=layout, style=style)
     tstop = BoundedFloatText(value=tstop_widget.value,
                              max=tstop_widget.value,
-                             description='Stop time:',
+                             description='Stop time (s)',
                              layout=layout, style=style)
-    seedcore = IntText(value=14, description='Seed: ',
+    seedcore = IntText(value=14, description='Seed',
                        layout=layout, style=style)
     location = RadioButtons(options=['proximal', 'distal'])
 
@@ -269,6 +270,7 @@ def run_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
                 burst_std=drive['burst_std'].value,
                 repeats=drive['repeats'].value,
                 location=drive['location'].value,
+                tstop=drive['tstop'].value,
                 weights_ampa=weights_ampa,
                 weights_nmda=weights_nmda,
                 synaptic_delays=synaptic_delays,
@@ -343,7 +345,8 @@ def run_hnn_gui():
 
     # accordians to group local-connectivity by cell type
     boxes = [VBox(slider) for slider in sliders]
-    titles = ['Layer 2/3 Pyr', 'Layer 5 Pyr', 'Layer 2 Bas', 'Layer 5 Bas']
+    titles = ['Layer 2/3 Pyramidal', 'Layer 5 Pyramidal', 'Layer 2 Basket',
+              'Layer 5 Basket']
     accordian = Accordion(children=boxes)
     for idx, title in enumerate(titles):
         accordian.set_title(idx, title)

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -16,8 +16,8 @@ from ipywidgets import (HTML, Accordion, AppLayout, BoundedFloatText, Button,
                         interactive_output, GridspecLayout)
 
 import hnn_core
-from hnn_core import (MPIBackend, JoblibBackend, Network, read_params,
-                      simulate_dipole)
+from hnn_core import (MPIBackend, JoblibBackend, read_params,
+                      simulate_dipole, jones_2009_model)
 from hnn_core.params import (_read_json, _read_legacy_params,
                              _extract_drive_specs_from_hnn_params)
 from hnn_core.viz import plot_dipole
@@ -54,10 +54,6 @@ def _get_sliders(params, param_keys):
 
     interactive_output(_update_params, {s.description: s for s in sliders})
     return sliders
-
-
-def _add_connectivity():
-    pass
 
 
 def _get_cell_specific_widgets(
@@ -465,7 +461,7 @@ def load_drives(variables, params, log_out, drives_out, drive_widgets,
                 drive_boxes, tstop):
     """Add drive ipywidgets from params.
     """
-    variables['net'] = Network(params)
+    variables['net'] = jones_2009_model(params)
     log_out.clear_output()
     with log_out:
         drive_specs = _extract_drive_specs_from_hnn_params(
@@ -557,7 +553,7 @@ def run_button_clicked(log_out, drive_widgets, variables, tstep, tstop,
         print(f"drive_widgets length={len(drive_widgets)}")
         params['dt'] = tstep.value
         params['tstop'] = tstop.value
-        variables['net'] = Network(
+        variables['net'] = jones_2009_model(
             params,
             add_drives_from_params=False,
         )

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -27,11 +27,6 @@ def create_expanded_button(description, button_style, height):
                   style=style)
 
 
-def update_params(params, **updates):
-    params.update(dict(**updates))
-    return params
-
-
 def _get_sliders(params, param_keys):
     """Get sliders"""
     style = {'description_width': '150px'}
@@ -44,8 +39,11 @@ def _get_sliders(params, param_keys):
             readout=True, readout_format='.2e', style=style)
         sliders.append(slider)
 
-    _update_params = partial(update_params, params)
-    interactive_output(update_params, {s.description: s for s in sliders})
+    def _update_params(params, **updates):
+        params.update(dict(**updates))
+        return params
+
+    interactive_output(_update_params, {s.description: s for s in sliders})
     return sliders
 
 
@@ -329,17 +327,17 @@ def run_hnn_gui():
     tstep = FloatText(value=0.025, description='tstep (s):', disabled=False)
     simulation_box = VBox([tstop, tstep])
 
-    # Sliders to change local-connectivity Params
-    sliders = [_get_sliders(params,
+    # Sliders to change local-connectivity params
+    sliders = [_get_sliders(variables['net']._params,
                ['gbar_L2Pyr_L2Pyr_ampa', 'gbar_L2Pyr_L2Pyr_nmda',
                 'gbar_L2Basket_L2Pyr_gabaa', 'gbar_L2Basket_L2Pyr_gabab']),
-               _get_sliders(params,
+               _get_sliders(variables['net']._params,
                ['gbar_L2Pyr_L5Pyr', 'gbar_L2Basket_L5Pyr',
                 'gbar_L5Pyr_L5Pyr_ampa', 'gbar_L5Pyr_L5Pyr_nmda',
                 'gbar_L5Basket_L5Pyr_gabaa', 'gbar_L5Basket_L5Pyr_gabab']),
-               _get_sliders(params,
+               _get_sliders(variables['net']._params,
                ['gbar_L2Pyr_L2Basket', 'gbar_L2Basket_L2Basket']),
-               _get_sliders(params,
+               _get_sliders(variables['net']._params,
                ['gbar_L2Pyr_L5Pyr', 'gbar_L2Basket_L5Pyr'])]
 
     # accordians to group local-connectivity by cell type

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -318,6 +318,14 @@ def run_hnn_gui():
     def _update_plot_window(plot_type):
         return update_plot_window(variables, plot_out, plot_type)
 
+    def _delete_drives_clicked(b):
+        drives_out.clear_output()
+        # black magic: the following does not work
+        # global drive_widgets; drive_widgets = list()
+        while len(drive_widgets) > 0:
+            drive_widgets.pop()
+            drive_boxes.pop()
+
     # Output windows
     drives_out = Output()  # window to add new drives
     log_out = Output(layout={'border': '1px solid gray', 'height': '150px',
@@ -383,16 +391,18 @@ def run_hnn_gui():
     interactive(_update_plot_window, plot_type='current dipole')
     plot_dropdown.observe(_update_plot_window, 'value')
 
-    # Run and load button
+    # Run, delete drives and load button
     run_button = create_expanded_button('Run', 'success', height='30px')
     style = {'button_color': '#8A2BE2', 'font_color': 'white'}
     load_button = FileUpload(accept='.json,.param', multiple=False,
                              style=style, description='Load network',
                              button_style='success')
+    delete_button = create_expanded_button('Delete drives', 'success', height='30px')
 
     load_button.observe(_on_upload_change)
     run_button.on_click(_run_button_clicked)
-    footer = HBox([run_button, load_button, plot_dropdown])
+    delete_button.on_click(_delete_drives_clicked)
+    footer = HBox([run_button, load_button, delete_button, plot_dropdown])
 
     right_sidebar = VBox([plot_out, log_out])
 

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -219,8 +219,8 @@ def on_upload_change(change, sliders, variables):
     variables['net'].external_drives = external_drives.copy()
 
 
-def on_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
-                      tstop, b):
+def run_button_clicked(log_out, plot_out, drive_widgets, variables, tstep,
+                       tstop, b):
     """Run the simulation and plot outputs."""
     plot_out.clear_output()
     log_out.clear_output()
@@ -304,9 +304,9 @@ def run_hnn_gui():
         return add_drive_widget(drive_type, drive_titles, drive_boxes,
                                 drive_widgets, drives_out, tstop)
 
-    def _on_button_clicked(b):
-        return on_button_clicked(log_out, plot_out, drive_widgets, variables,
-                                 tstep, tstop, b)
+    def _run_button_clicked(b):
+        return run_button_clicked(log_out, plot_out, drive_widgets, variables,
+                                  tstep, tstop, b)
 
     def _on_upload_change(change):
         return on_upload_change(change, sliders, variables)
@@ -386,7 +386,7 @@ def run_hnn_gui():
                              button_style='success')
 
     load_button.observe(_on_upload_change)
-    run_button.on_click(_on_button_clicked)
+    run_button.on_click(_run_button_clicked)
     footer = HBox([run_button, load_button, plot_dropdown])
 
     right_sidebar = VBox([plot_out, log_out])

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -628,7 +628,7 @@ def run_button_clicked(log_out, drive_widgets, variables, tstep, tstop,
                 n_procs=multiprocessing.cpu_count() - 1, mpi_cmd=mpi_cmd.value)
         else:
             variables['backend'] = JoblibBackend(n_jobs=joblib_cores.value)
-            print(f"Using Joblib as backend with {joblib_cores.value} core(s).")
+            print(f"Using Joblib with {joblib_cores.value} core(s).")
         with variables['backend']:
             variables['dpls'] = simulate_dipole(variables['net'],
                                                 tstop=tstop.value,

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -940,7 +940,7 @@ def run_hnn_gui():
     layout = Layout(width='200px', height='100px')
 
     drive_type_selection = RadioButtons(
-        options=['Evoked', 'Poisson', 'Rhythmic', 'Bursty'],
+        options=['Evoked', 'Poisson', 'Rhythmic'],
         value='Evoked',
         description='Drive:',
         disabled=False,

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -4,6 +4,7 @@
 #          Huzi Cheng <hzcheng15@icloud.com>
 
 import codecs
+import logging
 import multiprocessing
 import os
 import os.path as op
@@ -23,6 +24,17 @@ from hnn_core import (JoblibBackend, MPIBackend, jones_2009_model, read_params,
 from hnn_core.params import (_extract_drive_specs_from_hnn_params, _read_json,
                              _read_legacy_params)
 from hnn_core.viz import plot_dipole
+
+
+log_file = os.getenv("HNNGUI_LOGFILE", None)
+debug_gui = os.getenv("DEBUG_HNNGUI", "0")
+if debug_gui == '1' and log_file is not None:
+    logging.basicConfig(filename=log_file,
+                        filemode='w',
+                        level=logging.DEBUG,
+                        format='%(name)s - %(levelname)s - %(message)s')
+else:
+    logging.basicConfig(level=logging.ERROR)
 
 
 def create_expanded_button(description, button_style, height, disabled=False):
@@ -52,7 +64,8 @@ def _get_sliders(params, param_keys):
                                 style=style)
         sliders.append(slider)
 
-    def _update_params(variables, **updates):
+    def _update_params(**updates):
+        logging.debug(f'Connectivity parameters updates: {updates}')
         params.update(dict(**updates))
 
     interactive_output(_update_params, {s.description: s for s in sliders})
@@ -895,7 +908,7 @@ def run_hnn_gui():
     log_out = Output(layout={
         'border': '1px solid gray',
         'height': log_out_heiht,
-        'overflow_y': 'auto'
+        'overflow': 'auto'
     })
     viz_width = "1000px"
     viz_height = "500px"
@@ -1053,7 +1066,7 @@ def run_hnn_gui():
     # Run, delete drives and load button
     run_button = create_expanded_button('Run', 'success', height='30px')
 
-    style = {'button_color': '#8A2BE2', 'font_color': 'white'}
+    style = {'button_color': '#8A2BE2'}
     load_button = FileUpload(accept='.json,.param',
                              multiple=False,
                              style=style,

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -5,30 +5,32 @@
 
 import codecs
 import multiprocessing
-import os.path as op
-import numpy as np
 import os
+import os.path as op
+
 import matplotlib.pyplot as plt
+import numpy as np
 from IPython.display import display
 from ipywidgets import (HTML, Accordion, AppLayout, BoundedFloatText, Button,
-                        Dropdown, FileUpload, FloatLogSlider, FloatText, HBox,
-                        IntText, Layout, Output, RadioButtons, Tab, Text, VBox,
-                        interactive_output, GridspecLayout)
+                        Dropdown, FileUpload, FloatLogSlider, FloatText,
+                        GridspecLayout, HBox, IntText, Layout, Output,
+                        RadioButtons, Tab, Text, VBox, interactive_output)
 
 import hnn_core
-from hnn_core import (MPIBackend, JoblibBackend, read_params, simulate_dipole,
-                      jones_2009_model)
-from hnn_core.params import (_read_json, _read_legacy_params,
-                             _extract_drive_specs_from_hnn_params)
+from hnn_core import (JoblibBackend, MPIBackend, jones_2009_model, read_params,
+                      simulate_dipole)
+from hnn_core.params import (_extract_drive_specs_from_hnn_params, _read_json,
+                             _read_legacy_params)
 from hnn_core.viz import plot_dipole
 
 
-def create_expanded_button(description, button_style, height):
+def create_expanded_button(description, button_style, height, disabled=False):
     style = {'button_color': '#8A2BE2'}
     return Button(description=description,
                   button_style=button_style,
                   layout=Layout(height=height, width='auto'),
-                  style=style)
+                  style=style,
+                  disabled=disabled)
 
 
 def _get_sliders(params, param_keys):
@@ -345,7 +347,7 @@ def add_drive_widget(
     prespecified_delays=None,
     render=True,
     expand_last_drive=True,
-    event_seed=14,
+    event_seed=14
 ):
     """Add a widget for a new drive."""
     layout = Layout(width='270px', height='auto')
@@ -459,8 +461,7 @@ def update_plot_window(variables, _plot_out, plot_type):
 
 def load_drives(variables, params, log_out, drives_out, drive_widgets,
                 drive_boxes, tstop):
-    """Add drive ipywidgets from params.
-    """
+    """Add drive ipywidgets from params."""
     variables['net'] = jones_2009_model(params)
     log_out.clear_output()
     with log_out:
@@ -657,11 +658,11 @@ def handle_backend_change(backend_type, mpi_cmd_config, mpi_cmd):
 
 
 def init_left_right_viz_layout(plot_outputs,
-                       plot_dropdowns,
-                       window_height,
-                       variables,
-                       plot_options,
-                       border='1px solid gray'):
+                               plot_dropdowns,
+                               window_height,
+                               variables,
+                               plot_options,
+                               border='1px solid gray'):
     height_plot = window_height
     plot_outputs_L = Output(layout={'border': border, 'height': height_plot})
 
@@ -711,11 +712,11 @@ def init_left_right_viz_layout(plot_outputs,
 
 
 def init_upper_down_viz_layout(plot_outputs,
-                       plot_dropdowns,
-                       window_height,
-                       variables,
-                       plot_options,
-                       border='1px solid gray'):
+                               plot_dropdowns,
+                               window_height,
+                               variables,
+                               plot_options,
+                               border='1px solid gray'):
     height_plot = window_height
     plot_outputs_U = Output(layout={
         'border': border,
@@ -788,11 +789,13 @@ def initialize_viz_window(viz_window,
         # Left-Rright configuration
         if layout_option == "L-R":
             grid = init_left_right_viz_layout(plot_outputs, plot_dropdowns,
-                                      window_height, variables, plot_options)
+                                              window_height, variables,
+                                              plot_options)
         # Upper-Down configuration
         elif layout_option == "U-D":
             grid = init_upper_down_viz_layout(plot_outputs, plot_dropdowns,
-                                      window_height, variables, plot_options)
+                                              window_height, variables,
+                                              plot_options)
         # TODO: 2x2
 
         display(grid)
@@ -853,7 +856,8 @@ def run_hnn_gui():
     # header_button
     header_button = create_expanded_button('HUMAN NEOCORTICAL NEUROSOLVER',
                                            'success',
-                                           height='40px')
+                                           height='40px',
+                                           disabled=True)
 
     # Simulation parameters
     tstop = FloatText(value=170, description='tstop (ms):', disabled=False)

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -16,8 +16,8 @@ from ipywidgets import (HTML, Accordion, AppLayout, BoundedFloatText, Button,
                         interactive_output, GridspecLayout)
 
 import hnn_core
-from hnn_core import (MPIBackend, JoblibBackend, read_params,
-                      simulate_dipole, jones_2009_model)
+from hnn_core import (MPIBackend, JoblibBackend, read_params, simulate_dipole,
+                      jones_2009_model)
 from hnn_core.params import (_read_json, _read_legacy_params,
                              _extract_drive_specs_from_hnn_params)
 from hnn_core.viz import plot_dipole
@@ -930,7 +930,10 @@ def run_hnn_gui():
         ]),
         _get_sliders(params,
                      ['gbar_L2Pyr_L2Basket', 'gbar_L2Basket_L2Basket']),
-        _get_sliders(params, ['gbar_L2Pyr_L5Pyr', 'gbar_L2Basket_L5Pyr'])
+        _get_sliders(params, [
+            'gbar_L2Pyr_L5Basket', 'gbar_L5Pyr_L5Basket',
+            'gbar_L5Basket_L5Basket'
+        ])
     ]
 
     # accordians to group local-connectivity by cell type

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -60,30 +60,31 @@ def _add_connectivity():
     pass
 
 
-def _get_cell_specific_widgets(layout,
-                               style,
-                               location,
-                               data=None,
-                               default_data={
-                                   'weights_ampa': {
-                                       'L5_pyramidal': 0.,
-                                       'L2_pyramidal': 0.,
-                                       'L5_basket': 0.,
-                                       'L2_basket': 0.
-                                   },
-                                   'weights_nmda': {
-                                       'L5_pyramidal': 0.,
-                                       'L2_pyramidal': 0.,
-                                       'L5_basket': 0.,
-                                       'L2_basket': 0.
-                                   },
-                                   'delays': {
-                                       'L5_pyramidal': 0.1,
-                                       'L2_pyramidal': 0.1,
-                                       'L5_basket': 0.1,
-                                       'L2_basket': 0.1
-                                   },
-                               }):
+def _get_cell_specific_widgets(
+    layout,
+    style,
+    location,
+    data=None,
+    default_data={
+        'weights_ampa': {
+            'L5_pyramidal': 0.,
+            'L2_pyramidal': 0.,
+            'L5_basket': 0.,
+            'L2_basket': 0.
+        },
+        'weights_nmda': {
+            'L5_pyramidal': 0.,
+            'L2_pyramidal': 0.,
+            'L5_basket': 0.,
+            'L2_basket': 0.
+        },
+        'delays': {
+            'L5_pyramidal': 0.1,
+            'L2_pyramidal': 0.1,
+            'L5_basket': 0.1,
+            'L2_basket': 0.1
+        },
+    }):
     if isinstance(data, dict):
         for k in default_data.keys():
             if k in data:

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -56,10 +56,14 @@ def _get_sliders(params, param_keys):
     return sliders
 
 
+def _add_connectivity():
+    pass
+
+
 def _get_cell_specific_widgets(layout,
                                style,
                                location,
-                               data={},
+                               data=None,
                                default_data={
                                    'weights_ampa': {
                                        'L5_pyramidal': 0.,
@@ -80,10 +84,10 @@ def _get_cell_specific_widgets(layout,
                                        'L2_basket': 0.1
                                    },
                                }):
-
-    for k in default_data.keys():
-        if k in data:
-            default_data[k].update(data[k])
+    if isinstance(data, dict):
+        for k in default_data.keys():
+            if k in data:
+                default_data[k].update(data[k])
 
     kwargs = dict(layout=layout, style=style)
     cell_types = ['L5_pyramidal', 'L2_pyramidal', 'L5_basket', 'L2_basket']
@@ -125,7 +129,7 @@ def _get_rhythmic_widget(
     layout,
     style,
     location,
-    data={},
+    data=None,
     default_data={
         'tstart': 0.,
         'tstart_std': 0.,
@@ -135,11 +139,12 @@ def _get_rhythmic_widget(
         'repeats': 1,
         'seedcore': 14,
     },
-    default_weights_ampa={},
-    default_weights_nmda={},
-    default_delays={},
+    default_weights_ampa=None,
+    default_weights_nmda=None,
+    default_delays=None,
 ):
-    default_data.update(data)
+    if isinstance(data, dict):
+        default_data.update(data)
     kwargs = dict(layout=layout, style=style)
     tstart = FloatText(value=default_data['tstart'],
                        description='Start time (ms)',
@@ -200,7 +205,7 @@ def _get_poisson_widget(
     layout,
     style,
     location,
-    data={},
+    data=None,
     default_data={
         'tstart': 0.0,
         'tstop': 0.0,
@@ -212,11 +217,12 @@ def _get_poisson_widget(
             'L2_basket': 8.5,
         }
     },
-    default_weights_ampa={},
-    default_weights_nmda={},
-    default_delays={},
+    default_weights_ampa=None,
+    default_weights_nmda=None,
+    default_delays=None,
 ):
-    default_data.update(data)
+    if isinstance(data, dict):
+        default_data.update(data)
     tstart = FloatText(value=default_data['tstart'],
                        description='Start time (ms)',
                        layout=layout,
@@ -276,18 +282,19 @@ def _get_evoked_widget(
     layout,
     style,
     location,
-    data={},
+    data=None,
     default_data={
         'mu': 0,
         'sigma': 1,
         'numspikes': 1,
         'seedcore': 14,
     },
-    default_weights_ampa={},
-    default_weights_nmda={},
-    default_delays={},
+    default_weights_ampa=None,
+    default_weights_nmda=None,
+    default_delays=None,
 ):
-    default_data.update(data)
+    if isinstance(data, dict):
+        default_data.update(data)
     kwargs = dict(layout=layout, style=style)
     mu = FloatText(value=default_data['mu'],
                    description='Mean time:',
@@ -334,10 +341,10 @@ def add_drive_widget(
     tstop_widget,
     location,
     prespecified_drive_name=None,
-    prespecified_drive_data={},
-    prespecified_weights_ampa={},
-    prespecified_weights_nmda={},
-    prespecified_delays={},
+    prespecified_drive_data=None,
+    prespecified_weights_ampa=None,
+    prespecified_weights_nmda=None,
+    prespecified_delays=None,
     render=True,
     expand_last_drive=True,
     event_seed=14,
@@ -346,8 +353,10 @@ def add_drive_widget(
     layout = Layout(width='270px', height='auto')
     style = {'description_width': '150px'}
     drives_out.clear_output()
-
+    if not prespecified_drive_data:
+        prespecified_drive_data = {}
     prespecified_drive_data.update({"seedcore": max(event_seed, 2)})
+
     with drives_out:
         if not prespecified_drive_name:
             name = drive_type + str(len(drive_boxes))

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -1041,6 +1041,7 @@ def run_hnn_gui():
     )
     return hnn_gui
 
+
 def launch():
     from voila.app import main
     notebook_path = op.join(op.dirname(__file__), '..', 'hnn_widget.ipynb')

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -65,7 +65,8 @@ def _get_cell_specific_widgets(
     style,
     location,
     data=None,
-    default_data={
+):
+    default_data = {
         'weights_ampa': {
             'L5_pyramidal': 0.,
             'L2_pyramidal': 0.,
@@ -84,7 +85,7 @@ def _get_cell_specific_widgets(
             'L5_basket': 0.1,
             'L2_basket': 0.1
         },
-    }):
+    }
     if isinstance(data, dict):
         for k in default_data.keys():
             if k in data:
@@ -131,7 +132,11 @@ def _get_rhythmic_widget(
     style,
     location,
     data=None,
-    default_data={
+    default_weights_ampa=None,
+    default_weights_nmda=None,
+    default_delays=None,
+):
+    default_data = {
         'tstart': 0.,
         'tstart_std': 0.,
         'tstop': 0.,
@@ -139,11 +144,7 @@ def _get_rhythmic_widget(
         'burst_std': 0,
         'repeats': 1,
         'seedcore': 14,
-    },
-    default_weights_ampa=None,
-    default_weights_nmda=None,
-    default_delays=None,
-):
+    }
     if isinstance(data, dict):
         default_data.update(data)
     kwargs = dict(layout=layout, style=style)
@@ -207,7 +208,11 @@ def _get_poisson_widget(
     style,
     location,
     data=None,
-    default_data={
+    default_weights_ampa=None,
+    default_weights_nmda=None,
+    default_delays=None,
+):
+    default_data = {
         'tstart': 0.0,
         'tstop': 0.0,
         'seedcore': 14,
@@ -217,11 +222,7 @@ def _get_poisson_widget(
             'L5_basket': 8.5,
             'L2_basket': 8.5,
         }
-    },
-    default_weights_ampa=None,
-    default_weights_nmda=None,
-    default_delays=None,
-):
+    }
     if isinstance(data, dict):
         default_data.update(data)
     tstart = FloatText(value=default_data['tstart'],
@@ -284,16 +285,16 @@ def _get_evoked_widget(
     style,
     location,
     data=None,
-    default_data={
-        'mu': 0,
-        'sigma': 1,
-        'numspikes': 1,
-        'seedcore': 14,
-    },
     default_weights_ampa=None,
     default_weights_nmda=None,
     default_delays=None,
 ):
+    default_data = {
+        'mu': 0,
+        'sigma': 1,
+        'numspikes': 1,
+        'seedcore': 14,
+    }
     if isinstance(data, dict):
         default_data.update(data)
     kwargs = dict(layout=layout, style=style)

--- a/hnn_core/gui.py
+++ b/hnn_core/gui.py
@@ -50,77 +50,9 @@ def _get_sliders(params, param_keys):
     return sliders
 
 
-def _get_rhythmic_widget(drive_title, layout, style):
-    tstart = FloatText(value=0., description='Start time:',
-                       layout=layout, style=style)
-    tstart_std = FloatText(value=7.5, description='Start time dev:',
-                           layout=layout, style=style)
-    tstop = FloatText(value=7.5, description='Stop time:',
-                      layout=layout, style=style)
-    burst_rate = FloatText(value=7.5, description='Burst rate:',
-                           layout=layout, style=style)
-    burst_std = FloatText(value=7.5, description='Burst std dev:',
-                          layout=layout, style=style)
-    location = RadioButtons(options=['proximal', 'distal'])
-
-    drive_box = VBox([tstart, tstart_std, tstop, burst_rate, burst_std,
-                     location])
-    drive = dict(type='Rhythmic', name=drive_title,
-                 tstart=tstart, tstart_std=tstart_std,
-                 burst_rate=burst_rate, burst_std=burst_std,
-                 location=location)
-    return drive, drive_box
-
-
-def _get_poisson_widget(drive_title, layout, style):
+def _get_cell_specific_widgets(layout, style):
     cell_types = ['L5_pyramidal', 'L2_pyramidal', 'L5_basket',
                   'L2_basket']
-    tstart = FloatText(value=0.0, description='Start time:',
-                       layout=layout, style=style)
-    tstop = FloatText(value=8.5, description='Stop time:',
-                      layout=layout, style=style)
-    location = RadioButtons(options=['proximal', 'distal'])
-    labels = {'rate_constant': HTML(value="<b>Rate constants</b>"),
-              'ampa': HTML(value="<b>AMPA weights</b>"),
-              'nmda': HTML(value="<b>NMDA weights</b>")}
-    weights_ampa, weights_nmda = dict(), dict()
-    rate_constant = dict()
-    for cell_type in cell_types:
-        rate_constant[f'{cell_type}'] = FloatText(
-            value=8.5, description=f'{cell_type}:',
-            layout=layout, style=style)
-        weights_ampa[f'{cell_type}'] = FloatText(
-            value=0., description=f'{cell_type}:',
-            layout=layout, style=style)
-        weights_nmda[f'{cell_type}'] = FloatText(
-            value=0., description=f'{cell_type}:', layout=layout,
-            style=style)
-
-    drive_box = VBox([tstart, tstop, location] + [labels['rate_constant']] +
-                     list(rate_constant.values()) + [labels['ampa']] +
-                     list(weights_ampa.values()) + [labels['nmda']] +
-                     list(weights_nmda.values()))
-    drive = dict(type='Poisson', name=drive_title, tstart=tstart,
-                 tstop=tstop, rate_constant=rate_constant,
-                 location=location, weights_ampa=weights_ampa,
-                 weights_nmda=weights_nmda)
-    return drive, drive_box
-
-
-def _get_evoked_widget(drive_title, layout, style):
-    cell_types = ['L5_pyramidal', 'L2_pyramidal', 'L5_basket',
-                  'L2_basket']
-    mu = FloatText(value=0, description='Mean time:',
-                   layout=layout)
-    sigma = FloatText(value=1, description='Std dev time:',
-                      layout=layout)
-    numspikes = IntText(value=1, description='No. Spikes:',
-                        layout=layout)
-    location = RadioButtons(options=['proximal', 'distal'])
-    labels = {'ampa': HTML(value="<b>AMPA weights</b>"),
-              'nmda': HTML(value="<b>NMDA weights</b>"),
-              'delays': HTML(value="<b>Synaptic delays</b>")}
-
     weights_ampa, weights_nmda, delays = dict(), dict(), dict()
     for cell_type in cell_types:
         weights_ampa[f'{cell_type}'] = FloatText(
@@ -133,16 +65,85 @@ def _get_evoked_widget(drive_title, layout, style):
             value=0.1, description=f'{cell_type}:', layout=layout,
             style=style)
 
+    widgets_dict = {'weights_ampa': weights_ampa,
+                    'weights_nmda': weights_nmda, 'delays': delays}
+    widgets_list = ([HTML(value="<b>AMPA weights</b>")] +
+                    list(weights_ampa.values()) +
+                    [HTML(value="<b>NMDA weights</b>")] +
+                    list(weights_nmda.values()) +
+                    [HTML(value="<b>Synaptic delays</b>")] +
+                    list(delays.values()))
+    return widgets_list, widgets_dict
+
+
+def _get_rhythmic_widget(drive_title, layout, style):
+
+    tstart = FloatText(value=0., description='Start time:',
+                       layout=layout, style=style)
+    tstart_std = FloatText(value=7.5, description='Start time dev:',
+                           layout=layout, style=style)
+    tstop = FloatText(value=7.5, description='Stop time:',
+                      layout=layout, style=style)
+    burst_rate = FloatText(value=7.5, description='Burst rate:',
+                           layout=layout, style=style)
+    burst_std = FloatText(value=7.5, description='Burst std dev:',
+                          layout=layout, style=style)
+    location = RadioButtons(options=['proximal', 'distal'])
+
+    widgets_list, widgets_dict = _get_cell_specific_widgets(layout, style)
+    drive_box = VBox([tstart, tstart_std, tstop, burst_rate, burst_std,
+                     location] + widgets_list)
+    drive = dict(type='Rhythmic', name=drive_title,
+                 tstart=tstart, tstart_std=tstart_std,
+                 burst_rate=burst_rate, burst_std=burst_std)
+    drive.update(widgets_dict)
+    return drive, drive_box
+
+
+def _get_poisson_widget(drive_title, layout, style):
+    tstart = FloatText(value=0.0, description='Start time:',
+                       layout=layout, style=style)
+    tstop = FloatText(value=8.5, description='Stop time:',
+                      layout=layout, style=style)
+    location = RadioButtons(options=['proximal', 'distal'])
+
+    cell_types = ['L5_pyramidal', 'L2_pyramidal', 'L5_basket',
+                  'L2_basket']
+    rate_constant = dict()
+    for cell_type in cell_types:
+        rate_constant[f'{cell_type}'] = FloatText(
+            value=8.5, description=f'{cell_type}:',
+            layout=layout, style=style)
+
+    widgets_list, widgets_dict = _get_cell_specific_widgets(layout, style)
+    widgets_dict.update({'rate_constant': rate_constant})
+    widgets_list.extend([HTML(value="<b>Rate constants</b>")] +
+                        list(widgets_dict['rate_constant'].values()))
+
+    drive_box = VBox([tstart, tstop, location] + widgets_list)
+    drive = dict(type='Poisson', name=drive_title, tstart=tstart,
+                 tstop=tstop, rate_constant=rate_constant,
+                 location=location)
+    drive.update(widgets_dict)
+    return drive, drive_box
+
+
+def _get_evoked_widget(drive_title, layout, style):
+    mu = FloatText(value=0, description='Mean time:',
+                   layout=layout)
+    sigma = FloatText(value=1, description='Std dev time:',
+                      layout=layout)
+    numspikes = IntText(value=1, description='No. Spikes:',
+                        layout=layout)
+    location = RadioButtons(options=['proximal', 'distal'])
+
+    widgets_list, widgets_dict = _get_cell_specific_widgets(layout, style)
     drive_box = VBox([mu, sigma, numspikes, location] +
-                     [labels['ampa']] + list(weights_ampa.values()) +
-                     [labels['nmda']] + list(weights_nmda.values()) +
-                     [labels['delays']] + list(delays.values()))
+                     widgets_list)
     drive = dict(type='Evoked', name=drive_title,
                  mu=mu, sigma=sigma, numspikes=numspikes,
-                 sync_within_trial=False, location=location,
-                 weights_ampa=weights_ampa,
-                 weights_nmda=weights_nmda, delays=delays,
-                 space_constant=3.0)
+                 sync_within_trial=False, location=location)
+    drive.update(widgets_dict)
     return drive, drive_box
 
 
@@ -214,13 +215,16 @@ def on_upload_change(change, sliders, variables):
 def on_button_clicked(log_out, plot_out, drive_widgets, variables, b):
     """Run the simulation and plot outputs."""
     for drive in drive_widgets:
+        weights_ampa = {k: v.value for k, v in drive['weights_ampa'].items()}
+        weights_nmda = {k: v.value for k, v in drive['weights_nmda'].items()}
+        synaptic_delays = {k: v.value for k, v in drive['delays'].items()}
         if drive['type'] == 'Poisson':
-            weights_ampa, weights_nmda, rate_constant = dict(), dict(), dict()
-            for k, v in drive['rate_constant'].items():
-                if v.value > 0:
-                    weights_ampa[k] = drive['weights_ampa'][k].value
-                    weights_nmda[k] = drive['weights_nmda'][k].value
-                    rate_constant[k] = drive['rate_constant'][k].value
+            rate_constant = {k: v.value for k, v in
+                             drive['rate_constant'].items() if v.value > 0}
+            weights_ampa = {k: v for k, v in weights_ampa.items() if k in
+                            rate_constant}
+            weights_nmda = {k: v for k, v in weights_nmda.items() if k in
+                            rate_constant}
             variables['net'].add_poisson_drive(
                 name=drive['name'],
                 tstart=drive['tstart'].value,
@@ -229,14 +233,10 @@ def on_button_clicked(log_out, plot_out, drive_widgets, variables, b):
                 location=drive['location'].value,
                 weights_ampa=weights_ampa,
                 weights_nmda=weights_nmda,
+                synaptic_delays=synaptic_delays,
                 space_constant=100.0
             )
         elif drive['type'] == 'Evoked':
-            weights_ampa = {k: v.value for k, v in
-                            drive['weights_ampa'].items()}
-            weights_nmda = {k: v.value for k, v in
-                            drive['weights_nmda'].items()}
-            delays = {k: v.value for k, v in drive['delays'].items()}
             variables['net'].add_evoked_drive(
                 name=drive['name'],
                 mu=drive['mu'].value,
@@ -246,7 +246,7 @@ def on_button_clicked(log_out, plot_out, drive_widgets, variables, b):
                 location=drive['location'].value,
                 weights_ampa=weights_ampa,
                 weights_nmda=weights_nmda,
-                synaptic_delays=delays,
+                synaptic_delays=synaptic_delays,
                 space_constant=3.0
             )
         elif drive['type'] == 'Rhythmic':
@@ -256,7 +256,10 @@ def on_button_clicked(log_out, plot_out, drive_widgets, variables, b):
                 tstart_std=drive['tstart_std'].value,
                 burst_rate=drive['burst_rate'].value,
                 burst_std=drive['burst_std'].value,
-                location=drive['location'].value
+                location=drive['location'].value,
+                weights_ampa=weights_ampa,
+                weights_nmda=weights_nmda,
+                synaptic_delays=synaptic_delays
             )
     with log_out:
         variables['dpls'] = simulate_dipole(variables['net'], n_trials=1)

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -841,10 +841,10 @@ def run_hnn_gui():
     # Output windows
     drives_out = Output()  # window to add new drives
 
-    log_out_heiht = "100px"
+    log_out_height = "100px"
     log_out = Output(layout={
         'border': '1px solid gray',
-        'height': log_out_heiht,
+        'height': log_out_height,
         'overflow': 'auto'
     })
     viz_width = "1000px"
@@ -874,8 +874,6 @@ def run_hnn_gui():
                           viz_height, layout_option=viz_layout_selection.value,
                           init=True)
 
-    viz_layout_selection.observe(handle_viz_layout_change, 'value')
-
     # select backends
     backend_selection = Dropdown(
         options=[('Joblib', 'Joblib'), ('MPI', 'MPI')], value='Joblib',
@@ -889,10 +887,8 @@ def run_hnn_gui():
                                   description='Cores:', disabled=False)
 
     backend_config = Output()
-
     handle_backend_change(backend_selection.value, backend_config, mpi_cmd,
                           joblib_cores)
-    backend_selection.observe(_handle_backend_change, 'value')
 
     simulation_box = VBox([tstop, tstep, ntrials, backend_selection,
                            backend_config])
@@ -945,7 +941,6 @@ def run_hnn_gui():
     add_drive_button = create_expanded_button('Add drive', 'primary',
                                               height='30px')
 
-    add_drive_button.on_click(_add_drive_button_clicked)
     drive_selections = VBox(
         [HBox([drive_type_selection, location_selection]), add_drive_button])
 
@@ -970,17 +965,13 @@ def run_hnn_gui():
     load_button = FileUpload(accept='.json,.param', multiple=False,
                              style=style, description='Load network',
                              button_style='success')
-    delete_button = create_expanded_button('Delete drives', 'success',
-                                           height='30px')
+    delete_drive_button = create_expanded_button('Delete drives', 'success',
+                                                 height='30px')
 
-    load_button.observe(_on_upload_change)
-    run_button.on_click(_run_button_clicked)
-
-    delete_button.on_click(_delete_drives_clicked)
     left_width = '380px'
     footer = VBox([
         HBox([
-            HBox([run_button, load_button, delete_button],
+            HBox([run_button, load_button, delete_drive_button],
                  layout={"width": left_width}),
             viz_layout_selection,
         ]), log_out, simulation_status
@@ -999,6 +990,15 @@ def run_hnn_gui():
         pane_widths=[left_width, '0px', viz_width],
         pane_heights=['50px', viz_height, "1"],
     )
+
+    # ######## connect to callbacks ##########
+    backend_selection.observe(_handle_backend_change, 'value')
+    add_drive_button.on_click(_add_drive_button_clicked)
+    delete_drive_button.on_click(_delete_drives_clicked)
+    load_button.observe(_on_upload_change)
+    run_button.on_click(_run_button_clicked)
+    viz_layout_selection.observe(handle_viz_layout_change, 'value')
+
     return hnn_gui
 
 

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -36,7 +36,6 @@ if debug_gui == '1' and log_file is not None:
 else:
     logging.basicConfig(level=logging.ERROR)
 
-
 THEMECOLOR = "#8A2BE2"
 
 
@@ -518,7 +517,6 @@ def load_drives(variables, params, log_out, drives_out, drive_widgets,
             )
 
 
-
 def on_upload_change(
     change,
     sliders,
@@ -925,10 +923,9 @@ def run_hnn_gui():
     })
 
     # header_button
-    header_button = HTML(
-        value=
-        f"""<div style='background:{THEMECOLOR}; text-align: center; color: white;'>
-    HUMAN NEOCORTICAL NEUROSOLVER</div>""")
+    header_button = HTML(value=f"""<div
+        style='background:{THEMECOLOR};text-align:center;color:white;'>
+        HUMAN NEOCORTICAL NEUROSOLVER</div>""")
 
     # Simulation parameters
     tstop = FloatText(value=170, description='tstop (ms):', disabled=False)

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -6,12 +6,12 @@
 import codecs
 import logging
 import multiprocessing
-import os
 import os.path as op
 import sys
 
 import matplotlib.pyplot as plt
 import numpy as np
+
 from IPython.display import display
 from ipywidgets import (HTML, Accordion, AppLayout, BoundedFloatText,
                         BoundedIntText, Button, Dropdown, FileUpload,
@@ -316,8 +316,9 @@ def _get_evoked_widget(name, layout, style, location, data=None,
 
 def add_drive_widget(drive_type, drive_boxes, drive_widgets, drives_out,
                      tstop_widget, location,
-                     prespecified_drive_name=None, prespecified_drive_data=None,
-                     prespecified_weights_ampa=None, 
+                     prespecified_drive_name=None,
+                     prespecified_drive_data=None,
+                     prespecified_weights_ampa=None,
                      prespecified_weights_nmda=None,
                      prespecified_delays=None,
                      render=True, expand_last_drive=True, event_seed=14):
@@ -449,7 +450,7 @@ def load_drives(variables, params, log_out, drives_out, drive_widgets,
             should_render = idx == (len(drive_names) - 1)
 
             add_drive_widget(
-                specs['type'].capitalize(), drive_boxes, 
+                specs['type'].capitalize(), drive_boxes,
                 drive_widgets, drives_out, tstop, specs['location'],
                 prespecified_drive_name=drive_name,
                 prespecified_drive_data=specs['dynamics'],
@@ -797,6 +798,8 @@ def run_hnn_gui():
     plot_outputs_list = list()
     plot_dropdowns_list = list()
 
+    # ##### Callbacks #######
+
     def _run_button_clicked(b):
         return run_button_clicked(log_out, drive_widgets, variables, tstep,
                                   tstop, ntrials, backend_selection, mpi_cmd,
@@ -817,6 +820,23 @@ def run_hnn_gui():
         while len(drive_widgets) > 0:
             drive_widgets.pop()
             drive_boxes.pop()
+
+    def handle_viz_layout_change(layout_option):
+        return initialize_viz_window(viz_window, variables,
+                                     plot_outputs_list, plot_dropdowns_list,
+                                     viz_width, viz_height,
+                                     layout_option=layout_option.new)
+
+    def _handle_backend_change(backend_type):
+        return handle_backend_change(backend_type.new, backend_config, mpi_cmd,
+                                     joblib_cores)
+
+    def _add_drive_button_clicked(b):
+        return add_drive_widget(drive_type_selection.value, drive_boxes,
+                                drive_widgets, drives_out, tstop,
+                                location_selection.value)
+
+    # ##### Layout #######
 
     # Output windows
     drives_out = Output()  # window to add new drives
@@ -843,7 +863,7 @@ def run_hnn_gui():
     tstop = FloatText(value=170, description='tstop (ms):', disabled=False)
     tstep = FloatText(value=0.025, description='tstep (ms):', disabled=False)
     ntrials = IntText(value=1, description='Trials:', disabled=False)
-    
+
     # visualization layout
     viz_layout_selection = Dropdown(
         options=[('Horizontal', 'L-R'), ('Vertical', 'U-D')],
@@ -853,12 +873,6 @@ def run_hnn_gui():
                           plot_dropdowns_list, viz_width,
                           viz_height, layout_option=viz_layout_selection.value,
                           init=True)
-
-    def handle_viz_layout_change(layout_option):
-        return initialize_viz_window(viz_window, variables,
-                                     plot_outputs_list, plot_dropdowns_list,
-                                     viz_width, viz_height,
-                                     layout_option=layout_option.new)
 
     viz_layout_selection.observe(handle_viz_layout_change, 'value')
 
@@ -875,10 +889,6 @@ def run_hnn_gui():
                                   description='Cores:', disabled=False)
 
     backend_config = Output()
-
-    def _handle_backend_change(backend_type):
-        return handle_backend_change(backend_type.new, backend_config, mpi_cmd,
-                                     joblib_cores)
 
     handle_backend_change(backend_selection.value, backend_config, mpi_cmd,
                           joblib_cores)
@@ -934,11 +944,6 @@ def run_hnn_gui():
 
     add_drive_button = create_expanded_button('Add drive', 'primary',
                                               height='30px')
-
-    def _add_drive_button_clicked(b):
-        return add_drive_widget(drive_type_selection.value, drive_boxes,
-                                drive_widgets, drives_out, tstop,
-                                location_selection.value)
 
     add_drive_button.on_click(_add_drive_button_clicked)
     drive_selections = VBox(

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -499,25 +499,24 @@ def load_drives(variables, params, log_out, drives_out, drive_widgets,
         for idx, drive_name in enumerate(drive_names):  # order matters
             specs = drive_specs[drive_name]
             should_render = idx == (len(drive_names) - 1)
-            try:
-                add_drive_widget(
-                    specs['type'].capitalize(),
-                    drive_boxes,
-                    drive_widgets,
-                    drives_out,
-                    tstop,
-                    specs['location'],
-                    prespecified_drive_name=drive_name,
-                    prespecified_drive_data=specs['dynamics'],
-                    prespecified_weights_ampa=specs['weights_ampa'],
-                    prespecified_weights_nmda=specs['weights_nmda'],
-                    prespecified_delays=specs['synaptic_delays'],
-                    render=should_render,
-                    expand_last_drive=False,
-                    event_seed=specs['event_seed'],
-                )
-            except Exception as e:
-                logging.debug(f"load drive from params err: {e}")
+
+            add_drive_widget(
+                specs['type'].capitalize(),
+                drive_boxes,
+                drive_widgets,
+                drives_out,
+                tstop,
+                specs['location'],
+                prespecified_drive_name=drive_name,
+                prespecified_drive_data=specs['dynamics'],
+                prespecified_weights_ampa=specs['weights_ampa'],
+                prespecified_weights_nmda=specs['weights_nmda'],
+                prespecified_delays=specs['synaptic_delays'],
+                render=should_render,
+                expand_last_drive=False,
+                event_seed=specs['event_seed'],
+            )
+
 
 
 def on_upload_change(

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -139,17 +139,9 @@ def _get_cell_specific_widgets(
     return widgets_list, widgets_dict
 
 
-def _get_rhythmic_widget(
-    name,
-    tstop_widget,
-    layout,
-    style,
-    location,
-    data=None,
-    default_weights_ampa=None,
-    default_weights_nmda=None,
-    default_delays=None,
-):
+def _get_rhythmic_widget(name, tstop_widget, layout, style, location,
+                         data=None, default_weights_ampa=None,
+                         default_weights_nmda=None, default_delays=None):
     default_data = {
         'tstart': 0.,
         'tstart_std': 0.,
@@ -188,9 +180,7 @@ def _get_rhythmic_widget(
                        **kwargs)
 
     widgets_list, widgets_dict = _get_cell_specific_widgets(
-        layout,
-        style,
-        location,
+        layout, style, location,
         data={
             'weights_ampa': default_weights_ampa,
             'weights_nmda': default_weights_nmda,
@@ -215,17 +205,9 @@ def _get_rhythmic_widget(
     return drive, drive_box
 
 
-def _get_poisson_widget(
-    name,
-    tstop_widget,
-    layout,
-    style,
-    location,
-    data=None,
-    default_weights_ampa=None,
-    default_weights_nmda=None,
-    default_delays=None,
-):
+def _get_poisson_widget(name, tstop_widget, layout, style, location, data=None,
+                        default_weights_ampa=None, default_weights_nmda=None,
+                        default_delays=None):
     default_data = {
         'tstart': 0.0,
         'tstop': 0.0,
@@ -294,16 +276,9 @@ def _get_poisson_widget(
     return drive, drive_box
 
 
-def _get_evoked_widget(
-    name,
-    layout,
-    style,
-    location,
-    data=None,
-    default_weights_ampa=None,
-    default_weights_nmda=None,
-    default_delays=None,
-):
+def _get_evoked_widget(name, layout, style, location, data=None,
+                       default_weights_ampa=None, default_weights_nmda=None,
+                       default_delays=None):
     default_data = {
         'mu': 0,
         'sigma': 1,
@@ -353,20 +328,13 @@ def _get_evoked_widget(
     return drive, drive_box
 
 
-def add_drive_widget(drive_type,
-                     drive_boxes,
-                     drive_widgets,
-                     drives_out,
-                     tstop_widget,
-                     location,
-                     prespecified_drive_name=None,
-                     prespecified_drive_data=None,
-                     prespecified_weights_ampa=None,
+def add_drive_widget(drive_type, drive_boxes, drive_widgets, drives_out,
+                     tstop_widget, location,
+                     prespecified_drive_name=None, prespecified_drive_data=None,
+                     prespecified_weights_ampa=None, 
                      prespecified_weights_nmda=None,
                      prespecified_delays=None,
-                     render=True,
-                     expand_last_drive=True,
-                     event_seed=14):
+                     render=True, expand_last_drive=True, event_seed=14):
     """Add a widget for a new drive."""
     layout = Layout(width='270px', height='auto')
     style = {'description_width': '150px'}
@@ -417,13 +385,8 @@ def add_drive_widget(drive_type,
                 default_delays=prespecified_delays,
             )
 
-        if drive_type in [
-                'Evoked',
-                'Poisson',
-                'Rhythmic',
-                'Bursty',
-                'Gaussian',
-        ]:
+        if drive_type in ['Evoked', 'Poisson', 'Rhythmic', 'Bursty',
+                          'Gaussian']:
             drive_boxes.append(drive_box)
             drive_widgets.append(drive)
 
@@ -500,12 +463,8 @@ def load_drives(variables, params, log_out, drives_out, drive_widgets,
             should_render = idx == (len(drive_names) - 1)
 
             add_drive_widget(
-                specs['type'].capitalize(),
-                drive_boxes,
-                drive_widgets,
-                drives_out,
-                tstop,
-                specs['location'],
+                specs['type'].capitalize(), drive_boxes, 
+                drive_widgets, drives_out, tstop, specs['location'],
                 prespecified_drive_name=drive_name,
                 prespecified_drive_data=specs['dynamics'],
                 prespecified_weights_ampa=specs['weights_ampa'],
@@ -517,19 +476,8 @@ def load_drives(variables, params, log_out, drives_out, drive_widgets,
             )
 
 
-def on_upload_change(
-    change,
-    sliders,
-    params,
-    tstop,
-    tstep,
-    log_out,
-    variables,
-    # for adding drives
-    drive_boxes,
-    drive_widgets,
-    drives_out,
-):
+def on_upload_change(change, sliders, params, tstop, tstep, log_out, variables,
+                     drive_boxes, drive_widgets, drives_out):
     if len(change['owner'].value) == 0:
         return
 
@@ -677,14 +625,9 @@ def handle_backend_change(backend_type, backend_config, mpi_cmd, joblib_cores):
             display(joblib_cores)
 
 
-def init_left_right_viz_layout(plot_outputs,
-                               plot_dropdowns,
-                               window_height,
-                               variables,
-                               plot_options,
-                               previous_outputs,
-                               border='1px solid gray',
-                               init=False):
+def init_left_right_viz_layout(plot_outputs, plot_dropdowns, window_height,
+                               variables, plot_options, previous_outputs,
+                               border='1px solid gray', init=False):
     height_plot = window_height
     plot_outputs_L = Output(layout={'border': border, 'height': height_plot})
 
@@ -750,13 +693,9 @@ def init_left_right_viz_layout(plot_outputs,
     return grid
 
 
-def init_upper_down_viz_layout(plot_outputs,
-                               plot_dropdowns,
-                               window_height,
-                               variables,
-                               plot_options,
-                               previous_outputs,
-                               border='1px solid gray',
+def init_upper_down_viz_layout(plot_outputs, plot_dropdowns,
+                               window_height, variables, plot_options,
+                               previous_outputs, border='1px solid gray',
                                init=False):
     height_plot = window_height
     default_plot_types = [plot_options[0], plot_options[1]]
@@ -827,14 +766,9 @@ def init_upper_down_viz_layout(plot_outputs,
     return grid
 
 
-def initialize_viz_window(viz_window,
-                          variables,
-                          plot_outputs,
-                          plot_dropdowns,
-                          window_width,
-                          window_height,
-                          layout_option="L-R",
-                          init=False):
+def initialize_viz_window(viz_window, variables, plot_outputs,
+                          plot_dropdowns, window_width, window_height,
+                          layout_option="L-R", init=False):
     plot_options = [
         'current dipole', 'input histogram', 'spikes', 'PSD', 'spectogram',
         'network'
@@ -843,29 +777,21 @@ def initialize_viz_window(viz_window,
     previous_plot_outputs_values = []
     while len(plot_outputs) > 0:
         plot_outputs.pop()
-        # plot_dropdowns.pop()
         previous_plot_outputs_values.append(plot_dropdowns.pop().value)
 
     with viz_window:
         # Left-Rright configuration
         if layout_option == "L-R":
-            grid = init_left_right_viz_layout(plot_outputs,
-                                              plot_dropdowns,
-                                              window_height,
-                                              variables,
-                                              plot_options,
-                                              previous_plot_outputs_values,
-                                              init=init)
+            grid = init_left_right_viz_layout(
+                plot_outputs, plot_dropdowns, window_height, variables,
+                plot_options, previous_plot_outputs_values, init=init)
+
         # Upper-Down configuration
         elif layout_option == "U-D":
-            grid = init_upper_down_viz_layout(plot_outputs,
-                                              plot_dropdowns,
-                                              window_height,
-                                              variables,
-                                              plot_options,
-                                              previous_plot_outputs_values,
-                                              init=init)
-        # TODO: 2x2
+            grid = init_upper_down_viz_layout(
+                plot_outputs, plot_dropdowns, window_height,
+                variables, plot_options, previous_plot_outputs_values,
+                init=init)
 
         display(grid)
 
@@ -931,52 +857,38 @@ def run_hnn_gui():
     tstop = FloatText(value=170, description='tstop (ms):', disabled=False)
     tstep = FloatText(value=0.025, description='tstep (ms):', disabled=False)
     ntrials = IntText(value=1, description='Trials:', disabled=False)
-    # temporarily keep this
-
+    
+    # visualization layout
     viz_layout_selection = Dropdown(
         options=[('Horizontal', 'L-R'), ('Vertical', 'U-D')],
-        value='L-R',
-        description='Layout:',
-    )
+        value='L-R', description='Layout:')
     # initialize
-    initialize_viz_window(viz_window,
-                          variables,
-                          plot_outputs_list,
-                          plot_dropdowns_list,
-                          viz_width,
-                          viz_height,
-                          layout_option=viz_layout_selection.value,
+    initialize_viz_window(viz_window, variables, plot_outputs_list,
+                          plot_dropdowns_list, viz_width,
+                          viz_height, layout_option=viz_layout_selection.value,
                           init=True)
 
     def handle_viz_layout_change(layout_option):
-        return initialize_viz_window(
-            viz_window,
-            variables,
-            plot_outputs_list,
-            plot_dropdowns_list,
-            viz_width,
-            viz_height,
-            layout_option=layout_option.new,
-        )
+        return initialize_viz_window(viz_window, variables,
+                                     plot_outputs_list, plot_dropdowns_list,
+                                     viz_width, viz_height,
+                                     layout_option=layout_option.new)
 
     viz_layout_selection.observe(handle_viz_layout_change, 'value')
 
+    # select backends
     backend_selection = Dropdown(
         options=[('Joblib', 'Joblib'), ('MPI', 'MPI')],
         value='MPI' if os.getenv("USEMPI", '0') == '1' else 'Joblib',
         description='Backend:',
     )
 
-    mpi_cmd = Text(value='mpiexec',
-                   placeholder='Fill if applies',
-                   description='MPI cmd:',
-                   disabled=False)
+    mpi_cmd = Text(value='mpiexec', placeholder='Fill if applies',
+                   description='MPI cmd:', disabled=False)
 
-    joblib_cores = BoundedIntText(value=1,
-                                  min=1,
+    joblib_cores = BoundedIntText(value=1, min=1,
                                   max=multiprocessing.cpu_count(),
-                                  description='Cores:',
-                                  disabled=False)
+                                  description='Cores:', disabled=False)
 
     backend_config = Output()
 
@@ -988,13 +900,8 @@ def run_hnn_gui():
                           joblib_cores)
     backend_selection.observe(_handle_backend_change, 'value')
 
-    simulation_box = VBox([
-        tstop,
-        tstep,
-        ntrials,
-        backend_selection,
-        backend_config,
-    ])
+    simulation_box = VBox([tstop, tstep, ntrials, backend_selection,
+                           backend_config])
 
     # Sliders to change local-connectivity params
     sliders = [
@@ -1041,8 +948,7 @@ def run_hnn_gui():
                                       disabled=False,
                                       layout=layout)
 
-    add_drive_button = create_expanded_button('Add drive',
-                                              'primary',
+    add_drive_button = create_expanded_button('Add drive', 'primary',
                                               height='30px')
 
     def _add_drive_button_clicked(b):
@@ -1072,13 +978,10 @@ def run_hnn_gui():
     run_button = create_expanded_button('Run', 'success', height='30px')
 
     style = {'button_color': THEMECOLOR}
-    load_button = FileUpload(accept='.json,.param',
-                             multiple=False,
-                             style=style,
-                             description='Load network',
+    load_button = FileUpload(accept='.json,.param', multiple=False,
+                             style=style, description='Load network',
                              button_style='success')
-    delete_button = create_expanded_button('Delete drives',
-                                           'success',
+    delete_button = create_expanded_button('Delete drives', 'success',
                                            height='30px')
 
     load_button.observe(_on_upload_change)

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -88,7 +88,7 @@ def _get_cell_specific_widgets(layout, style, location, data=None):
     }
     if isinstance(data, dict):
         for k in default_data.keys():
-            if k in data:
+            if k in data and data[k] is not None:
                 default_data[k].update(data[k])
 
     kwargs = dict(layout=layout, style=style)

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1105,5 +1105,5 @@ def run_hnn_gui():
 
 def launch():
     from voila.app import main
-    notebook_path = op.join(op.dirname(__file__), '..', 'hnn_widget.ipynb')
+    notebook_path = op.join(op.dirname(__file__), 'hnn_widget.ipynb')
     main([notebook_path, *sys.argv[1:]])

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -16,7 +16,7 @@ from IPython.display import display
 from ipywidgets import (HTML, Accordion, AppLayout, BoundedFloatText,
                         BoundedIntText, Button, Dropdown, FileUpload,
                         FloatLogSlider, FloatText, GridspecLayout, HBox,
-                        IntText, Label, Layout, Output, RadioButtons, Tab,
+                        IntText, Layout, Output, RadioButtons, Tab,
                         Text, VBox, interactive_output)
 
 import hnn_core
@@ -25,7 +25,6 @@ from hnn_core import (JoblibBackend, MPIBackend, jones_2009_model, read_params,
 from hnn_core.params import (_extract_drive_specs_from_hnn_params, _read_json,
                              _read_legacy_params)
 from hnn_core.viz import plot_dipole
-
 
 THEMECOLOR = "#8A2BE2"
 
@@ -125,9 +124,15 @@ def _get_cell_specific_widgets(layout, style, location, data=None):
     return widgets_list, widgets_dict
 
 
-def _get_rhythmic_widget(name, tstop_widget, layout, style, location,
-                         data=None, default_weights_ampa=None,
-                         default_weights_nmda=None, default_delays=None):
+def _get_rhythmic_widget(name,
+                         tstop_widget,
+                         layout,
+                         style,
+                         location,
+                         data=None,
+                         default_weights_ampa=None,
+                         default_weights_nmda=None,
+                         default_delays=None):
     default_data = {
         'tstart': 0.,
         'tstart_std': 0.,
@@ -166,17 +171,18 @@ def _get_rhythmic_widget(name, tstop_widget, layout, style, location,
                        **kwargs)
 
     widgets_list, widgets_dict = _get_cell_specific_widgets(
-        layout, style, location,
+        layout,
+        style,
+        location,
         data={
             'weights_ampa': default_weights_ampa,
             'weights_nmda': default_weights_nmda,
             'delays': default_delays,
         },
     )
-    drive_box = VBox([
-        HTML(value=f"<p>Location: {location}</p>"), tstart, tstart_std, tstop,
-        burst_rate, burst_std, repeats, seedcore
-    ] + widgets_list)
+    drive_box = VBox(
+        [tstart, tstart_std, tstop, burst_rate, burst_std, repeats, seedcore] +
+        widgets_list)
     drive = dict(type='Rhythmic',
                  name=name,
                  tstart=tstart,
@@ -191,8 +197,14 @@ def _get_rhythmic_widget(name, tstop_widget, layout, style, location,
     return drive, drive_box
 
 
-def _get_poisson_widget(name, tstop_widget, layout, style, location, data=None,
-                        default_weights_ampa=None, default_weights_nmda=None,
+def _get_poisson_widget(name,
+                        tstop_widget,
+                        layout,
+                        style,
+                        location,
+                        data=None,
+                        default_weights_ampa=None,
+                        default_weights_nmda=None,
                         default_delays=None):
     default_data = {
         'tstart': 0.0,
@@ -246,9 +258,7 @@ def _get_poisson_widget(name, tstop_widget, layout, style, location, data=None,
     widgets_list.extend([HTML(value="<b>Rate constants</b>")] +
                         list(widgets_dict['rate_constant'].values()))
 
-    drive_box = VBox(
-        [HTML(value=f"<p>Location: {location}</p>"), tstart, tstop, seedcore] +
-        widgets_list)
+    drive_box = VBox([tstart, tstop, seedcore] + widgets_list)
     drive = dict(
         type='Poisson',
         name=name,
@@ -262,8 +272,13 @@ def _get_poisson_widget(name, tstop_widget, layout, style, location, data=None,
     return drive, drive_box
 
 
-def _get_evoked_widget(name, layout, style, location, data=None,
-                       default_weights_ampa=None, default_weights_nmda=None,
+def _get_evoked_widget(name,
+                       layout,
+                       style,
+                       location,
+                       data=None,
+                       default_weights_ampa=None,
+                       default_weights_nmda=None,
                        default_delays=None):
     default_data = {
         'mu': 0,
@@ -298,10 +313,7 @@ def _get_evoked_widget(name, layout, style, location, data=None,
         },
     )
 
-    drive_box = VBox([
-        HTML(value=f"<p>Location: {location}</p>"), mu, sigma, numspikes,
-        seedcore
-    ] + widgets_list)
+    drive_box = VBox([mu, sigma, numspikes, seedcore] + widgets_list)
     drive = dict(type='Evoked',
                  name=name,
                  mu=mu,
@@ -314,14 +326,20 @@ def _get_evoked_widget(name, layout, style, location, data=None,
     return drive, drive_box
 
 
-def add_drive_widget(drive_type, drive_boxes, drive_widgets, drives_out,
-                     tstop_widget, location,
+def add_drive_widget(drive_type,
+                     drive_boxes,
+                     drive_widgets,
+                     drives_out,
+                     tstop_widget,
+                     location,
                      prespecified_drive_name=None,
                      prespecified_drive_data=None,
                      prespecified_weights_ampa=None,
                      prespecified_weights_nmda=None,
                      prespecified_delays=None,
-                     render=True, expand_last_drive=True, event_seed=14):
+                     render=True,
+                     expand_last_drive=True,
+                     event_seed=14):
     """Add a widget for a new drive."""
     layout = Layout(width='270px', height='auto')
     style = {'description_width': '150px'}
@@ -372,8 +390,9 @@ def add_drive_widget(drive_type, drive_boxes, drive_widgets, drives_out,
                 default_delays=prespecified_delays,
             )
 
-        if drive_type in ['Evoked', 'Poisson', 'Rhythmic', 'Bursty',
-                          'Gaussian']:
+        if drive_type in [
+                'Evoked', 'Poisson', 'Rhythmic', 'Bursty', 'Gaussian'
+        ]:
             drive_boxes.append(drive_box)
             drive_widgets.append(drive)
 
@@ -384,7 +403,8 @@ def add_drive_widget(drive_type, drive_boxes, drive_widgets, drives_out,
                 1 if expand_last_drive else None,
             )
             for idx, drive in enumerate(drive_widgets):
-                accordion.set_title(idx, drive['name'])
+                accordion.set_title(idx,
+                                    f"{drive['name']} ({drive['location']})")
             display(accordion)
 
 
@@ -399,34 +419,51 @@ def update_plot_window(variables, _plot_out, plot_type):
 
     with _plot_out:
         if plot_type['new'] == 'spikes':
-            fig, ax = plt.subplots()
-            variables['net'].cell_response.plot_spikes_raster(ax=ax)
+            if variables['net'].cell_response:
+                fig, ax = plt.subplots()
+                variables['net'].cell_response.plot_spikes_raster(ax=ax)
+            else:
+                print("No cell response data")
 
         elif plot_type['new'] == 'current dipole':
-            fig, ax = plt.subplots()
-            # variables['dpls'][0].plot(ax=ax)
-            plot_dipole(variables['dpls'], ax=ax, average=True)
+            if variables['dpls'] is not None:
+                fig, ax = plt.subplots()
+                plot_dipole(variables['dpls'], ax=ax, average=True)
+            else:
+                print("No dipole data")
 
         elif plot_type['new'] == 'input histogram':
             # BUG: got error here, need a better way to handle exception
-            fig, ax = plt.subplots()
-            variables['net'].cell_response.plot_spikes_hist(ax=ax)
+            if variables['net'].cell_response:
+                fig, ax = plt.subplots()
+                variables['net'].cell_response.plot_spikes_hist(ax=ax)
+            else:
+                print("No cell response data")
 
         elif plot_type['new'] == 'PSD':
-            fig, ax = plt.subplots()
-            variables['dpls'][0].plot_psd(fmin=0, fmax=50, ax=ax)
+            if variables['dpls'] is not None:
+                fig, ax = plt.subplots()
+                variables['dpls'][0].plot_psd(fmin=0, fmax=50, ax=ax)
+            else:
+                print("No dipole data")
 
         elif plot_type['new'] == 'spectogram':
-            freqs = np.arange(10., 100., 1.)
-            n_cycles = freqs / 8.
-            fig, ax = plt.subplots()
-            variables['dpls'][0].plot_tfr_morlet(freqs,
-                                                 n_cycles=n_cycles,
-                                                 ax=ax)
+            if variables['dpls'] is not None:
+                freqs = np.arange(10., 100., 1.)
+                n_cycles = freqs / 8.
+                fig, ax = plt.subplots()
+                variables['dpls'][0].plot_tfr_morlet(freqs,
+                                                     n_cycles=n_cycles,
+                                                     ax=ax)
+            else:
+                print("No dipole data")
         elif plot_type['new'] == 'network':
-            fig = plt.figure()
-            ax = fig.add_subplot(111, projection='3d')
-            variables['net'].plot_cells(ax=ax)
+            if variables['net']:
+                fig = plt.figure()
+                ax = fig.add_subplot(111, projection='3d')
+                variables['net'].plot_cells(ax=ax)
+            else:
+                print("No network data")
 
 
 def load_drives(variables, params, log_out, drives_out, drive_widgets,
@@ -450,8 +487,12 @@ def load_drives(variables, params, log_out, drives_out, drive_widgets,
             should_render = idx == (len(drive_names) - 1)
 
             add_drive_widget(
-                specs['type'].capitalize(), drive_boxes,
-                drive_widgets, drives_out, tstop, specs['location'],
+                specs['type'].capitalize(),
+                drive_boxes,
+                drive_widgets,
+                drives_out,
+                tstop,
+                specs['location'],
                 prespecified_drive_name=drive_name,
                 prespecified_drive_data=specs['dynamics'],
                 prespecified_weights_ampa=specs['weights_ampa'],
@@ -581,13 +622,17 @@ def run_button_clicked(log_out, drive_widgets, variables, tstep, tstop,
             variables['backend'] = JoblibBackend(n_jobs=joblib_cores.value)
             print(f"Using Joblib with {joblib_cores.value} core(s).")
         with variables['backend']:
-            simulation_status.value = "Running..."
+            simulation_status.value = """<div
+            style='background:orange;padding-left:10px;color:white;'>
+            Running...</div>"""
             variables['dpls'] = simulate_dipole(variables['net'],
                                                 tstop=tstop.value,
                                                 n_trials=ntrials.value)
 
             window_len, scaling_factor = 30, 3000
-            simulation_status.value = "Simulation finished"
+            simulation_status.value = """<div
+            style='background:green;padding-left:10px;color:white;'>
+            Simulation finished</div>"""
             for dpl in variables['dpls']:
                 dpl.smooth(window_len).scale(scaling_factor)
 
@@ -612,9 +657,14 @@ def handle_backend_change(backend_type, backend_config, mpi_cmd, joblib_cores):
             display(joblib_cores)
 
 
-def init_left_right_viz_layout(plot_outputs, plot_dropdowns, window_height,
-                               variables, plot_options, previous_outputs,
-                               border='1px solid gray', init=False):
+def init_left_right_viz_layout(plot_outputs,
+                               plot_dropdowns,
+                               window_height,
+                               variables,
+                               plot_options,
+                               previous_outputs,
+                               border='1px solid gray',
+                               init=False):
     height_plot = window_height
     plot_outputs_L = Output(layout={'border': border, 'height': height_plot})
 
@@ -680,9 +730,13 @@ def init_left_right_viz_layout(plot_outputs, plot_dropdowns, window_height,
     return grid
 
 
-def init_upper_down_viz_layout(plot_outputs, plot_dropdowns,
-                               window_height, variables, plot_options,
-                               previous_outputs, border='1px solid gray',
+def init_upper_down_viz_layout(plot_outputs,
+                               plot_dropdowns,
+                               window_height,
+                               variables,
+                               plot_options,
+                               previous_outputs,
+                               border='1px solid gray',
                                init=False):
     height_plot = window_height
     default_plot_types = [plot_options[0], plot_options[1]]
@@ -753,9 +807,14 @@ def init_upper_down_viz_layout(plot_outputs, plot_dropdowns,
     return grid
 
 
-def initialize_viz_window(viz_window, variables, plot_outputs,
-                          plot_dropdowns, window_width, window_height,
-                          layout_option="L-R", init=False):
+def initialize_viz_window(viz_window,
+                          variables,
+                          plot_outputs,
+                          plot_dropdowns,
+                          window_width,
+                          window_height,
+                          layout_option="L-R",
+                          init=False):
     plot_options = [
         'current dipole', 'input histogram', 'spikes', 'PSD', 'spectogram',
         'network'
@@ -769,16 +828,23 @@ def initialize_viz_window(viz_window, variables, plot_outputs,
     with viz_window:
         # Left-Rright configuration
         if layout_option == "L-R":
-            grid = init_left_right_viz_layout(
-                plot_outputs, plot_dropdowns, window_height, variables,
-                plot_options, previous_plot_outputs_values, init=init)
+            grid = init_left_right_viz_layout(plot_outputs,
+                                              plot_dropdowns,
+                                              window_height,
+                                              variables,
+                                              plot_options,
+                                              previous_plot_outputs_values,
+                                              init=init)
 
         # Upper-Down configuration
         elif layout_option == "U-D":
-            grid = init_upper_down_viz_layout(
-                plot_outputs, plot_dropdowns, window_height,
-                variables, plot_options, previous_plot_outputs_values,
-                init=init)
+            grid = init_upper_down_viz_layout(plot_outputs,
+                                              plot_dropdowns,
+                                              window_height,
+                                              variables,
+                                              plot_options,
+                                              previous_plot_outputs_values,
+                                              init=init)
 
         display(grid)
 
@@ -822,9 +888,12 @@ def run_hnn_gui():
             drive_boxes.pop()
 
     def handle_viz_layout_change(layout_option):
-        return initialize_viz_window(viz_window, variables,
-                                     plot_outputs_list, plot_dropdowns_list,
-                                     viz_width, viz_height,
+        return initialize_viz_window(viz_window,
+                                     variables,
+                                     plot_outputs_list,
+                                     plot_dropdowns_list,
+                                     viz_width,
+                                     viz_height,
                                      layout_option=layout_option.new)
 
     def _handle_backend_change(backend_type):
@@ -865,33 +934,43 @@ def run_hnn_gui():
     ntrials = IntText(value=1, description='Trials:', disabled=False)
 
     # visualization layout
-    viz_layout_selection = Dropdown(
-        options=[('Horizontal', 'L-R'), ('Vertical', 'U-D')],
-        value='L-R', description='Layout:')
+    viz_layout_selection = Dropdown(options=[('Horizontal', 'L-R'),
+                                             ('Vertical', 'U-D')],
+                                    value='L-R',
+                                    description='Layout:')
     # initialize
-    initialize_viz_window(viz_window, variables, plot_outputs_list,
-                          plot_dropdowns_list, viz_width,
-                          viz_height, layout_option=viz_layout_selection.value,
+    initialize_viz_window(viz_window,
+                          variables,
+                          plot_outputs_list,
+                          plot_dropdowns_list,
+                          viz_width,
+                          viz_height,
+                          layout_option=viz_layout_selection.value,
                           init=True)
 
     # select backends
-    backend_selection = Dropdown(
-        options=[('Joblib', 'Joblib'), ('MPI', 'MPI')], value='Joblib',
-        description='Backend:')
+    backend_selection = Dropdown(options=[('Joblib', 'Joblib'),
+                                          ('MPI', 'MPI')],
+                                 value='Joblib',
+                                 description='Backend:')
 
-    mpi_cmd = Text(value='mpiexec', placeholder='Fill if applies',
-                   description='MPI cmd:', disabled=False)
+    mpi_cmd = Text(value='mpiexec',
+                   placeholder='Fill if applies',
+                   description='MPI cmd:',
+                   disabled=False)
 
-    joblib_cores = BoundedIntText(value=1, min=1,
+    joblib_cores = BoundedIntText(value=1,
+                                  min=1,
                                   max=multiprocessing.cpu_count(),
-                                  description='Cores:', disabled=False)
+                                  description='Cores:',
+                                  disabled=False)
 
     backend_config = Output()
     handle_backend_change(backend_selection.value, backend_config, mpi_cmd,
                           joblib_cores)
 
-    simulation_box = VBox([tstop, tstep, ntrials, backend_selection,
-                           backend_config])
+    simulation_box = VBox(
+        [tstop, tstep, ntrials, backend_selection, backend_config])
 
     # Sliders to change local-connectivity params
     sliders = [
@@ -923,7 +1002,7 @@ def run_hnn_gui():
         cell_connectivity.set_title(idx, title)
 
     # Dropdown for different drives
-    layout = Layout(width='200px', height='100px')
+    layout = Layout(width='200px')
 
     drive_type_selection = RadioButtons(
         options=['Evoked', 'Poisson', 'Rhythmic'],
@@ -938,11 +1017,12 @@ def run_hnn_gui():
                                       disabled=False,
                                       layout=layout)
 
-    add_drive_button = create_expanded_button('Add drive', 'primary',
+    add_drive_button = create_expanded_button('Add drive',
+                                              'primary',
                                               height='30px')
 
     drive_selections = VBox(
-        [HBox([drive_type_selection, location_selection]), add_drive_button])
+        [drive_type_selection, location_selection, add_drive_button])
 
     # XXX: should be simpler to use Stacked class starting
     # from IPywidgets > 8.0
@@ -956,16 +1036,21 @@ def run_hnn_gui():
         left_tab.set_title(idx, title)
 
     # Running status
-    simulation_status = Label(value="Not running")
+    simulation_status = HTML(value="""<div
+        style='background:gray;padding-left:10px;color:white;'>
+         Not running</div>""")
 
     # Run, delete drives and load button
     run_button = create_expanded_button('Run', 'success', height='30px')
 
     style = {'button_color': THEMECOLOR}
-    load_button = FileUpload(accept='.json,.param', multiple=False,
-                             style=style, description='Load network',
+    load_button = FileUpload(accept='.json,.param',
+                             multiple=False,
+                             style=style,
+                             description='Load network',
                              button_style='success')
-    delete_drive_button = create_expanded_button('Delete drives', 'success',
+    delete_drive_button = create_expanded_button('Delete drives',
+                                                 'success',
                                                  height='30px')
 
     left_width = '380px'

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -26,15 +26,6 @@ from hnn_core.params import (_extract_drive_specs_from_hnn_params, _read_json,
                              _read_legacy_params)
 from hnn_core.viz import plot_dipole
 
-log_file = os.getenv("HNNGUI_LOGFILE", None)
-debug_gui = os.getenv("DEBUG_HNNGUI", "0")
-if debug_gui == '1' and log_file is not None:
-    logging.basicConfig(filename=log_file,
-                        filemode='a',
-                        level=logging.DEBUG,
-                        format='%(name)s - %(levelname)s - %(message)s')
-else:
-    logging.basicConfig(level=logging.ERROR)
 
 THEMECOLOR = "#8A2BE2"
 
@@ -74,12 +65,7 @@ def _get_sliders(params, param_keys):
     return sliders
 
 
-def _get_cell_specific_widgets(
-    layout,
-    style,
-    location,
-    data=None,
-):
+def _get_cell_specific_widgets(layout, style, location, data=None):
     default_data = {
         'weights_ampa': {
             'L5_pyramidal': 0.,
@@ -878,10 +864,8 @@ def run_hnn_gui():
 
     # select backends
     backend_selection = Dropdown(
-        options=[('Joblib', 'Joblib'), ('MPI', 'MPI')],
-        value='MPI' if os.getenv("USEMPI", '0') == '1' else 'Joblib',
-        description='Backend:',
-    )
+        options=[('Joblib', 'Joblib'), ('MPI', 'MPI')], value='Joblib',
+        description='Backend:')
 
     mpi_cmd = Text(value='mpiexec', placeholder='Fill if applies',
                    description='MPI cmd:', disabled=False)

--- a/hnn_core/gui/hnn_widget.ipynb
+++ b/hnn_core/gui/hnn_widget.ipynb
@@ -31,7 +31,7 @@
     }
    ],
    "source": [
-    "from hnn_core.gui import run_hnn_gui\n",
+    "from hnn_core.gui.gui import run_hnn_gui\n",
     "from IPython.display import display\n",
     "\n",
     "display(run_hnn_gui())"

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1,6 +1,7 @@
 # Authors: Huzi Cheng <hzcheng15@icloud.com>
-from hnn_core.gui import run_hnn_gui
 import os
+
+from hnn_core.gui import run_hnn_gui
 
 
 def test_run_gui():

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1,6 +1,4 @@
 # Authors: Huzi Cheng <hzcheng15@icloud.com>
-import os
-
 from hnn_core.gui.gui import run_hnn_gui
 
 

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1,0 +1,10 @@
+# Authors: Huzi Cheng <hzcheng15@icloud.com>
+from hnn_core.gui import run_hnn_gui
+import os
+
+
+def test_run_gui():
+    """Test if main gui function gives proper ipywidget"""
+    os.environ["DEBUG_HNNGUI"] = "0"
+    gui = run_hnn_gui()
+    assert gui is not None

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -6,6 +6,5 @@ from hnn_core.gui.gui import run_hnn_gui
 
 def test_run_gui():
     """Test if main gui function gives proper ipywidget"""
-    os.environ["DEBUG_HNNGUI"] = "0"
     gui = run_hnn_gui()
     assert gui is not None

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1,7 +1,7 @@
 # Authors: Huzi Cheng <hzcheng15@icloud.com>
 import os
 
-from hnn_core.gui import run_hnn_gui
+from hnn_core.gui.gui import run_hnn_gui
 
 
 def test_run_gui():

--- a/hnn_widget.ipynb
+++ b/hnn_widget.ipynb
@@ -8,12 +8,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0420f75f7a5a4ae3a2305cf9a38e24e8",
+       "model_id": "92fe4b4b9a914188a6c193ba5b659cb7",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "AppLayout(children=(Button(button_style='success', description='Human Neocortical Neurosolver', layout=Layout(…"
+       "AppLayout(children=(Button(button_style='success', description='HUMAN NEOCORTICAL NEUROSOLVER', layout=Layout(…"
       ]
      },
      "metadata": {},
@@ -45,7 +45,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/hnn_widget.ipynb
+++ b/hnn_widget.ipynb
@@ -8,7 +8,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "92fe4b4b9a914188a6c193ba5b659cb7",
+       "model_id": "6dd8f3c03c664417be1d770ac25aa76a",
        "version_major": 2,
        "version_minor": 0
       },

--- a/hnn_widget.ipynb
+++ b/hnn_widget.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [

--- a/setup.py
+++ b/setup.py
@@ -115,5 +115,5 @@ if __name__ == "__main__":
               'mod/x86_64/*',
               'mod/x86_64/.lib/*']},
           cmdclass={'build_py': build_py_mod, 'build_mod': BuildMod},
-          entry_points={'console_scripts': ['hnn-gui=hnn_core.gui:launch']}
+          entry_points={'console_scripts': ['hnn-gui=hnn_core.gui.gui:launch']}
           )

--- a/setup.py
+++ b/setup.py
@@ -114,5 +114,6 @@ if __name__ == "__main__":
               'mod/*',
               'mod/x86_64/*',
               'mod/x86_64/.lib/*']},
-          cmdclass={'build_py': build_py_mod, 'build_mod': BuildMod}
+          cmdclass={'build_py': build_py_mod, 'build_mod': BuildMod},
+          entry_points={'console_scripts': ['hnn-gui=hnn_core.gui:launch']}
           )

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,9 @@ if __name__ == "__main__":
               'matplotlib',
               'scipy'
           ],
+          extra_requires={
+              'gui': ['ipywidgets', 'voila']
+          },
           packages=find_packages(),
           package_data={'hnn_core': [
               'param/*.json',

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
               'matplotlib',
               'scipy'
           ],
-          extra_requires={
+          extras_require={
               'gui': ['ipywidgets', 'voila']
           },
           packages=find_packages(),


### PR DESCRIPTION
Here is a demo of the GUI with ipywidgets. 

[Try on Mybinder!!!](https://mybinder.org/v2/gh/jasmainak/hnn-core/hnn_gui?urlpath=voila%2Frender%2Fhnn_widget.ipynb)

Some advantages of this approach:
- Easier to maintain. We can probably get 95% of the functionality with 1000 lines of clean code as opposed to maintaining [8000 lines](http://line-count.herokuapp.com/jonescompneurolab/hnn) of messy code
- Easy to install/deploy in classroom environment
- You can easily add new features (e.g., Nick's work related to connectivity). 
- Ability to spin up HNN from the mobile and host a demo on Brown website using JupyterHub :-)
- Potential to integrate with MNE source localization ['notebook' backend](https://github.com/mne-tools/mne-python/blob/4a0ff5ca675f2f97838c7941a015c6ef8e59f12e/mne/viz/backends/_notebook.py)

To run this example, you'll need `ipywidgets` and `voila`. First make sure you have the latest version of `jupyter`

```sh
$ conda install jupyter
```

Then install the dependencies:

```sh
$ pip install ipywidgets voila
```

Finally do:

```sh
$ voila hnn_widget.ipynb
```

`voila` is not strictly necessary. You can also do:

```sh
$ jupyter-notebook hnn_widget.ipynb
```

and run the first cell.

You should see:

|       current dipole                     |        spikes              |
|-------------------------|--------------------|
|![image](https://user-images.githubusercontent.com/15852194/115123479-385fb900-9f8b-11eb-8b85-3e6d2fa2f4e5.png)  |![image](https://user-images.githubusercontent.com/15852194/115123685-2df1ef00-9f8c-11eb-8f3b-663486466193.png)|

PS: If we want interactive plots, we could potentially leverage [ipympl](https://github.com/matplotlib/ipympl) but I would say, let's start with something simple

### HNN-core examples tested

- [x] Evoked example
- [x] Rhythmic (alpha) example
- [x] Gamma example

### TODO / Wishlist 

- [x] [Demo on binder](https://voila.readthedocs.io/en/stable/deploy.html#deployment-on-binder)
- [x] Tab for simulation parameters (tstop etc)
- [x] Bound tstop of drives by tstop of simulation
- [x] Run button twice
- [x] Connectivity sliders should update the connectivity
- [x] Make it work also for .param file
- [x] Update readme
- [x] Updating slider doesn't update connectivity? *Fixed*
- [ ] Ability to overlay results from previous simulation
- [x] Don't instantiate `Network` until `run` button is pressed?
- [x] Run multiple trials
- [x] Add drive using radio button + "Add" button instead of dropdown
- [ ] Implement widgets for optimization + LFP/CSD (+ connectivity?)
- [x] Distal should not show L5 Basket
- [x] Button to delete drives
- [ ] Cell properties tab
- [ ] Add tests
- [ ] Stop button
- [ ] whats new
- [ ] separate callbacks from layout
- [x] GUI Scripts 