### PR TITLE
Fix dipole and network (spiking) class write methods

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -19,7 +19,10 @@ Simulation (:py:mod:`hnn_core`):
    L5Basket
    ExtFeed
    simulate_dipole
+   read_dipole
    Network
+   Spikes
+   read_spikes
 
 .. currentmodule:: hnn_core.params
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -19,10 +19,8 @@ Simulation (:py:mod:`hnn_core`):
    L5Basket
    ExtFeed
    simulate_dipole
-   read_dipole
    Network
    Spikes
-   read_spikes
 
 .. currentmodule:: hnn_core.params
 
@@ -31,3 +29,13 @@ Simulation (:py:mod:`hnn_core`):
 
    Params
    read_params
+
+Inputs and Outputs (:py:mod:`hnn_core`):
+
+.. currentmodule:: hnn_core
+
+.. autosummary::
+   :toctree: generated/
+
+   read_dipole
+   read_spikes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,7 +35,7 @@ API
 
 - Make a context manager for Network class, by `Mainak Jas`_ and `Blake Caldwell`_ in `#86 <https://github.com/jasmainak/hnn-core/pull/86>`_
 
-- Add read and write methods to Dipole and Network classes, by `Ryan Thorpe`_ in `#96 <https://github.com/jonescompneurolab/hnn-core/pull/96>`_
+- Create Spikes class, add write methods and read functions for Spikes and Dipole classes, by `Ryan Thorpe`_ in `#96 <https://github.com/jonescompneurolab/hnn-core/pull/96>`_
 
 .. _Mainak Jas: http://jasmainak.github.io/
 .. _Blake Caldwell: https://github.com/blakecaldwell

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,8 @@ API
 
 - Make a context manager for Network class, by `Mainak Jas`_ and `Blake Caldwell`_ in `#86 <https://github.com/jasmainak/hnn-core/pull/86>`_
 
+- Add read and write methods to Dipole and Network classes, by `Ryan Thorpe`_ in `#96 <https://github.com/jonescompneurolab/hnn-core/pull/96>`_
+
 .. _Mainak Jas: http://jasmainak.github.io/
 .. _Blake Caldwell: https://github.com/blakecaldwell
 .. _Ryan Thorpe: https://github.com/rythorpe

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -16,7 +16,7 @@ import os.path as op
 # Let us import hnn_core
 
 import hnn_core
-from hnn_core import simulate_dipole, read_params, Network
+from hnn_core import simulate_dipole, read_params, Network, read_spikes
 
 hnn_core_root = op.join(op.dirname(hnn_core.__file__), '..')
 
@@ -42,12 +42,18 @@ dpls = simulate_dipole(net, n_jobs=1, n_trials=2)
 import matplotlib.pyplot as plt
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 for dpl in dpls:
-    dpl.plot(ax=axes[0], layer='agg')
+    dpl.plot(ax=axes[0], layer='agg', show=False)
 net.plot_input(ax=axes[1])
 
 ###############################################################################
-# Finally, we can also plot the spikes.
-net.plot_spikes()
+# Also, we can plot the spikes and write them to txt files.
+# Note that we can use formatting syntax to specify the filename pattern
+# with which each trial will be written. To read spikes back in, we can use
+# wildcard expressions.
+net.spikes.plot()
+net.spikes.write('spk_%d.txt')
+spikes = read_spikes('spk_*.txt')
+spikes.plot()
 
 ###############################################################################
 # Now, let us try to make the exogenous driving inputs to the cells

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -51,6 +51,7 @@ net.plot_input(ax=axes[1])
 # Note that we can use formatting syntax to specify the filename pattern
 # with which each trial will be written. To read spikes back in, we can use
 # wildcard expressions.
+net.spikes.plot()
 with tempfile.TemporaryDirectory() as tmp_dir_name:
     print(tmp_dir_name)
     net.spikes.write(op.join(tmp_dir_name, 'spk_%d.txt'))

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -11,6 +11,7 @@ waveforms using HNN-core.
 #          Sam Neymotin <samnemo@gmail.com>
 
 import os.path as op
+import tempfile
 
 ###############################################################################
 # Let us import hnn_core
@@ -50,8 +51,10 @@ net.plot_input(ax=axes[1])
 # Note that we can use formatting syntax to specify the filename pattern
 # with which each trial will be written. To read spikes back in, we can use
 # wildcard expressions.
-net.spikes.write('spk_%d.txt')
-spikes = read_spikes('spk_*.txt')
+with tempfile.TemporaryDirectory() as tmp_dir_name:
+    print(tmp_dir_name)
+    net.spikes.write(op.join(tmp_dir_name, 'spk_%d.txt'))
+    spikes = read_spikes(op.join(tmp_dir_name, 'spk_*.txt'))
 spikes.plot()
 
 ###############################################################################

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -50,7 +50,6 @@ net.plot_input(ax=axes[1])
 # Note that we can use formatting syntax to specify the filename pattern
 # with which each trial will be written. To read spikes back in, we can use
 # wildcard expressions.
-net.spikes.plot()
 net.spikes.write('spk_%d.txt')
 spikes = read_spikes('spk_*.txt')
 spikes.plot()

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -81,6 +81,6 @@ dpl = simulate_dipole(net)
 
 import matplotlib.pyplot as plt
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
-dpl[0].plot(ax=axes[0])
+dpl[0].plot(ax=axes[0], show=False)
 net.plot_input(ax=axes[1])
-net.plot_spikes()
+net.spikes.plot()

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -2,7 +2,7 @@ from .utils import load_custom_mechanisms
 
 load_custom_mechanisms()
 
-from .dipole import simulate_dipole
+from .dipole import simulate_dipole, import_dipole
 from .feed import ExtFeed
 from .params import Params, read_params
 from .network import Network

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -2,7 +2,7 @@ from .utils import load_custom_mechanisms
 
 load_custom_mechanisms()
 
