### PR TITLE
[MRG] fix logic checking extinput synweights zero

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -28,6 +28,8 @@ Bug
 
 - Fix rhythmic input feed, by `Ryan Thorpe`_ in `#98 <https://github.com/jonescompneurolab/hnn-core/pull/98>`_
 
+- Fix bug introduced into rhythmic input feed and add test, by `Christopher Bailey`_ in `#102 <https://github.com/jonescompneurolab/hnn-core/pull/102>`_
+
 API
 ~~~
 
@@ -36,3 +38,4 @@ API
 .. _Mainak Jas: http://jasmainak.github.io/
 .. _Blake Caldwell: https://github.com/blakecaldwell
 .. _Ryan Thorpe: https://github.com/rythorpe
+.. _Christopher Bailey: https://github.com/cjayb

--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -180,13 +180,17 @@ class ExtFeed(object):
         """Creates the ongoing external inputs (rhythmic)."""
         # print("__create_extinput")
         # Return if all synaptic weights are 0
+        all_syn_weights_zero = True  # fixes #101
         for key in self.p_ext.keys():
             if key.startswith('L2Pyr') or \
                     key.startswith('L5Pyr') or \
                     key.startswith('L2Bask') or \
                     key.startswith('L5Bask'):
-                if self.p_ext[key][0] <= 0.0:
-                    return False
+                if self.p_ext[key][0] > 0.0:
+                    all_syn_weights_zero = False
+        if all_syn_weights_zero:
+            return False
+
         # store f_input as self variable for later use if it exists in p
         # t0 is always defined
         t0 = self.p_ext['t0']

--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -180,7 +180,7 @@ class ExtFeed(object):
         """Creates the ongoing external inputs (rhythmic)."""
         # print("__create_extinput")
         # Return if all synaptic weights are 0
-        all_syn_weights_zero = True  # fixes #101
+        all_syn_weights_zero = True
         for key in self.p_ext.keys():
             if key.startswith('L2Pyr') or \
                     key.startswith('L5Pyr') or \

--- a/hnn_core/tests/test_feed.py
+++ b/hnn_core/tests/test_feed.py
@@ -21,29 +21,20 @@ def test_external_rhythmic_feeds():
                    'input_prox_A_weight_L2Pyr_ampa': 5.4e-5,
                    'input_prox_A_weight_L5Pyr_ampa': 5.4e-5,
                    't0_input_prox': 50})
-    net = Network(deepcopy(params))
 
-    # from Network.build: creates ExtFeeds in < 1 sec
-    net._create_all_src()
-    # needed to close the ParallelContext, else next pc will segfault
-    from hnn_core.parallel import pc
-    pc.gid_clear()
+    with Network(deepcopy(params)) as net:
+        net._create_all_src()
 
-    # annoyingly, net.extinput_list is always 2, whether populated
-    # or not, so the first few assertions have no effect
-    # the eventvec needs to be > 0, though (catches #101, tests #102)
-    assert len(net.extinput_list) == 2  # (distal & proximal)
-    for ei in net.extinput_list:
-        # naming could be better
-        assert ei.ty == 'extinput'
-        # eventvec is of type h.Vector
-        assert ei.eventvec.hname().startswith('Vector')
-        # not sure why this is 40 for both, just test > 0
-        assert len(ei.eventvec.as_numpy()) > 0
-        # move this to new test of create_pext in params?
-        # tests that cryptically named input parameters indeed
-        # copied into p_ext
-        loc = ei.p_ext['loc'][:4]
-        for lay in ['L2', 'L5']:
-            pname = 'input_' + loc + '_A_weight_' + lay + 'Pyr_ampa'
-            assert ei.p_ext[lay + 'Pyr_ampa'][0] == params[pname]
+        assert len(net.extinput_list) == 2  # (distal & proximal)
+        for ei in net.extinput_list:
+            # XXX: need to rename ei.ty to 'rhythmic'
+            assert ei.ty == 'extinput'
+            assert ei.eventvec.hname().startswith('Vector')
+            # not sure why this is 40 for both, just test > 0
+            assert len(ei.eventvec.as_numpy()) > 0
+
+            # check that ei.p_ext matches params
+            loc = ei.p_ext['loc'][:4]  # loc=prox or dist
+            for layer in ['L2', 'L5']:
+                key = 'input_{}_A_weight_{}Pyr_ampa'.format(loc, layer)
+                assert ei.p_ext[layer + 'Pyr_ampa'][0] == params[key]

