### PR TITLE
Fix extinput (rhythmic) input param feed

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -177,7 +177,7 @@ sphinx_gallery_conf = {
     'examples_dirs': '../examples',
     # path where to save gallery generated examples
     'gallery_dirs': 'auto_examples',
-    'backreferences_dir': False,
+    'backreferences_dir': 'generated',
     'reference_url': {
         'hnn_core': 'https://jonescompneurolab.github.io/hnn-core/'
     },

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,7 +26,7 @@ Bug
 
 - Fix missing autapses in network construction, by `Mainak Jas`_ in `#50 <https://github.com/jonescompneurolab/hnn-core/pull/50>`_
 
-- Fix rhythmic input feed, by 'Ryan Thorpe'_ in '#98 <https://github.com/jonescompneurolab/hnn-core/pull/98>'_
+- Fix rhythmic input feed, by 'Ryan Thorpe'_ in `#98 <https://github.com/jonescompneurolab/hnn-core/pull/98>`_
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,8 @@ Bug
 
 - Fix missing autapses in network construction, by `Mainak Jas`_ in `#50 <https://github.com/jonescompneurolab/hnn-core/pull/50>`_
 
+- Fix rhythmic input feed, by 'Ryan Thorpe'_ in '#98 <https://github.com/jonescompneurolab/hnn-core/pull/98>'_
+
 API
 ~~~
 

--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -184,7 +184,7 @@ class ExtFeed(object):
             if key.startswith('L2Pyr') or \
                     key.startswith('L5Pyr') or \
                     key.startswith('L2Bask') or \
-                    key.startswith('L2Bask'):
+                    key.startswith('L5Bask'):
                 if self.p_ext[key][0] <= 0.0:
                     return False
         # store f_input as self variable for later use if it exists in p

--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -179,7 +179,7 @@ class ExtFeed(object):
     def __create_extinput(self):
         """Creates the ongoing external inputs (rhythmic)."""
         # print("__create_extinput")
-        # Escape if all synaptic weights are 0
+        # Return if all synaptic weights are 0
         for key in self.p_ext.keys():
             if key.startswith('L2Pyr') or \
                     key.startswith('L5Pyr') or \

--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -59,7 +59,7 @@ class ExtFeed(object):
                 if self.p_ext['sync_evinput']:
                     self.seed = self.p_ext['prng_seedcore']
                 else:
-                    self.seed = self.p_ext['prng_seedcore'] + self.gid
+                    self.seed = self.p_ext['prng_seedcore'] + self.gid - 2
             elif self.ty.startswith('extinput'):
                 # seed for events assuming a given start time
                 self.seed = self.p_ext['prng_seedcore'] + self.gid

--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -179,6 +179,14 @@ class ExtFeed(object):
     def __create_extinput(self):
         """Creates the ongoing external inputs (rhythmic)."""
         # print("__create_extinput")
+        # Escape if all synaptic weights are 0
+        for key in self.p_ext.keys():
+            if key.startswith('L2Pyr') or \
+                    key.startswith('L5Pyr') or \
+                    key.startswith('L2Bask') or \
+                    key.startswith('L2Bask'):
+                if self.p_ext[key][0] <= 0.0:
+                    return False
         # store f_input as self variable for later use if it exists in p
         # t0 is always defined
         t0 = self.p_ext['t0']

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -186,38 +186,35 @@ def feed_validate(p_ext, d, tstop):
        could be properly made into a meaningful class.
     """
 
-    # only append if t0 is less than simulation tstop
-    if tstop > d['t0']:
-        # # reset tstop if the specified tstop exceeds the
-        # # simulation runtime
-        # if d['tstop'] == 0:
-        #     d['tstop'] = tstop
+    # # reset tstop if the specified tstop exceeds the
+    # # simulation runtime
+    # if d['tstop'] == 0:
+    #     d['tstop'] = tstop
 
-        if d['tstop'] > tstop:
-            d['tstop'] = tstop
+    if d['tstop'] > tstop:
+        d['tstop'] = tstop
 
-        # if stdev is zero, increase synaptic weights 5 fold to make
-        # single input equivalent to 5 simultaneous input to prevent spiking
-        # <<---- SN: WHAT IS THIS RULE!?!?!?
-        if not d['stdev'] and d['distribution'] != 'uniform':
-            for key in d.keys():
-                if key.endswith('Pyr'):
-                    d[key] = (d[key][0] * 5., d[key][1])
-                elif key.endswith('Basket'):
-                    d[key] = (d[key][0] * 5., d[key][1])
+    # if stdev is zero, increase synaptic weights 5 fold to make
+    # single input equivalent to 5 simultaneous input to prevent spiking
+    # <<---- SN: WHAT IS THIS RULE!?!?!?
+    if not d['stdev'] and d['distribution'] != 'uniform':
+        for key in d.keys():
+            if key.endswith('Pyr'):
+                d[key] = (d[key][0] * 5., d[key][1])
+            elif key.endswith('Basket'):
+                d[key] = (d[key][0] * 5., d[key][1])
 
-        # if L5 delay is -1, use same delays as L2 unless L2 delay is 0.1 in
-        # which case use 1. <<---- SN: WHAT IS THIS RULE!?!?!?
-        if d['L5Pyr_ampa'][1] == -1:
-            for key in d.keys():
-                if key.startswith('L5'):
-                    if d['L2Pyr'][1] != 0.1:
-                        d[key] = (d[key][0], d['L2Pyr'][1])
-                    else:
-                        d[key] = (d[key][0], 1.)
+    # if L5 delay is -1, use same delays as L2 unless L2 delay is 0.1 in
+    # which case use 1. <<---- SN: WHAT IS THIS RULE!?!?!?
+    if d['L5Pyr_ampa'][1] == -1:
+        for key in d.keys():
+            if key.startswith('L5'):
+                if d['L2Pyr'][1] != 0.1:
+                    d[key] = (d[key][0], d['L2Pyr'][1])
+                else:
+                    d[key] = (d[key][0], 1.)
 
-        p_ext.append(d)
-
+    p_ext.append(d)
     return p_ext
 
 

--- a/hnn_core/tests/test_compare_hnn.py
+++ b/hnn_core/tests/test_compare_hnn.py
@@ -44,12 +44,10 @@ def test_hnn_core():
     assert 'extinput' not in spiketype_counts
     assert 'exgauss' not in spiketype_counts
     assert 'extpois' not in spiketype_counts
-    assert spiketype_counts == {
-        'evprox1': 269,
-        'L2_basket': 55,
-        'L2_pyramidal': 88,
-        'L5_pyramidal': 390,
-        'L5_basket': 87,
-        'evdist1': 234,
-        'evprox2': 269
-    }
+    assert spiketype_counts == {'evprox1': 269,
+                                'L2_basket': 54,
+                                'L2_pyramidal': 113,
+                                'L5_pyramidal': 395,
+                                'L5_basket': 85,
+                                'evdist1': 234,
+                                'evprox2': 269}

--- a/hnn_core/tests/test_compare_hnn.py
+++ b/hnn_core/tests/test_compare_hnn.py
@@ -33,3 +33,23 @@ def test_hnn_core():
     dpl_pr = loadtxt(fname)
     assert_array_equal(dpl_pr[:, 2], dpl_master[:, 2])  # L2
     assert_array_equal(dpl_pr[:, 3], dpl_master[:, 3])  # L5
+
+    # Test spike type counts
+    spiketype_counts = {}
+    for spikegid in net.spikegids[0]:
+        if net.gid_to_type(spikegid) not in spiketype_counts:
+            spiketype_counts[net.gid_to_type(spikegid)] = 0
+        else:
+            spiketype_counts[net.gid_to_type(spikegid)] += 1
+    assert 'extinput' not in spiketype_counts
+    assert 'exgauss' not in spiketype_counts
+    assert 'extpois' not in spiketype_counts
+    assert spiketype_counts == {
+        'evprox1': 269,
+        'L2_basket': 55,
+        'L2_pyramidal': 88,
+        'L5_pyramidal': 390,
+        'L5_basket': 87,
+        'evdist1': 234,
+        'evprox2': 269
+    }

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -13,8 +13,18 @@ def test_network():
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
     net = Network(deepcopy(params))
+
+    # Assert that params are conserved across Network initialization
     for p in params:
         assert params[p] == net.params[p]
     assert len(params) == len(net.params)
     print(net)
     print(net.cells[:2])
+
+    # Assert that proper number of gids are created for Network inputs
+    assert len(net.gid_dict['extinput']) == 2
+    assert len(net.gid_dict['extgauss']) == net.N_cells
+    assert len(net.gid_dict['extpois']) == net.N_cells
+    for ev_input in params['t_ev*']:
+        type_key = ev_input[2: -2] + ev_input[-1]
+        assert len(net.gid_dict[type_key]) == net.N_cells


### PR DESCRIPTION
There is some odd behavior in how rhythmic inputs are handled. The default param set avoids loading and running `extinput` inputs (i.e., rhythmic inputs) by assigning the start time, `t0`, to a time after `tstop`. If, however, someone loads the default param file and then modifies it so that `t0` lies within the simulation timeline, the dipole changes. See the attached example script (a modified version of "plot_simulate_evoked.py" and its corresponding terminal outputs. Currently, the attached script creates this image along with "original_terminal_out.txt": 
![Screenshot from 2020-04-15 20-59-10](https://user-images.githubusercontent.com/20212206/79408560-a7b25f80-7f69-11ea-8f99-b3326f1e49dd.png)

The commit in this PR creates this image along with "fixed_terminal_out.txt":
![Screenshot from 2020-04-15 21-01-50](https://user-images.githubusercontent.com/20212206/79408742-11326e00-7f6a-11ea-9133-31089161e4a5.png)

Note that my proposed fix might mess with the current rng seeds.

[extinput_demo.zip](https://github.com/jonescompneurolab/hnn-core/files/4484546/extinput_demo.zip)