-from .dipole import simulate_dipole, import_dipole
+from .dipole import simulate_dipole, read_dipole
 from .feed import ExtFeed
 from .params import Params, read_params
 from .network import Network

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -5,6 +5,6 @@ load_custom_mechanisms()
 from .dipole import simulate_dipole, read_dipole
 from .feed import ExtFeed
 from .params import Params, read_params
-from .network import Network
+from .network import Network, Spikes, read_spikes
 from .pyramidal import L2Pyr, L5Pyr
 from .basket import L2Basket, L5Basket

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -134,6 +134,26 @@ def simulate_dipole(net, n_trials=1, n_jobs=1):
     return dpl
 
 
+def import_dipole(fname, units='nAm'):
+    """Read dipole values from a file and create a Dipole instance.
+
+    Parameters
+    ----------
+    fname : str
+        Full path to the input file (.txt)
+
+    Returns
+    -------
+    dpl : Dipole
+        The instance of Dipole class
+    """
+    dpl_data = np.loadtxt(fname, dtype=float)
+    dpl = Dipole(dpl_data[:, 0], dpl_data[:, 1:4])
+    if units == 'nAm':
+        dpl.units = units
+    return dpl
+
+
 class Dipole(object):
     """Dipole class.
 
@@ -277,7 +297,7 @@ class Dipole(object):
         Outputs
         -------
         txt file at fname where rows correspond to samples
-            and columns, delimited by \\t, correspond to 
+            and columns, delimited by \\t, correspond to
             1) time (s),
             2) aggregate current dipole (scaled nAm),
             3) L2/3 current dipole (scaled nAm), and

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -276,10 +276,12 @@ class Dipole(object):
 
         Outputs
         -------
-        txt file at fname where rows correspond to samples and columns,
-            delimited by \\t, correspond to 1) time (s), 2) aggregate current
-            dipole (scaled nAm), 3) L2/3 current dipole (scaled nAm), and 4) L5
-            current dipole (scaled nAm)
+        txt file at fname where rows correspond to samples
+            and columns, delimited by \\t, correspond to 
+            1) time (s),
+            2) aggregate current dipole (scaled nAm),
+            3) L2/3 current dipole (scaled nAm), and
+            4) L5 current dipole (scaled nAm)
         """
         X = np.r_[[self.t, self.dpl['agg'], self.dpl['L2'], self.dpl['L5']]].T
         np.savetxt(fname, X, fmt=['%3.3f', '%5.4f', '%5.4f', '%5.4f'],

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -273,6 +273,13 @@ class Dipole(object):
         ----------
         fname : str
             Full path to the output file (.txt)
+
+        Outputs
+        -------
+        txt file at fname where rows correspond to samples and columns,
+            delimited by \\t, correspond to 1) time (s), 2) aggregate current
+            dipole (scaled nAm), 3) L2/3 current dipole (scaled nAm), and 4) L5
+            current dipole (scaled nAm)
         """
         X = np.r_[[self.t, self.dpl['agg'], self.dpl['L2'], self.dpl['L5']]].T
         np.savetxt(fname, X, fmt=['%3.3f', '%5.4f', '%5.4f', '%5.4f'],

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -275,5 +275,5 @@ class Dipole(object):
             Full path to the output file (.txt)
         """
         X = np.r_[[self.t, self.dpl['agg'], self.dpl['L2'], self.dpl['L5']]].T
-        np.savetxt('dpl2.txt', X, fmt=['%3.3f', '%5.4f', '%5.4f', '%5.4f'],
+        np.savetxt(fname, X, fmt=['%3.3f', '%5.4f', '%5.4f', '%5.4f'],
                    delimiter='\t')

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -105,7 +105,7 @@ def _simulate_single_trial(net):
         dpl.convert_fAm_to_nAm()
         dpl.scale(net.params['dipole_scalefctr'])
         dpl.smooth(net.params['dipole_smooth_win'] / h.dt)
-    return dpl, net.spikes.times.to_python(), net.spikes.gids.to_python()
+    return dpl, net.spikes._times.to_python(), net.spikes._gids.to_python()
 
 
 def simulate_dipole(net, n_trials=1, n_jobs=1):
@@ -129,8 +129,8 @@ def simulate_dipole(net, n_trials=1, n_jobs=1):
     parallel, myfunc = _parallel_func(_clone_and_simulate, n_jobs=n_jobs)
     out = parallel(myfunc(net.params, idx) for idx in range(n_trials))
     dpl, spiketimes, spikegids = zip(*out)
-    net.spikes.times = spiketimes
-    net.spikes.gids = spikegids
+    net.spikes._times = list(spiketimes)
+    net.spikes._gids = list(spikegids)
     net.spikes.update_types(net.gid_dict)
     return dpl
 

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -128,9 +128,9 @@ def simulate_dipole(net, n_trials=1, n_jobs=1):
     """
     parallel, myfunc = _parallel_func(_clone_and_simulate, n_jobs=n_jobs)
     out = parallel(myfunc(net.params, idx) for idx in range(n_trials))
-    dpl, spiketimes, spikegids = zip(*out)
-    net.spikes._times = list(spiketimes)
-    net.spikes._gids = list(spikegids)
+    dpl, spike_times, spike_gids = zip(*out)
+    net.spikes._times = list(spike_times)
+    net.spikes._gids = list(spike_gids)
     net.spikes.update_types(net.gid_dict)
     return dpl
 
@@ -297,8 +297,8 @@ class Dipole(object):
 
         Outputs
         -------
-        txt file at fname where rows correspond to samples
-            and columns, delimited by \\t, correspond to
+        A tab separatd txt file where rows correspond
+            to samples and columns correspond to
             1) time (s),
             2) aggregate current dipole (scaled nAm),
             3) L2/3 current dipole (scaled nAm), and

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -105,7 +105,7 @@ def _simulate_single_trial(net):
         dpl.convert_fAm_to_nAm()
         dpl.scale(net.params['dipole_scalefctr'])
         dpl.smooth(net.params['dipole_smooth_win'] / h.dt)
-    return dpl, net.spiketimes.to_python(), net.spikegids.to_python()
+    return dpl, net.spikes.times.to_python(), net.spikes.gids.to_python()
 
 
 def simulate_dipole(net, n_trials=1, n_jobs=1):
@@ -129,8 +129,9 @@ def simulate_dipole(net, n_trials=1, n_jobs=1):
     parallel, myfunc = _parallel_func(_clone_and_simulate, n_jobs=n_jobs)
     out = parallel(myfunc(net.params, idx) for idx in range(n_trials))
     dpl, spiketimes, spikegids = zip(*out)
-    net.spiketimes = spiketimes
-    net.spikegids = spikegids
+    net.spikes.times = spiketimes
+    net.spikes.gids = spikegids
+    net.spikes.update_types(net.gid_dict)
     return dpl
 
 

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -134,7 +134,7 @@ def simulate_dipole(net, n_trials=1, n_jobs=1):
     return dpl
 
 
-def import_dipole(fname, units='nAm'):
+def read_dipole(fname, units='nAm'):
     """Read dipole values from a file and create a Dipole instance.
 
     Parameters

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -558,6 +558,12 @@ class Network(object):
         trial_idx : list of int
             Indices of selected trials. If None,
             all trials are selected.
+
+        Outputs
+        -------
+        txt file at fname where rows correspond to spikes and columns, delimited
+            by '\\t', correspond to 1) spike time (s), 2) spike gid, and 3) gid
+            type
         """
         if trial_idx is None:
             trial_idx = range(len(self.spiketimes))

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -556,7 +556,7 @@ class Network(object):
         fname : str
             Full path to the output file (.txt)
         trial_idx : list of int
-            Indices of selected trials. If 'all',
+            Indices of selected trials. If None,
             all trials are selected.
         """
         if trial_idx==None:
@@ -573,6 +573,6 @@ class Network(object):
             gidtypes[np.in1d(spikegids,gid_range)] = spike_type
 
         with open(fname,'w') as f:
-            for i in range(len(spiketimes)):
-                f.write('{:.3f}\t{}\t{}\n'.format(spiketimes[i],
-                    int(spikegids[i]),gidtypes[i]))
+            for spk_idx in range(len(spiketimes)):
+                f.write('{:.3f}\t{}\t{}\n'.format(spiketimes[spk_idx],
+                    int(spikegids[spk_idx]),gidtypes[spk_idx]))

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -547,3 +547,30 @@ class Network(object):
         if show:
             plt.show()
         return ax.get_figure()
+
+    def write_spikes(self, fname, trial_idx='all'):
+        """Write spike times to a file.
+
+        Parameters
+        ----------
+        fname : str
+            Full path to the output file (.txt)
+        trial_idx : list of int
+            Indices of selected trials. If 'all',
+            all trials are selected.
+        """
+        if trial_idx=='all':
+            spiketimes = sum(self.spiketimes,[])
+            spikegids = sum(self.spikegids,[])
+        else:
+            spiketimes = sum(self.spiketimes[trial_idx],[])
+            spikegids = sum(self.spikegids[trial_idx],[])
+
+        gidtypes = np.empty_like(spikegids,dtype='<U36')
+        for spike_type,gid_range in self.gid_dict.items():
+            gidtypes[np.in1d(spikegids,gid_range)] = spike_type
+
+        with open(fname,'w') as f:
+            for i in range(len(spiketimes)):
+                f.write('{:.3f}\t{}\t{}\n'.format(spiketimes[i],
+                    int(spikegids[i]),gidtypes[i]))

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -559,7 +559,7 @@ class Network(object):
             Indices of selected trials. If None,
             all trials are selected.
         """
-        if trial_idx==None:
+        if trial_idx is None:
             trial_idx = range(len(self.spiketimes))
 
         spiketimes = []

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -586,7 +586,7 @@ class Network(object):
         with open(fname, 'w') as f:
             for spk_idx in range(len(spiketimes)):
                 f.write('{:.3f}\t{}\t{}\n'.format(spiketimes[spk_idx],
-                    int(spikegids[spk_idx]), gidtypes[spk_idx]))
+                        int(spikegids[spk_idx]), gidtypes[spk_idx]))
 
     def read_spikes(self, fname, append_trial=True):
         """Read spike times from a file.
@@ -594,7 +594,7 @@ class Network(object):
         Parameters
         ----------
         fname : str
-            Full path to the output file (.txt)
+            Full path to the input file (.txt)
         append_trials : bool
             If True, append the contents of fname
             (i.e., as a trial) to the spike-related
@@ -602,7 +602,6 @@ class Network(object):
             all spikes of the Network instance will
             be overwritten.
         """
-
         spike_data = np.loadtxt(fname, dtype=str)
         spiketimes = spike_data[:, 0].astype(float)
         spikegids = spike_data[:, 1].astype(float)

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -610,6 +610,11 @@ class Spikes(object):
             self.gids = h.Vector()
         self.types = types
 
+    def __repr__(self):
+        class_name = self.__class__.__name__
+        num_trials = len(self.times)
+        return '<%s | %d trials>' % (class_name, num_trials)
+
     def __eq__(self, other):
         if not isinstance(other, Spikes):
             return NotImplemented

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -15,8 +15,7 @@ from .params import create_pext
 
 
 def read_spikes(fname, gid_dict=None):
-    """Read spiking activity from a collection of spike trial
-    files.
+    """Read spiking activity from a collection of spike trial files.
 
     Parameters
     ----------
@@ -591,12 +590,13 @@ class Spikes(object):
 
     Methods
     -------
-    update_types : update spike types in the current instance of
-        Spikes
-    plot : plot and return a matplotlib Figure object showing the
-        aggregate network spiking activity according to cell type
-    write : write spiking activity to a collection of spike trial
-        files
+    update_types(gid_dict)
+        Update spike types in the current instance of Spikes.
+    plot(ax=None, show=True)
+        Plot and return a matplotlib Figure object showing the
+        aggregate network spiking activity according to cell type.
+    write(fname)
+        Write spiking activity to a collection of spike trial files.
     '''
 
     def __init__(self, times=None, gids=None, types=None):
@@ -648,8 +648,7 @@ class Spikes(object):
         self.types = spiketypes
 
     def plot(self, ax=None, show=True):
-        """Plot the aggregate spiking activity according to cell
-        type.
+        """Plot the aggregate spiking activity according to cell type.
 
         Parameters
         ----------
@@ -662,7 +661,7 @@ class Spikes(object):
         Returns
         -------
         fig : instance of matplotlib Figure
-            The matplotlib figure object
+            The matplotlib figure object.
         """
 
         import matplotlib.pyplot as plt