--- a/hnn_core/tests/test_feed.py
+++ b/hnn_core/tests/test_feed.py
@@ -1,0 +1,46 @@
+# Authors: Mainak Jas <mainakjas@gmail.com>
+#          Christopher Bailey <bailey.cj@gmail.com>
+
+from copy import deepcopy
+import os.path as op
+
+import hnn_core
+from hnn_core import read_params, Network
+
+
+def test_external_rhythmic_feeds():
+    """Test external rhythmic feeds to proximal and distal dendrites."""
+    hnn_core_root = op.join(op.dirname(hnn_core.__file__), '..')
+    params_fname = op.join(hnn_core_root, 'param', 'default.json')
+    params = read_params(params_fname)
+
+    # default parameters have no rhythmic inputs (distal or proximal),
+    params.update({'input_dist_A_weight_L2Pyr_ampa': 5.4e-5,
+                   'input_dist_A_weight_L5Pyr_ampa': 5.4e-5,
+                   't0_input_dist': 50,
+                   'input_prox_A_weight_L2Pyr_ampa': 5.4e-5,
+                   'input_prox_A_weight_L5Pyr_ampa': 5.4e-5,
+                   't0_input_prox': 50})
+    net = Network(deepcopy(params))
+
+    # from Network.build: creates ExtFeeds in < 1 sec
+    net._create_all_src()
+
+    # annoyingly, net.extinput_list is always 2, whether populated
+    # or not, so the first few assertions have no effect
+    # the eventvec needs to be > 0, though (catches #101, tests #102)
+    assert len(net.extinput_list) == 2  # (distal & proximal)
+    for ei in net.extinput_list:
+        # naming could be better
+        assert ei.ty == 'extinput'
+        # eventvec is of type h.Vector
+        assert ei.eventvec.hname().startswith('Vector')
+        # not sure why this is 40 for both, just test > 0
+        assert len(ei.eventvec.as_numpy()) > 0
+        # move this to new test of create_pext in params?
+        # tests that cryptically named input parameters indeed
+        # copied into p_ext
+        loc = ei.p_ext['loc'][:4]
+        for lay in ['L2', 'L5']:
+            pname = 'input_' + loc + '_A_weight_' + lay + 'Pyr_ampa'
+            assert ei.p_ext[lay + 'Pyr_ampa'][0] == params[pname]

--- a/hnn_core/tests/test_feed.py
+++ b/hnn_core/tests/test_feed.py
@@ -25,6 +25,9 @@ def test_external_rhythmic_feeds():
 
     # from Network.build: creates ExtFeeds in < 1 sec
     net._create_all_src()
+    # needed to close the ParallelContext, else next pc will segfault
+    from hnn_core.parallel import pc
+    pc.gid_clear()
 
     # annoyingly, net.extinput_list is always 2, whether populated
     # or not, so the first few assertions have no effect

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -1,5 +1,4 @@
 # Authors: Mainak Jas <mainakjas@gmail.com>
-#          Christopher Bailey <bailey.cj@gmail.com>
 
 from copy import deepcopy
 import os.path as op
@@ -29,35 +28,3 @@ def test_network():
     for ev_input in params['t_ev*']:
         type_key = ev_input[2: -2] + ev_input[-1]
         assert len(net.gid_dict[type_key]) == net.N_cells
