### PR TITLE
[MRG] cleanup variable names and logic related to "common" inputs

### DIFF
--- a/hnn_core/basket.py
+++ b/hnn_core/basket.py
@@ -68,8 +68,8 @@ class L2Basket(BasketSingle):
     # par: receive from external inputs
     def parreceive(self, gid, gid_dict, pos_dict, p_ext):
         # for some gid relating to the input feed:
-        for gid_src, p_src, pos in zip(gid_dict['extinput'],
-                                       p_ext, pos_dict['extinput']):
+        for gid_src, p_src, pos in zip(gid_dict['common'],
+                                       p_ext, pos_dict['common']):
             # check if AMPA params are defined in the p_src
             if 'L2Basket_ampa' in p_src.keys():
                 # create an nc_dict
@@ -83,7 +83,7 @@ class L2Basket(BasketSingle):
                 }
 
                 # AMPA synapse
-                self.ncfrom_extinput.append(self.parconnect_from_src(
+                self.ncfrom_common.append(self.parconnect_from_src(
                     gid_src, nc_dict_ampa, self.soma_ampa))
 
             # Check if NMDA params are defined in p_src
@@ -98,7 +98,7 @@ class L2Basket(BasketSingle):
                 }
 
                 # NMDA synapse
-                self.ncfrom_extinput.append(self.parconnect_from_src(
+                self.ncfrom_common.append(self.parconnect_from_src(
                     gid_src, nc_dict_nmda, self.soma_nmda))
 
     # one parreceive function to handle all types of external parreceives
@@ -225,8 +225,8 @@ class L5Basket(BasketSingle):
     # parallel receive function parreceive()
     def parreceive(self, gid, gid_dict, pos_dict, p_ext):
         """Receive."""
-        for gid_src, p_src, pos in zip(gid_dict['extinput'], p_ext,
-                                       pos_dict['extinput']):
+        for gid_src, p_src, pos in zip(gid_dict['common'], p_ext,
+                                       pos_dict['common']):
             # Check if AMPA params are define in p_src
             if 'L5Basket_ampa' in p_src.keys():
                 nc_dict_ampa = {
@@ -239,7 +239,7 @@ class L5Basket(BasketSingle):
                 }
 
                 # AMPA synapse
-                self.ncfrom_extinput.append(self.parconnect_from_src(
+                self.ncfrom_common.append(self.parconnect_from_src(
                     gid_src, nc_dict_ampa, self.soma_ampa))
 
             # Check if nmda params are define in p_src
@@ -254,7 +254,7 @@ class L5Basket(BasketSingle):
                 }
 
                 # NMDA synapse
-                self.ncfrom_extinput.append(self.parconnect_from_src(
+                self.ncfrom_common.append(self.parconnect_from_src(
                     gid_src, nc_dict_nmda, self.soma_nmda))
 
     # one parreceive function to handle all types of external parreceives

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -45,7 +45,7 @@ class _Cell(object):
         self.ncfrom_L2Basket = []
         self.ncfrom_L5Pyr = []
         self.ncfrom_L5Basket = []
-        self.ncfrom_extinput = []
+        self.ncfrom_common = []
         self.ncfrom_extgauss = []
         self.ncfrom_extpois = []
         self.ncfrom_ev = []

--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -22,7 +22,13 @@ class ExtFeed(object):
         'extgauss' : Gaussian-distributed input to proximal dendrites
         'evprox' : Proximal input at specified time (or Gaussian spread)
         'evdist' : Distal input at specified time (or Gaussian spread)
-        'common' : Common inputs to all cells (locations parameter-dependent)
+
+        'common' : As opposed to other feed types, these have timing that is
+        identical (synchronous) for all real cells in the network. Proximal
+        and distal dendrites have separate parameter sets, and need not be
+        synchronous. Note that not all cells classes (types) are required to
+        receive 'common' input---separate conductivity values can be assigned
+        to basket vs. pyramidal cells and AMPA vs. NMDA synapses
     cell_type : str | None
         The cell type, e.g., 'L2_basket', 'L5_pyramidal', etc., or None for
         common inputs (cell population-level weights for common inputs

--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -29,11 +29,10 @@ class ExtFeed(object):
         synchronous. Note that not all cells classes (types) are required to
         receive 'common' input---separate conductivity values can be assigned
         to basket vs. pyramidal cells and AMPA vs. NMDA synapses
-    cell_type : str | None
-        The cell type, e.g., 'L2_basket', 'L5_pyramidal', etc., or None for
-        common inputs (cell population-level weights for common inputs
-        are defined separately in the parameters)
-    p_ext : dict
+    target_cell_type : str | None
+        The target cell type of the feed, e.g., 'L2_basket', 'L5_pyramidal',
+        etc., or None for 'common' inputs
+    params : dict
         Parameters of the external input feed, arranged into a dictionary.
     gid : int
         The cell ID.
@@ -51,14 +50,14 @@ class ExtFeed(object):
         The cell ID
     """
 
-    def __init__(self, feed_type, cell_type, p_ext, gid):
+    def __init__(self, feed_type, target_cell_type, params, gid):
         # VecStim setup
         self.nrn_eventvec = h.Vector()
         self.nrn_vecstim = h.VecStim()
-        self.p_ext = p_ext
+        self.p_ext = params
         # used to determine cell type-specific parameters for
         # (not used for 'common', such as for rhythmic alpha/beta input)
-        self.cell_type = cell_type  # XXX rename for all cell types?
+        self.cell_type = target_cell_type
         self.feed_type = feed_type
         self.gid = gid
         self.set_prng()  # sets seeds for random num generator

--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -81,7 +81,7 @@ class ExtFeed(object):
                 if self.params['sync_evinput']:
                     self.seed = self.params['prng_seedcore']
                 else:
-                    self.seed = self.params['prng_seedcore'] + self.gid - 2
+                    self.seed = self.params['prng_seedcore'] + self.gid
             elif self.feed_type.startswith('common'):
                 # seed for events assuming a given start time
                 self.seed = self.params['prng_seedcore'] + self.gid

--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -136,7 +136,7 @@ class ExtFeed(object):
         # check the t interval
         t0 = self.params['t_interval'][0]
         T = self.params['t_interval'][1]
-        lamtha = self.params[self.cell_type][3]  # index 3 is frequency (lamtha)
+        lamtha = self.params[self.cell_type][3]  # ind 3 is frequency (lamtha)
         # values MUST be sorted for VecStim()!
         # start the initial value
         if lamtha > 0.:
@@ -167,7 +167,7 @@ class ExtFeed(object):
         if self.cell_type in self.params.keys():
             # assign the params
             mu = self.params['t0'] + inc
-            sigma = self.params[self.cell_type][3]  # index 3 is sigma_t (stdev)
+            sigma = self.params[self.cell_type][3]  # ind 3 is sigma_t (stdev)
             numspikes = int(self.params['numspikes'])
             # if a non-zero sigma is specified
             if sigma:

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -360,7 +360,10 @@ class Network(object):
                 # timing will be identical for all cells
                 # XXX common_feeds is a list of dict (comp. unique_feeds)
                 self.common_feeds.append(
-                    ExtFeed(src_type, None, self.p_common[p_ind], gid))
+                    ExtFeed(feed_type=src_type,
+                            target_cell_type=None,
+                            params=self.p_common[p_ind],
+                            gid=gid))
 
                 # now use the param index in the params and create
                 # the cell and artificial NetCon
@@ -378,8 +381,10 @@ class Network(object):
                 # specified because these feeds have cell-specific parameters
                 # XXX unique_feeds is a dict of dict (comp. common_feeds)
                 self.unique_feeds[src_type].append(
-                    ExtFeed(src_type, target_cell_type,
-                            self.p_unique[src_type], gid))
+                    ExtFeed(feed_type=src_type,
+                            target_cell_type=target_cell_type,
+                            params=self.p_unique[src_type],
+                            gid=gid))
                 pc.cell(gid,
                         self.unique_feeds[src_type][-1].connect_to_target(
                             self.params['threshold']))

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -346,7 +346,7 @@ class Network(object):
                 pc.cell(gid, self.cells[-1].connect_to_target(
                         None, self.params['threshold']))
 
-            # external inputs are special types of pseudo-cells
+            # external inputs are special types of artificial-cells
             # 'common': all cells impacted with identical TIMING of spike
             # events. NB: cell types can still have different weights for how
             # such 'common' spikes influence them
@@ -358,15 +358,14 @@ class Network(object):
 
                 # new ExtFeed: target cell type irrelevant (None) since input
                 # timing will be identical for all cells
-                # XXX common_feeds is a list of dict (comp. unique_feeds)
+                # XXX common_feeds is a list of dict
                 self.common_feeds.append(
                     ExtFeed(feed_type=src_type,
                             target_cell_type=None,
                             params=self.p_common[p_ind],
                             gid=gid))
 
-                # now use the param index in the params and create
-                # the cell and artificial NetCon
+                # create the cell and artificial NetCon
                 pc.cell(gid, self.common_feeds[-1].connect_to_target(
                         self.params['threshold']))
 
@@ -379,7 +378,7 @@ class Network(object):
 
                 # new ExtFeed, where now both feed type and target cell type
                 # specified because these feeds have cell-specific parameters
-                # XXX unique_feeds is a dict of dict (comp. common_feeds)
+                # XXX unique_feeds is a dict of dict
                 self.unique_feeds[src_type].append(
                     ExtFeed(feed_type=src_type,
                             target_cell_type=target_cell_type,

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -190,17 +190,16 @@ def _feed_validate(p_ext, p_ext_d, tstop):
     ----------
     p_ext : list
         Cumulative list of dicts where each dict contains
-        all parameters of an extinput.
+        all parameters of an ExtFeed input.
     p_ext_d : dict
-        The extinput to validate and append to p_ext.
+        The parameter set to validate and append to p_ext.
     tstop : float
         Stop time of the simulation.
 
     Returns
     -------
     p_ext : list
-        Cumulative list of dicts with newly appended
-        extinput.
+        Cumulative list of dicts with newly appended ExtFeed.
     """
 
     # # reset tstop if the specified tstop exceeds the
@@ -284,13 +283,13 @@ def create_pext(p, tstop):
     p : dict
         The parameters returned by ExpParams(f_psim).return_pdict()
     """
-    p_ext = []
+    p_common = []
 
     # p_unique is a dict of input param types that end up going to each cell
     # uniquely
     p_unique = {}
 
-    # default params for proximal rhythmic inputs
+    # default params for common proximal inputs
     feed_prox = {
         'f_input': p['f_input_prox'],
         't0': p['t0_input_prox'],
@@ -323,9 +322,9 @@ def create_pext(p, tstop):
     }
 
     # ensures time interval makes sense
-    p_ext = _feed_validate(p_ext, feed_prox, tstop)
+    p_common = _feed_validate(p_common, feed_prox, tstop)
 
-    # default params for distal rhythmic inputs
+    # default params for common distal inputs
     feed_dist = {
         'f_input': p['f_input_dist'],
         't0': p['t0_input_dist'],
@@ -353,7 +352,7 @@ def create_pext(p, tstop):
         'threshold': p['threshold']
     }
 
-    p_ext = _feed_validate(p_ext, feed_dist, tstop)
+    p_common = _feed_validate(p_common, feed_dist, tstop)
 
     nprox, ndist = _count_evoked_inputs(p)
     # print('nprox,ndist evoked inputs:', nprox, ndist)
@@ -463,7 +462,7 @@ def create_pext(p, tstop):
         'threshold': p['threshold']
     }
 
-    return p_ext, p_unique
+    return p_common, p_unique
 
 
 # Takes two dictionaries (d1 and d2) and compares the keys in d1 to those in d2

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -16,7 +16,7 @@ from .params_default import get_params_default
 # filename d)
 def _count_evoked_inputs(d):
     nprox = ndist = 0
-    for k, v in d.items():
+    for k, _ in d.items():
         if k.startswith('t_'):
             if k.count('evprox') > 0:
                 nprox += 1

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -202,35 +202,37 @@ def _feed_validate(p_ext, p_ext_d, tstop):
         Cumulative list of dicts with newly appended ExtFeed.
     """
 
-    # # reset tstop if the specified tstop exceeds the
-    # # simulation runtime
-    # if p_ext_d['tstop'] == 0:
-    #     p_ext_d['tstop'] = tstop
+    # only append if t0 is less than simulation tstop
+    if tstop > p_ext_d['t0']:
+        # # reset tstop if the specified tstop exceeds the
+        # # simulation runtime
+        # if p_ext_d['tstop'] == 0:
+        #     p_ext_d['tstop'] = tstop
 
-    if p_ext_d['tstop'] > tstop:
-        p_ext_d['tstop'] = tstop
+        if p_ext_d['tstop'] > tstop:
+            p_ext_d['tstop'] = tstop
 
-    # if stdev is zero, increase synaptic weights 5 fold to make
-    # single input equivalent to 5 simultaneous input to prevent spiking
-    # <<---- SN: WHAT IS THIS RULE!?!?!?
-    if not p_ext_d['stdev'] and p_ext_d['distribution'] != 'uniform':
-        for key in p_ext_d.keys():
-            if key.endswith('Pyr'):
-                p_ext_d[key] = (p_ext_d[key][0] * 5., p_ext_d[key][1])
-            elif key.endswith('Basket'):
-                p_ext_d[key] = (p_ext_d[key][0] * 5., p_ext_d[key][1])
+        # if stdev is zero, increase synaptic weights 5 fold to make
+        # single input equivalent to 5 simultaneous input to prevent spiking
+        # <<---- SN: WHAT IS THIS RULE!?!?!?
+        if not p_ext_d['stdev'] and p_ext_d['distribution'] != 'uniform':
+            for key in p_ext_d.keys():
+                if key.endswith('Pyr'):
+                    p_ext_d[key] = (p_ext_d[key][0] * 5., p_ext_d[key][1])
+                elif key.endswith('Basket'):
+                    p_ext_d[key] = (p_ext_d[key][0] * 5., p_ext_d[key][1])
 
-    # if L5 delay is -1, use same delays as L2 unless L2 delay is 0.1 in
-    # which case use 1. <<---- SN: WHAT IS THIS RULE!?!?!?
-    if p_ext_d['L5Pyr_ampa'][1] == -1:
-        for key in p_ext_d.keys():
-            if key.startswith('L5'):
-                if p_ext_d['L2Pyr'][1] != 0.1:
-                    p_ext_d[key] = (p_ext_d[key][0], p_ext_d['L2Pyr'][1])
-                else:
-                    p_ext_d[key] = (p_ext_d[key][0], 1.)
+        # if L5 delay is -1, use same delays as L2 unless L2 delay is 0.1 in
+        # which case use 1. <<---- SN: WHAT IS THIS RULE!?!?!?
+        if p_ext_d['L5Pyr_ampa'][1] == -1:
+            for key in p_ext_d.keys():
+                if key.startswith('L5'):
+                    if p_ext_d['L2Pyr'][1] != 0.1:
+                        p_ext_d[key] = (p_ext_d[key][0], p_ext_d['L2Pyr'][1])
+                    else:
+                        p_ext_d[key] = (p_ext_d[key][0], 1.)
 
-    p_ext.append(p_ext_d)
+        p_ext.append(p_ext_d)
     return p_ext
 
 

--- a/hnn_core/pyramidal.py
+++ b/hnn_core/pyramidal.py
@@ -872,7 +872,8 @@ class L5Pyr(Pyr):
                       'L2_basket', 'L2Basket', lamtha=50.,
                       postsyns=[self.apicaltuft_gabaa])
 
-    # receive from external inputs
+    # receive from common inputs
+    # XXX check NetCon connections for proximal inputs with zero weights
     def parreceive(self, gid, gid_dict, pos_dict, p_ext):
         for gid_src, p_src, pos in zip(gid_dict['common'],
                                        p_ext, pos_dict['common']):

--- a/hnn_core/pyramidal.py
+++ b/hnn_core/pyramidal.py
@@ -428,8 +428,8 @@ class L2Pyr(Pyr):
     # may be reorganizable
     def parreceive(self, gid, gid_dict, pos_dict, p_ext):
         """Connect cell."""
-        for gid_src, p_src, pos in zip(gid_dict['extinput'], p_ext,
-                                       pos_dict['extinput']):
+        for gid_src, p_src, pos in zip(gid_dict['common'], p_ext,
+                                       pos_dict['common']):
             # Check if AMPA params defined in p_src
             if 'L2Pyr_ampa' in p_src.keys():
                 nc_dict_ampa = {
@@ -443,15 +443,15 @@ class L2Pyr(Pyr):
 
                 # Proximal feed AMPA synapses
                 if p_src['loc'] == 'proximal':
-                    self.ncfrom_extinput.append(self.parconnect_from_src(
+                    self.ncfrom_common.append(self.parconnect_from_src(
                         gid_src, nc_dict_ampa, self.basal2_ampa))
-                    self.ncfrom_extinput.append(self.parconnect_from_src(
+                    self.ncfrom_common.append(self.parconnect_from_src(
                         gid_src, nc_dict_ampa, self.basal3_ampa))
-                    self.ncfrom_extinput.append(self.parconnect_from_src(
+                    self.ncfrom_common.append(self.parconnect_from_src(
                         gid_src, nc_dict_ampa, self.apicaloblique_ampa))
                 # Distal feed AMPA synapses
                 elif p_src['loc'] == 'distal':
-                    self.ncfrom_extinput.append(self.parconnect_from_src(
+                    self.ncfrom_common.append(self.parconnect_from_src(
                         gid_src, nc_dict_ampa, self.apicaltuft_ampa))
 
             # Check is NMDA params defined in p_src
@@ -467,15 +467,15 @@ class L2Pyr(Pyr):
 
                 # Proximal feed NMDA synapses
                 if p_src['loc'] == 'proximal':
-                    self.ncfrom_extinput.append(self.parconnect_from_src(
+                    self.ncfrom_common.append(self.parconnect_from_src(
                         gid_src, nc_dict_nmda, self.basal2_nmda))
-                    self.ncfrom_extinput.append(self.parconnect_from_src(
+                    self.ncfrom_common.append(self.parconnect_from_src(
                         gid_src, nc_dict_nmda, self.basal3_nmda))
-                    self.ncfrom_extinput.append(self.parconnect_from_src(
+                    self.ncfrom_common.append(self.parconnect_from_src(
                         gid_src, nc_dict_nmda, self.apicaloblique_nmda))
                 # Distal feed NMDA synapses
                 elif p_src['loc'] == 'distal':
-                    self.ncfrom_extinput.append(self.parconnect_from_src(
+                    self.ncfrom_common.append(self.parconnect_from_src(
                         gid_src, nc_dict_nmda, self.apicaltuft_nmda))
 
     # one parreceive function to handle all types of external parreceives
@@ -874,8 +874,8 @@ class L5Pyr(Pyr):
 
     # receive from external inputs
     def parreceive(self, gid, gid_dict, pos_dict, p_ext):
-        for gid_src, p_src, pos in zip(gid_dict['extinput'],
-                                       p_ext, pos_dict['extinput']):
+        for gid_src, p_src, pos in zip(gid_dict['common'],
+                                       p_ext, pos_dict['common']):
             # Check if AMPA params defined in p_src
             if 'L5Pyr_ampa' in p_src.keys():
                 nc_dict_ampa = {
@@ -890,19 +890,19 @@ class L5Pyr(Pyr):
                 # Proximal feed AMPA synapses
                 if p_src['loc'] == 'proximal':
                     # basal2_ampa, basal3_ampa, apicaloblique_ampa
-                    self.ncfrom_extinput.append(
+                    self.ncfrom_common.append(
                         self.parconnect_from_src(gid_src, nc_dict_ampa,
                                                  self.basal2_ampa))
-                    self.ncfrom_extinput.append(
+                    self.ncfrom_common.append(
                         self.parconnect_from_src(gid_src, nc_dict_ampa,
                                                  self.basal3_ampa))
-                    self.ncfrom_extinput.append(
+                    self.ncfrom_common.append(
                         self.parconnect_from_src(gid_src, nc_dict_ampa,
                                                  self.apicaloblique_ampa))
                 # Distal feed AMPA synsapes
                 elif p_src['loc'] == 'distal':
                     # apical tuft
-                    self.ncfrom_extinput.append(
+                    self.ncfrom_common.append(
                         self.parconnect_from_src(gid_src, nc_dict_ampa,
                                                  self.apicaltuft_ampa))
 
@@ -920,19 +920,19 @@ class L5Pyr(Pyr):
                 # Proximal feed NMDA synapses
                 if p_src['loc'] == 'proximal':
                     # basal2_nmda, basal3_nmda, apicaloblique_nmda
-                    self.ncfrom_extinput.append(
+                    self.ncfrom_common.append(
                         self.parconnect_from_src(
                             gid_src, nc_dict_nmda, self.basal2_nmda))
-                    self.ncfrom_extinput.append(
+                    self.ncfrom_common.append(
                         self.parconnect_from_src(
                             gid_src, nc_dict_nmda, self.basal3_nmda))
-                    self.ncfrom_extinput.append(
+                    self.ncfrom_common.append(
                         self.parconnect_from_src(
                             gid_src, nc_dict_nmda, self.apicaloblique_nmda))
                 # Distal feed NMDA synsapes
                 elif p_src['loc'] == 'distal':
                     # apical tuft
-                    self.ncfrom_extinput.append(
+                    self.ncfrom_common.append(
                         self.parconnect_from_src(
                             gid_src, nc_dict_nmda, self.apicaltuft_nmda))
 

--- a/hnn_core/tests/test_compare_hnn.py
+++ b/hnn_core/tests/test_compare_hnn.py
@@ -41,7 +41,7 @@ def test_hnn_core():
             spiketype_counts[net.gid_to_type(spikegid)] = 0
         else:
             spiketype_counts[net.gid_to_type(spikegid)] += 1
-    assert 'extinput' not in spiketype_counts
+    assert 'common' not in spiketype_counts
     assert 'exgauss' not in spiketype_counts
     assert 'extpois' not in spiketype_counts
     assert spiketype_counts == {'evprox1': 269,

--- a/hnn_core/tests/test_feed.py
+++ b/hnn_core/tests/test_feed.py
@@ -25,13 +25,15 @@ def test_extfeed():
     pytest.raises(ValueError, ExtFeed,
                   'ev', None, p_bogus, 0)  # ambiguous
 
+    # XXX 'unique' external feeds are always created; why?
     for feed_type in ['extpois', 'extgauss']:
         feed = ExtFeed(feed_type=feed_type,
                        target_cell_type='L2_basket',
                        params=p_unique[feed_type],
                        gid=0)
         print(feed)  # test repr
-    for ii in range(2):  # distal and proximal
+    # XXX but 'common' (rhythmic) feeds are not
+    for ii in range(len(p_common)):  # len == 0 for def. params
         feed = ExtFeed(feed_type='common',
                        target_cell_type=None,
                        params=p_common[ii],
@@ -68,7 +70,7 @@ def test_external_common_feeds():
             assert len(ei.nrn_eventvec.as_numpy()) > 0
 
             # check that ei.p_ext matches params
-            loc = ei.p_ext['loc'][:4]  # loc=prox or dist
+            loc = ei.params['loc'][:4]  # loc=prox or dist
             for layer in ['L2', 'L5']:
                 key = 'input_{}_A_weight_{}Pyr_ampa'.format(loc, layer)
-                assert ei.p_ext[layer + 'Pyr_ampa'][0] == params[key]
+                assert ei.params[layer + 'Pyr_ampa'][0] == params[key]

--- a/hnn_core/tests/test_feed.py
+++ b/hnn_core/tests/test_feed.py
@@ -3,6 +3,7 @@
 
 from copy import deepcopy
 import os.path as op
+import pytest
 
 import hnn_core
 from hnn_core import read_params, Network, Params
@@ -10,27 +11,35 @@ from hnn_core.feed import ExtFeed
 from hnn_core.params import create_pext
 
 
-def test_ExtFeed_object():
+def test_extfeed():
     """Test the different external feeds."""
 
     params = Params()
     p_common, p_unique = create_pext(params,
                                      params['tstop'])
+
+    # feed name must be valid and unambiguous
+    p_bogus = {'prng_seedcore': 0}
+    pytest.raises(ValueError, ExtFeed,
+                  'invalid_feed', None, p_bogus, 0)
+    pytest.raises(ValueError, ExtFeed,
+                  'ev', None, p_bogus, 0)  # ambiguous
+
     for feed_type in ['extpois', 'extgauss']:
-        ef = ExtFeed(feed_type, 'L2_basket', p_unique[feed_type], 0)
-        print(ef)  # test repr
+        feed = ExtFeed(feed_type, 'L2_basket', p_unique[feed_type], 0)
+        print(feed)  # test repr
     for ii in range(2):  # distal and proximal
-        ef = ExtFeed('common', None, p_common[ii], 0) 
-        print(ef)  # test repr
+        feed = ExtFeed('common', None, p_common[ii], 0)
+        print(feed)  # test repr
 
 
-def test_external_rhythmic_feeds():
-    """Test external rhythmic feeds to proximal and distal dendrites."""
+def test_external_common_feeds():
+    """Test external common feeds to proximal and distal dendrites."""
     hnn_core_root = op.join(op.dirname(hnn_core.__file__), '..')
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
 
-    # default parameters have no rhythmic inputs (distal or proximal),
+    # default parameters have no common inputs (distal or proximal),
     params.update({'input_dist_A_weight_L2Pyr_ampa': 5.4e-5,
                    'input_dist_A_weight_L5Pyr_ampa': 5.4e-5,
                    't0_input_dist': 50,
@@ -41,16 +50,16 @@ def test_external_rhythmic_feeds():
     with Network(deepcopy(params)) as net:
         net._create_all_src()
 
-        assert len(net.common_feed_list) == 2  # (distal & proximal)
-        for ei in net.common_feed_list:
+        assert len(net.common_feeds) == 2  # (distal & proximal)
+        for ei in net.common_feeds:
             assert ei.feed_type == 'common'
             assert ei.cell_type is None  # artificial cell
-            assert hasattr(ei, 'nrn_EventVec')
-            assert hasattr(ei, 'nrn_VecStim')
-            assert ei.nrn_EventVec.hname().startswith('Vector')
-            assert hasattr(ei.nrn_VecStim, 'play')
+            assert hasattr(ei, 'nrn_eventvec')
+            assert hasattr(ei, 'nrn_vecstim')
+            assert ei.nrn_eventvec.hname().startswith('Vector')
+            assert hasattr(ei.nrn_vecstim, 'play')
             # parameters should lead to > 0 input spikes
-            assert len(ei.nrn_EventVec.as_numpy()) > 0
+            assert len(ei.nrn_eventvec.as_numpy()) > 0
 
             # check that ei.p_ext matches params
             loc = ei.p_ext['loc'][:4]  # loc=prox or dist

--- a/hnn_core/tests/test_feed.py
+++ b/hnn_core/tests/test_feed.py
@@ -48,7 +48,7 @@ def test_external_common_feeds():
                    't0_input_prox': 50})
 
     with Network(deepcopy(params)) as net:
-        net._create_all_src()
+        net._create_all_spike_sources()
 
         assert len(net.common_feeds) == 2  # (distal & proximal)
         for ei in net.common_feeds:

--- a/hnn_core/tests/test_feed.py
+++ b/hnn_core/tests/test_feed.py
@@ -26,10 +26,16 @@ def test_extfeed():
                   'ev', None, p_bogus, 0)  # ambiguous
 
     for feed_type in ['extpois', 'extgauss']:
-        feed = ExtFeed(feed_type, 'L2_basket', p_unique[feed_type], 0)
+        feed = ExtFeed(feed_type=feed_type,
+                       target_cell_type='L2_basket',
+                       params=p_unique[feed_type],
+                       gid=0)
         print(feed)  # test repr
     for ii in range(2):  # distal and proximal
-        feed = ExtFeed('common', None, p_common[ii], 0)
+        feed = ExtFeed(feed_type='common',
+                       target_cell_type=None,
+                       params=p_common[ii],
+                       gid=0)
         print(feed)  # test repr
 
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -22,7 +22,7 @@ def test_network():
     print(net.cells[:2])
 
     # Assert that proper number of gids are created for Network inputs
-    assert len(net.gid_dict['extinput']) == 2
+    assert len(net.gid_dict['common']) == 2
     assert len(net.gid_dict['extgauss']) == net.N_cells
     assert len(net.gid_dict['extpois']) == net.N_cells
     for ev_input in params['t_ev*']:

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -22,7 +22,7 @@ def test_network():
     print(net.cells[:2])
 
     # Assert that proper number of gids are created for Network inputs
-    assert len(net.gid_dict['common']) == 2
+    assert len(net.gid_dict['common']) == 0
     assert len(net.gid_dict['extgauss']) == net.n_cells
     assert len(net.gid_dict['extpois']) == net.n_cells
     for ev_input in params['t_ev*']:

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -23,8 +23,8 @@ def test_network():
 
     # Assert that proper number of gids are created for Network inputs
     assert len(net.gid_dict['common']) == 2
-    assert len(net.gid_dict['extgauss']) == net.N_cells
-    assert len(net.gid_dict['extpois']) == net.N_cells
+    assert len(net.gid_dict['extgauss']) == net.n_cells
+    assert len(net.gid_dict['extpois']) == net.n_cells
     for ev_input in params['t_ev*']:
         type_key = ev_input[2: -2] + ev_input[-1]
-        assert len(net.gid_dict[type_key]) == net.N_cells
+        assert len(net.gid_dict[type_key]) == net.n_cells

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -12,16 +12,27 @@ from hnn_core import read_params, Params
 hnn_core_root = op.join(op.dirname(hnn_core.__file__), '..')
 
 
-def test_params():
-    """Test params object."""
+def test_read_params():
+    """Test reading of params object."""
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
     print(params)
     print(params['L2Pyr*'])
 
+    # unsupported extension
+    pytest.raises(ValueError, read_params, 'params.txt')
+    # empty file
+    empty_fname = op.join(hnn_core_root, 'param', 'empty.json')
+    with open(empty_fname, 'w') as json_data:
+        json.dump({}, json_data)
+    pytest.raises(ValueError, read_params, empty_fname)
+    # non dict type
+    pytest.raises(ValueError, Params, [])
+    pytest.raises(ValueError, Params, 'sdfdfdf')
 
-def test_legacy_params():
-    """Test reading legacy .param file."""
+
+def test_read_legacy_params():
+    """Test reading of legacy .param file."""
     param_url = ('https://raw.githubusercontent.com/hnnsolver/'
                  'hnn-core/test_data/default.param')
     params_legacy_fname = op.join(hnn_core_root, 'param', 'default.param')
@@ -36,7 +47,7 @@ def test_legacy_params():
 
 
 def test_base_params():
-    """Test params object with base params"""
+    """Test default params object matches base params"""
     param_url = ('https://raw.githubusercontent.com/jonescompneurolab/'
                  'hnn-core/test_data/base.json')
     params_base_fname = op.join(hnn_core_root, 'param', 'base.json')
@@ -46,14 +57,3 @@ def test_base_params():
     params_base = read_params(params_base_fname)
     params = Params()
     assert params == params_base
-
-    # unsupported extension
-    pytest.raises(ValueError, read_params, 'params.txt')
-    # empty file
-    empty_fname = op.join(hnn_core_root, 'param', 'empty.json')
-    with open(empty_fname, 'w') as json_data:
-        json.dump({}, json_data)
-    pytest.raises(ValueError, read_params, empty_fname)
-    # non dict type
-    pytest.raises(ValueError, Params, [])
-    pytest.raises(ValueError, Params, 'sdfdfdf')


### PR DESCRIPTION
This PR is an attempt to clarify the code in terms of "external inputs" a.k.a. "external feeds". A lot of the diff is cosmetic, _e.g._, variable name changes. New tests and validations are also included.

One key point is renaming `extinput` to `common`. Our instinct was to go for `rhythmic`, as that's the only thing these are [currently used for](https://jonescompneurolab.github.io/hnn-tutorials/alpha_and_beta/alpha_and_beta). However, the input mechanism is completely generic and could in principle support non-rhythmic inputs as well (_e.g._, Poisson bursts?).

The parameter handling of "common" and "unique" external feeds is still a little opaque in the code, but this should clarify. A future refactor/PR could remove the `ExtFeed` class (and parameter dicts) in favour of functions with signatures that clearly specify what parameters it expects: e.g., t_start, t_std, freq etc