@@ -688,8 +687,7 @@ class Spikes(object):
         return ax.get_figure()
 
     def write(self, fname):
-        """Write spiking activity to a collection of spike trial
-        files.
+        """Write spiking activity to a collection of spike trial files.
 
         Parameters
         ----------

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -613,8 +613,8 @@ class Network(object):
             for gid_type in np.unique(gid_types):
                 gid_type_max = np.max(spikegids[gid_types == gid_type])
                 gid_type_min = np.min(spikegids[gid_types == gid_type])
-                assert (gid_type_max in self.gid_dict.get(gid_type, False) and
-                        gid_type_min in self.gid_dict.get(gid_type, False)), \
+                assert (gid_type_max in self.gid_dict.get(gid_type, [None]) and
+                        gid_type_min in self.gid_dict.get(gid_type, [None])), \
                     "Error: gids in %s are incompatible with the current \
                     network" % (fname,)
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -565,9 +565,10 @@ class Network(object):
 
         Outputs
         -------
-        txt file at fname where rows correspond to spikes and columns, delimited
-            by '\\t', correspond to 1) spike time (s), 2) spike gid, and 3) gid
-            type
+        txt file at fname where rows correspond to
+            spikes and columns, delimited by '\\t',
+            correspond to 1) spike time (s),
+            2) spike gid, and 3) gid type
         """
         if trial_idx is None:
             trial_idx = range(len(self.spiketimes))
@@ -578,14 +579,14 @@ class Network(object):
             spiketimes += self.spiketimes[idx]
             spikegids += self.spikegids[idx]
 
-        gidtypes = np.empty_like(spikegids,dtype='<U36')
-        for spike_type,gid_range in self.gid_dict.items():
-            gidtypes[np.in1d(spikegids,gid_range)] = spike_type
+        gidtypes = np.empty_like(spikegids, dtype='<U36')
+        for spike_type, gid_range in self.gid_dict.items():
+            gidtypes[np.in1d(spikegids, gid_range)] = spike_type
 
-        with open(fname,'w') as f:
+        with open(fname, 'w') as f:
             for spk_idx in range(len(spiketimes)):
                 f.write('{:.3f}\t{}\t{}\n'.format(spiketimes[spk_idx],
-                    int(spikegids[spk_idx]),gidtypes[spk_idx]))
+                    int(spikegids[spk_idx]), gidtypes[spk_idx]))
 
     def read_spikes(self, fname, append_trial=True):
         """Read spike times from a file.
@@ -595,26 +596,28 @@ class Network(object):
         fname : str
             Full path to the output file (.txt)
         append_trials : bool