-
-
-def test_external_rhythmic_feeds():
-    """Test external rhythmic feeds to proximal and distal dendrites."""
-    hnn_core_root = op.join(op.dirname(hnn_core.__file__), '..')
-    params_fname = op.join(hnn_core_root, 'param', 'default.json')
-    params = read_params(params_fname)
-
-    # default parameters have no rhythmic inputs (distal or proximal),
-    params.update({'input_dist_A_weight_L2Pyr_ampa': 5.4e-5,
-                   'input_dist_A_weight_L5Pyr_ampa': 5.4e-5,
-                   't0_input_dist': 50,
-                   'input_prox_A_weight_L2Pyr_ampa': 5.4e-5,
-                   'input_prox_A_weight_L5Pyr_ampa': 5.4e-5,
-                   't0_input_prox': 50})
-    net = Network(deepcopy(params))
-
-    # from Network.build: creates ExtFeeds in < 1 sec
-    net._create_all_src()
-
-    # annoyingly, net.extinput_list is always 2, whether populated
-    # or not, so the first few assertions have no effect
-    # the last one needs to be > 0, though (catches #101, tests #102)
-    # Assert number of rhythmic inputs is 2 (distal & proximal)
-    assert len(net.extinput_list) == 2
-    for ei in net.extinput_list:
-        # naming could be better
-        assert ei.ty == 'extinput'
-        # eventvec is of type h.Vector
-        assert ei.eventvec.hname().startswith('Vector')
-        # not sure why this is 40 for both, just test > 0
-        assert len(ei.eventvec.as_numpy()) > 0

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -1,4 +1,5 @@
 # Authors: Mainak Jas <mainakjas@gmail.com>
+#          Christopher Bailey <bailey.cj@gmail.com>
 
 from copy import deepcopy
 import os.path as op
@@ -28,3 +29,35 @@ def test_network():
     for ev_input in params['t_ev*']:
         type_key = ev_input[2: -2] + ev_input[-1]
         assert len(net.gid_dict[type_key]) == net.N_cells
+
+
+def test_external_rhythmic_feeds():
+    """Test external rhythmic feeds to proximal and distal dendrites."""
+    hnn_core_root = op.join(op.dirname(hnn_core.__file__), '..')
+    params_fname = op.join(hnn_core_root, 'param', 'default.json')
+    params = read_params(params_fname)
+
+    # default parameters have no rhythmic inputs (distal or proximal),
+    params.update({'input_dist_A_weight_L2Pyr_ampa': 5.4e-5,
+                   'input_dist_A_weight_L5Pyr_ampa': 5.4e-5,
+                   't0_input_dist': 50,
+                   'input_prox_A_weight_L2Pyr_ampa': 5.4e-5,
+                   'input_prox_A_weight_L5Pyr_ampa': 5.4e-5,
+                   't0_input_prox': 50})
+    net = Network(deepcopy(params))
+
+    # from Network.build: creates ExtFeeds in < 1 sec
+    net._create_all_src()
+
+    # annoyingly, net.extinput_list is always 2, whether populated
+    # or not, so the first few assertions have no effect
+    # the last one needs to be > 0, though (catches #101, tests #102)
+    # Assert number of rhythmic inputs is 2 (distal & proximal)
+    assert len(net.extinput_list) == 2
+    for ei in net.extinput_list:
+        # naming could be better
+        assert ei.ty == 'extinput'
+        # eventvec is of type h.Vector
+        assert ei.eventvec.hname().startswith('Vector')
+        # not sure why this is 40 for both, just test > 0
+        assert len(ei.eventvec.as_numpy()) > 0


### PR DESCRIPTION
This PR fixes the part of #98 (specifically 94fc21a6 in `feed.py`) that botches the alpha-example.

No test written yet, input appreciated! There's a refactor brewing (see also discussion in #98), so perhaps tests should be deferred? To speed up tests, would it make sense to create a 'minimal network'? Not sure that makes sense, but almost 3 min spent on just the full alpha-example isn't sustainable. 

Fixes #101 