-            If True, append the contents of fname (i.e., as a trial) to the
-            spike-related attributes of Network instance. If False, all spikes
-            of the Network instance will be overwritten.
+            If True, append the contents of fname
+            (i.e., as a trial) to the spike-related
+            attributes of Network instance. If False,
+            all spikes of the Network instance will
+            be overwritten.
         """
 
-        spike_data = np.loadtxt(fname,dtype=str)
-        spiketimes = spike_data[:,0].astype(float)
-        spikegids = spike_data[:,1].astype(float)
+        spike_data = np.loadtxt(fname, dtype=str)
+        spiketimes = spike_data[:, 0].astype(float)
+        spikegids = spike_data[:, 1].astype(float)
 
         # Note that legacy HNN 'spk.txt' files contain only 2 columns
         # Handle 3-column version with gid validation
-        if spike_data.shape[0]==3:
-            gid_types = spike_data[:,2].astype(str)
+        if spike_data.shape[0] == 3:
+            gid_types = spike_data[:, 2].astype(str)
             for gid_type in np.unique(gid_types):
-                gid_type_max = np.max(spikegids[gid_types==gid_type])
-                gid_type_min = np.min(spikegids[gid_types==gid_type])
-                assert (gid_type_max in self.gid_dict.get(gid_type,False) and
-                    gid_type_min in self.gid_dict.get(gid_type,False)),\
+                gid_type_max = np.max(spikegids[gid_types == gid_type])
+                gid_type_min = np.min(spikegids[gid_types == gid_type])
+                assert (gid_type_max in self.gid_dict.get(gid_type, False) and
+                        gid_type_min in self.gid_dict.get(gid_type, False)), \
                     "Error: gids in %s are incompatible with the current \
-                    network" %(fname,)
+                    network" % (fname,)
 
         if append_trial is True:
             self.spiketimes = self.spiketimes + (list(spiketimes),)

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -103,6 +103,10 @@ class Network(object):
         # global dictionary of gid and cell type
         self.gid_dict = {}
         self._create_gid_dict()
+        # create empty tuple of spiketime trials
+        self.spiketimes = ()
+        # create empty tuple of spikegids trials
+        self.spikegids = ()
         # assign gid to hosts, creates list of gids for this node in _gid_list
         # _gid_list length is number of cells assigned to this id()
         self._gid_list = []

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -49,9 +49,9 @@ def read_spikes(fname, gid_dict=None):
         if spike_trial.shape[1] == 3:
             spiketypes += [list(spike_trial[:, 2].astype(str))]
         else:
-            assert gid_dict is not None, ("Error: gid_dict must be provided "
-                                          "if spike types are unspecified in "
-                                          "'spk.txt' file")
+            if gid_dict is None:
+                raise ValueError("gid_dict must be provided if spike types "
+                                 "are unspecified in 'spk.txt' file")
             spiketypes_trial = np.empty((spike_trial.shape[1], 1), dtype=str)
             for gidtype, gids in gid_dict.items():
                 spikegids_mask = np.in1d(spike_trial[:, 1].astype(float), gids)
@@ -608,16 +608,17 @@ class Spikes(object):
             types = []
 
         # Validate arguments
-        for arg in [times, gids, types]:
+        arg_names = ['times', 'gids', 'types']
+        for arg_idx, arg in enumerate([times, gids, types]):
             # Validate 1st-order list
             if not isinstance(arg, list):
-                raise TypeError('the argument set to %s should be a list of '
-                                'lists' % (arg,))
+                raise TypeError('%s should be a list of lists'
+                                % (arg_names[arg_idx],))
             # If arg is not an empty list, validate 2st-order list
             for trial_list in arg:
                 if not isinstance(trial_list, list):
-                    raise TypeError('the argument set to %s should be a list '
-                                    'of lists' % (arg,))
+                    raise TypeError('%s should be a list of lists'
+                                    % (arg_names[arg_idx],))
             # Set the length of 'times' as a references and validate
             # uniform length
             if arg == times:

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -41,14 +41,14 @@ def read_spikes(fname, gid_dict=None):
     spiketypes = ()
     for file in sorted(glob(fname)):
         spike_trial = np.loadtxt(file, dtype=str)
-        spiketimes = spiketimes + (list(spike_trial[:, 0].astype(float)),)
-        spikegids = spikegids + (list(spike_trial[:, 1].astype(int)),)
+        spiketimes += (list(spike_trial[:, 0].astype(float)),)
+        spikegids += (list(spike_trial[:, 1].astype(int)),)
 
         # Note that legacy HNN 'spk.txt' files don't contain a 3rd column for
         # spike type. If reading a legacy version, validate that a gid_dict is
         # provided.
         if spike_trial.shape[1] == 3:
-            spiketypes = spiketypes + (list(spike_trial[:, 2].astype(str)),)
+            spiketypes += (list(spike_trial[:, 2].astype(str)),)
         else:
             assert gid_dict is not None, ("Error: gid_dict must be provided "
                                           "if spike types are unspecified in "
@@ -57,7 +57,7 @@ def read_spikes(fname, gid_dict=None):
             for gidtype, gids in gid_dict.items():
                 spikegids_mask = np.in1d(spike_trial[:, 1].astype(float), gids)
                 spiketypes_trial[spikegids_mask] = gidtype
-            spiketypes = spiketypes + (list(spiketypes_trial),)
+            spiketypes += (list(spiketypes_trial),)
 
     return Spikes(times=spiketimes, gids=spikegids, types=spiketypes)
 
@@ -644,7 +644,7 @@ class Spikes(object):
             for gidtype, gids in gid_dict.items():
                 spikegids_mask = np.in1d(self.gids[trl_idx], gids)
                 spiketypes_trial[spikegids_mask] = gidtype
-            spiketypes = spiketypes + (list(spiketypes_trial),)
+            spiketypes += (list(spiketypes_trial),)
         self.types = spiketypes
 
     def plot(self, ax=None, show=True):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -52,12 +52,11 @@ def read_spikes(fname, gid_dict=None):
             if gid_dict is None:
                 raise ValueError("gid_dict must be provided if spike types "
                                  "are unspecified in the file %s" % (file,))
-            spike_types_trial = np.empty((spike_trial.shape[1], 1), dtype=str)
-            for gidtype, gids in gid_dict.items():
-                spike_gids_mask = np.in1d(spike_trial[:, 1].astype(float),
-                                          gids)
-                spike_types_trial[spike_gids_mask] = gidtype
-            spike_types += [list(spike_types_trial)]
+            spike_types += [[]]
+
+    spikes = Spikes(times=spike_times, gids=spike_gids, types=spike_types)
+    if gid_dict is not None:
+        spikes.update_types(gid_dict)
 
     return Spikes(times=spike_times, gids=spike_gids, types=spike_types)
 
@@ -670,6 +669,16 @@ class Spikes(object):
             containing the range of Cell or input IDs of different
             cell or input types.
         """
+
+        # Validate gid_dict
+        gid_dict_ranges = list(gid_dict.values())
+        for item_idx_1 in range(len(gid_dict_ranges)):
+            for item_idx_2 in range(item_idx_1 + 1, len(gid_dict_ranges)):
+                gid_set_1 = set(gid_dict_ranges[item_idx_1])
+                gid_set_2 = set(gid_dict_ranges[item_idx_2])
+                if not gid_set_1.isdisjoint(gid_set_2):
+                    raise ValueError('gid_dict should contain only disjoint '
+                                     'sets of gid values')
 
         spike_types = list()
         for trial_idx in range(len(self._times)):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -556,7 +556,7 @@ class Network(object):
 
 
 class Spikes(object):
-    '''The Spikes class.
+    """The Spikes class.
 
     Parameters
     ----------
@@ -597,7 +597,7 @@ class Spikes(object):
         aggregate network spiking activity according to cell type.
     write(fname)
         Write spiking activity to a collection of spike trial files.
-    '''
+    """
 
     def __init__(self, times=None, gids=None, types=None):
         if times is None:

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -5,6 +5,7 @@
 
 import itertools as it
 import numpy as np
+from glob import glob
 
 from neuron import h
 
@@ -33,7 +34,6 @@ def read_spikes(fname, gid_dict=None):
     spikes : Spikes object
         An instance of the Spikes object.
     """
-    from glob import glob
 
     spiketimes = ()
     spikegids = ()
@@ -600,8 +600,6 @@ class Spikes(object):
     '''
 
     def __init__(self, times=None, gids=None, types=None):
-        from neuron import h
-
         self.times = times
         if times is None:
             self.times = h.Vector()

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -51,7 +51,7 @@ def read_spikes(fname, gid_dict=None):
         else:
             if gid_dict is None:
                 raise ValueError("gid_dict must be provided if spike types "
-                                 "are unspecified in 'spk.txt' file")
+                                 "are unspecified in the file %s" % fname)
             spiketypes_trial = np.empty((spike_trial.shape[1], 1), dtype=str)
             for gidtype, gids in gid_dict.items():
                 spikegids_mask = np.in1d(spike_trial[:, 1].astype(float), gids)
@@ -571,7 +571,7 @@ class Spikes(object):
         Each element of the 1st-order list is a trial.
         The 2nd-order list contains the type of spike (e.g., evprox1
         or L2_pyramidal) that occured at the corresonding time stamp.
-        Each gid corresponds to a type via Network::gid_dict.
+        Each gid corresponds to a type via Network().gid_dict.
 
     Attributes
     ----------
@@ -720,7 +720,7 @@ class Spikes(object):
         return ax.get_figure()
 
     def write(self, fname):
-        """Write spiking activity to a collection of spike trial files.
+        """Write spiking activity per trial to a collection of files.
 
         Parameters
         ----------

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -607,6 +607,18 @@ class Spikes(object):
         self.gids = gids
         self.types = types
 
+    def __eq__(self, other):
+        if not isinstance(other, Spikes):
+            return NotImplemented
+        # Round each element of each list within the tuple
+        times_self = [[round(time, 3) for time in trial]
+                      for trial in self.times]
+        times_other = [[round(time, 3) for time in trial]
+                       for trial in other.times]
+        return (times_self == times_other and
+                self.gids == other.gids and
+                self.types == other.types)
+
     def plot(self, ax=None, show=True):
         """Plot the aggregate spiking activity according to cell
         type.

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -548,7 +548,7 @@ class Network(object):
             plt.show()
         return ax.get_figure()
 
-    def write_spikes(self, fname, trial_idx='all'):
+    def write_spikes(self, fname, trial_idx=None):
         """Write spike times to a file.
 
         Parameters
@@ -559,14 +559,14 @@ class Network(object):
             Indices of selected trials. If 'all',
             all trials are selected.
         """
-        if trial_idx=='all':
+        if trial_idx==None:
             trial_idx = range(len(self.spiketimes))
 
         spiketimes = []
         spikegids = []
-        for i in trial_idx:
-            spiketimes += self.spiketimes[i]
-            spikegids += self.spikegids[i]
+        for idx in trial_idx:
+            spiketimes += self.spiketimes[idx]
+            spikegids += self.spikegids[idx]
 
         gidtypes = np.empty_like(spikegids,dtype='<U36')
         for spike_type,gid_range in self.gid_dict.items():

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -591,9 +591,12 @@ class Spikes(object):
 
     Methods
     -------
+    update_types : update spike types in the current instance of
+        Spikes
     plot : plot and return a matplotlib Figure object showing the
         aggregate network spiking activity according to cell type
-    write : write spike times to a file
+    write : write spiking activity to a collection of spike trial
+        files
     '''
 
     def __init__(self, times=None, gids=None, types=None):
@@ -688,9 +691,6 @@ class Spikes(object):
         fname : str
             String format (e.g., '<pathname>/spk_%d.txt') of the
             path to the output spike file(s).
-        trial_idx : list of int
-            Indices of selected trials. If None,
-            all trials are selected.
 
         Outputs
         -------

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -560,11 +560,13 @@ class Network(object):
             all trials are selected.
         """
         if trial_idx=='all':
-            spiketimes = sum(self.spiketimes,[])
-            spikegids = sum(self.spikegids,[])
-        else:
-            spiketimes = sum(self.spiketimes[trial_idx],[])
-            spikegids = sum(self.spikegids[trial_idx],[])
+            trial_idx = range(len(self.spiketimes))
+
+        spiketimes = []
+        spikegids = []
+        for i in trial_idx:
+            spiketimes += self.spiketimes[i]
+            spikegids += self.spikegids[i]
 
         gidtypes = np.empty_like(spikegids,dtype='<U36')
         for spike_type,gid_range in self.gid_dict.items():

--- a/hnn_core/tests/test_compare_hnn.py
+++ b/hnn_core/tests/test_compare_hnn.py
@@ -36,7 +36,7 @@ def test_hnn_core():
 
     # Test spike type counts
     spiketype_counts = {}
-    for spikegid in net.spikegids[0]:
+    for spikegid in net.spikes.gids[0]:
         if net.gid_to_type(spikegid) not in spiketype_counts:
             spiketype_counts[net.gid_to_type(spikegid)] = 0
         else:

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 import hnn_core
-from hnn_core import read_params, import_dipole
+from hnn_core import read_params, read_dipole
 from hnn_core.dipole import Dipole
 
 matplotlib.use('agg')
@@ -26,7 +26,7 @@ def test_dipole():
     dipole.smooth(params['dipole_smooth_win'] / params['dt'])
     dipole.plot(layer='agg')
     dipole.write(dpl_out_fname)
-    dipole_read = import_dipole(dpl_out_fname)
+    dipole_read = read_dipole(dpl_out_fname)
     assert_array_equal(dipole_read.t, dipole.t.round(3))
     for dpl_key in dipole.dpl.keys():
         assert_array_equal(dipole_read.dpl[dpl_key],

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -2,7 +2,8 @@ import matplotlib
 import os.path as op
 
 import numpy as np
-from numpy.testing import assert_array_equal
+#from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose
 
 import hnn_core
 from hnn_core import read_params, read_dipole
@@ -27,7 +28,7 @@ def test_dipole():
     dipole.plot(layer='agg')
     dipole.write(dpl_out_fname)
     dipole_read = read_dipole(dpl_out_fname)
-    assert_array_equal(dipole_read.t, dipole.t.round(3))
+    assert_allclose(dipole_read.t, dipole.t, rtol=0, atol=0.00051)
     for dpl_key in dipole.dpl.keys():
-        assert_array_equal(dipole_read.dpl[dpl_key],
-                           dipole.dpl[dpl_key].round(4))
+        assert_allclose(dipole_read.dpl[dpl_key],
+                        dipole.dpl[dpl_key], rtol=0, atol=0.000051)

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -11,11 +11,10 @@ matplotlib.use('agg')
 
 
 def test_dipole():
-    """Test params object."""
+    """Test dipole object."""
     hnn_core_root = op.join(op.dirname(hnn_core.__file__), '..')
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
-
     times = np.random.random(6000)
     data = np.random.random((6000, 3))
     dipole = Dipole(times, data)
@@ -25,3 +24,4 @@ def test_dipole():
     dipole.smooth(params['dipole_smooth_win'] / params['dt'])
     dipole.plot(layer='agg')
     dipole.write('/tmp/dpl1.txt')
+    assert op.exists('/tmp/dpl1.txt')

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -2,9 +2,10 @@ import matplotlib
 import os.path as op
 
 import numpy as np
+from numpy.testing import assert_array_equal
 
 import hnn_core
-from hnn_core import read_params
+from hnn_core import read_params, import_dipole
 from hnn_core.dipole import Dipole
 
 matplotlib.use('agg')
@@ -14,6 +15,7 @@ def test_dipole():
     """Test dipole object."""
     hnn_core_root = op.join(op.dirname(hnn_core.__file__), '..')
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
+    dpl_out_fname = '/tmp/dpl1.txt'
     params = read_params(params_fname)
     times = np.random.random(6000)
     data = np.random.random((6000, 3))
@@ -23,5 +25,9 @@ def test_dipole():
     dipole.scale(params['dipole_scalefctr'])
     dipole.smooth(params['dipole_smooth_win'] / params['dt'])
     dipole.plot(layer='agg')
-    dipole.write('/tmp/dpl1.txt')
-    assert op.exists('/tmp/dpl1.txt')
+    dipole.write(dpl_out_fname)
+    dipole_read = import_dipole(dpl_out_fname)
+    assert_array_equal(dipole_read.t, dipole.t.round(3))
+    for dpl_key in dipole.dpl.keys():
+        assert_array_equal(dipole_read.dpl[dpl_key],
+                           dipole.dpl[dpl_key].round(4))

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -2,7 +2,6 @@ import matplotlib
 import os.path as op
 
 import numpy as np
-#from numpy.testing import assert_array_equal
 from numpy.testing import assert_allclose
 
 import hnn_core

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -61,10 +61,15 @@ def test_spikes():
                         types=spiketypes)
 
     # Write spike file with no 'types' column
-    # Check for error when read back in without providing gid_dict
+    # Check for gid_dict errors
     for fname in sorted(glob('/tmp/spk_*.txt')):
         times_gids_only = np.loadtxt(fname, dtype=str)[:, (0, 1)]
         np.savetxt(fname, times_gids_only, delimiter='\t', fmt='%s')
     with pytest.raises(ValueError, match="gid_dict must be provided if spike "
                        "types are unspecified in the file /tmp/spk_0.txt"):
         spikes = read_spikes('/tmp/spk_*.txt')
+    with pytest.raises(ValueError, match="gid_dict should contain only "
+                       "disjoint sets of gid values"):
+        gid_dict = {'L2_pyramidal': range(3), 'L2_basket': range(2, 4),
+                    'L5_pyramidal': range(4, 6), 'L5_basket': range(6, 8)}
+        spikes = read_spikes('/tmp/spk_*.txt', gid_dict=gid_dict)

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -29,4 +29,4 @@ def test_network():
         type_key = ev_input[2: -2] + ev_input[-1]
         assert len(net.gid_dict[type_key]) == net.N_cells
     net.write_spikes('/tmp/spk1.txt', trial_idx=None)
-    assert op.exists('/tmp/spk1.txt', trial_idx=None)
+    assert op.exists('/tmp/spk1.txt')

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import os.path as op
 
 import hnn_core
-from hnn_core import read_params, Network
+from hnn_core import read_params, Network, Spikes, read_spikes
 
 
 def test_network():
@@ -27,6 +27,12 @@ def test_network():
     assert len(net.gid_dict['extpois']) == net.n_cells
     for ev_input in params['t_ev*']:
         type_key = ev_input[2: -2] + ev_input[-1]
-        assert len(net.gid_dict[type_key]) == net.N_cells
-    net.write_spikes('/tmp/spk1.txt', trial_idx=None)
-    assert op.exists('/tmp/spk1.txt')
+        assert len(net.gid_dict[type_key]) == net.n_cells
+
+    # Test read/write spikes consistency
+    spiketimes = ([2.3456, 7.89], [4.2812, 93.2])
+    spikegids = ([1, 3], [5, 7])
+    spiketypes = (['L2_pyramidal', 'L2_basket'], ['L5_pyramidal', 'L5_basket'])
+    spikes = Spikes(times=spiketimes, gids=spikegids, types=spiketypes)
+    spikes.write('/tmp/spk_%d.txt')
+    assert spikes == read_spikes('/tmp/spk_*.txt')

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -27,4 +27,6 @@ def test_network():
     assert len(net.gid_dict['extpois']) == net.n_cells
     for ev_input in params['t_ev*']:
         type_key = ev_input[2: -2] + ev_input[-1]
-        assert len(net.gid_dict[type_key]) == net.n_cells
+        assert len(net.gid_dict[type_key]) == net.N_cells
+    net.write_spikes('/tmp/spk1.txt', trial_idx=None)
+    assert op.exists('/tmp/spk1.txt', trial_idx=None)

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -47,35 +47,23 @@ def test_spikes():
     spikes.write('/tmp/spk_%d.txt')
     assert spikes == read_spikes('/tmp/spk_*.txt')
 
-    # TypeError should be raised when one of the args is entered as a non-list
-    # (e.g., when times is a tuple of lists)
-    with pytest.raises(TypeError) as excinfo:
-        spiketimes_tuple = ([2.3456, 7.89], [4.2812, 93.2])
-        spikes = Spikes(times=spiketimes_tuple, gids=spikegids,
+    with pytest.raises(TypeError, match="times should be a list of lists"):
+        spikes = Spikes(times=([2.3456, 7.89], [4.2812, 93.2]), gids=spikegids,
                         types=spiketypes)
-    assert "times should be a list of lists" in str(excinfo.value)
 
-    # TypeError should be raised when one of the args is entered as a list of
-    # non-lists (e.g., when times is a list of ints)
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(TypeError, match="times should be a list of lists"):
         spikes = Spikes(times=[1, 2], gids=spikegids, types=spiketypes)
-    assert "times should be a list of lists" in str(excinfo.value)
 
-    # ValueError should be raised when one of the args is entered as an
-    # incongruent number of trials (e.g., 1 trial when all other args have 2)
-    with pytest.raises(ValueError) as excinfo:
-        spiketimes_1_trial = [[2.3456, 7.89]]
-        spikes = Spikes(times=spiketimes_1_trial, gids=spikegids,
+    with pytest.raises(ValueError, match="times, gids, and types should be "
+                       "lists of the same length"):
+        spikes = Spikes(times=[[2.3456, 7.89]], gids=spikegids,
                         types=spiketypes)
-    assert ("times, gids, and types should be lists of the same length"
-            in str(excinfo.value))
 
     # Write spike file with no 'types' column
     # Check for error when read back in without providing gid_dict
     for fname in sorted(glob('/tmp/spk_*.txt')):
         times_gids_only = np.loadtxt(fname, dtype=str)[:, (0, 1)]
         np.savetxt(fname, times_gids_only, delimiter='\t', fmt='%s')
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="gid_dict must be provided if spike "
+                       "types are unspecified in the file /tmp/spk_0.txt"):
         spikes = read_spikes('/tmp/spk_*.txt')
-    assert ("gid_dict must be provided if spike types are unspecified in "
-            "'spk.txt' file" in str(excinfo.value))

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -2,6 +2,9 @@
 
 from copy import deepcopy
 import os.path as op
+from glob import glob
+import numpy as np
+import pytest
 
 import hnn_core
 from hnn_core import read_params, Network, Spikes, read_spikes
@@ -29,10 +32,50 @@ def test_network():
         type_key = ev_input[2: -2] + ev_input[-1]
         assert len(net.gid_dict[type_key]) == net.n_cells
 
-    # Test read/write spikes consistency
-    spiketimes = ([2.3456, 7.89], [4.2812, 93.2])
-    spikegids = ([1, 3], [5, 7])
-    spiketypes = (['L2_pyramidal', 'L2_basket'], ['L5_pyramidal', 'L5_basket'])
+    # Assert that an empty Spikes object is created as an attribute
+    assert net.spikes == Spikes()
+
+
+def test_spikes():
+    '''Test spikes object.'''
+
+    # Round-trip test
+    spiketimes = [[2.3456, 7.89], [4.2812, 93.2]]
+    spikegids = [[1, 3], [5, 7]]
+    spiketypes = [['L2_pyramidal', 'L2_basket'], ['L5_pyramidal', 'L5_basket']]
     spikes = Spikes(times=spiketimes, gids=spikegids, types=spiketypes)
     spikes.write('/tmp/spk_%d.txt')
     assert spikes == read_spikes('/tmp/spk_*.txt')
+
+    # TypeError should be raised when one of the args is entered as a non-list
+    # (e.g., when times is a tuple of lists)
+    with pytest.raises(TypeError) as excinfo:
+        spiketimes_tuple = ([2.3456, 7.89], [4.2812, 93.2])
+        spikes = Spikes(times=spiketimes_tuple, gids=spikegids,
+                        types=spiketypes)
+    assert "times should be a list of lists" in str(excinfo.value)
+
+    # TypeError should be raised when one of the args is entered as a list of
+    # non-lists (e.g., when times is a list of ints)
+    with pytest.raises(TypeError) as excinfo:
+        spikes = Spikes(times=[1, 2], gids=spikegids, types=spiketypes)
+    assert "times should be a list of lists" in str(excinfo.value)
+
+    # ValueError should be raised when one of the args is entered as an
+    # incongruent number of trials (e.g., 1 trial when all other args have 2)
+    with pytest.raises(ValueError) as excinfo:
+        spiketimes_1_trial = [[2.3456, 7.89]]
+        spikes = Spikes(times=spiketimes_1_trial, gids=spikegids,
+                        types=spiketypes)
+    assert ("times, gids, and types should be lists of the same length"
+            in str(excinfo.value))
+
+    # Write spike file with no 'types' column
+    # Check for error when read back in without providing gid_dict
+    for fname in sorted(glob('/tmp/spk_*.txt')):
+        times_gids_only = np.loadtxt(fname, dtype=str)[:, (0, 1)]
+        np.savetxt(fname, times_gids_only, delimiter='\t', fmt='%s')
+    with pytest.raises(ValueError) as excinfo:
+        spikes = read_spikes('/tmp/spk_*.txt')
+    assert ("gid_dict must be provided if spike types are unspecified in "
+            "'spk.txt' file" in str(excinfo.value))

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -46,6 +46,7 @@ def test_spikes():
     spikes = Spikes(times=spiketimes, gids=spikegids, types=spiketypes)
     spikes.write('/tmp/spk_%d.txt')
     assert spikes == read_spikes('/tmp/spk_*.txt')
+    assert ("Spikes | 2 simulation trials" in repr(spikes))
 
     with pytest.raises(TypeError, match="times should be a list of lists"):
         spikes = Spikes(times=([2.3456, 7.89], [4.2812, 93.2]), gids=spikegids,

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -37,7 +37,7 @@ def test_network():
 
 
 def test_spikes():
-    '''Test spikes object.'''
+    """Test spikes object."""
 
     # Round-trip test
     spiketimes = [[2.3456, 7.89], [4.2812, 93.2]]


### PR DESCRIPTION
Two changes have been made: 1) `dipole.write()` has been fixed to save files according to the user-specified name, and 2) `network.write_spikes()` has been added so that spiking data for selected trials can be saved to a single .txt file. See the attached example (a modified version of the plot_simulate_evoked.py example) and its corresponding output .txt and .png files that demonstrates reconstruction of the simulated spike event plot using the spike .txt files.
[demo.zip](https://github.com/jonescompneurolab/hnn-core/files/4391152/demo.zip)
