### PR TITLE
[MRG] ENH: plot_input() accepts flexible spike_types argument

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -55,7 +55,7 @@ Visualization (:py:mod:`hnn_core.viz`):
    :toctree: generated/
 
    plot_dipole
-   plot_hist_input
+   plot_spikes_hist
    plot_spikes_raster
    plot_cells
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,6 +27,8 @@ Changelog
 
 - Modify plot_dipole() to accept both lists and individual instances of Dipole object, by `Nick Tolley`_ in `#145 <https://github.com/jonescompneurolab/hnn-core/pull/145>`_
 
+- Update plot_hist_input() to plot_hist() with a flexibly defined spike_types argument, by `Nick Tolley`_ in `#157 <https://github.com/jonescompneurolab/hnn-core/pull/157>`_
+
 Bug
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,7 +27,7 @@ Changelog
 
 - Modify plot_dipole() to accept both lists and individual instances of Dipole object, by `Nick Tolley`_ in `#145 <https://github.com/jonescompneurolab/hnn-core/pull/145>`_
 
-- Update plot_hist_input() to plot_hist() with a flexibly defined spike_types argument, by `Nick Tolley`_ in `#157 <https://github.com/jonescompneurolab/hnn-core/pull/157>`_
+- Update plot_hist_input() to plot_spikes_hist() which can plot histogram of spikes for any cell type, by `Nick Tolley`_ in `#157 <https://github.com/jonescompneurolab/hnn-core/pull/157>`_
 
 Bug
 ~~~

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -53,7 +53,7 @@ with JoblibBackend(n_jobs=1):
 import matplotlib.pyplot as plt
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 plot_dipole(dpls, ax=axes[0], layer='agg', show=False)
-net.spikes.plot_input(ax=axes[1], spike_types=['evprox', 'evdist'])
+net.spikes.plot_hist(ax=axes[1], spike_types=['evprox', 'evdist'])
 
 ###############################################################################
 # Also, we can plot the spikes and write them to txt files.
@@ -84,4 +84,4 @@ with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
     dpls_sync = simulate_dipole(net_sync, n_trials=1)
 
 dpls_sync[0].plot()
-net_sync.spikes.plot_input()
+net_sync.spikes.plot_hist()

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -53,7 +53,7 @@ with JoblibBackend(n_jobs=1):
 import matplotlib.pyplot as plt
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 plot_dipole(dpls, ax=axes[0], layer='agg', show=False)
-net.spikes.plot_input(ax=axes[1])
+net.spikes.plot_input(ax=axes[1], spike_types=['evprox', 'evdist'])
 
 ###############################################################################
 # Also, we can plot the spikes and write them to txt files.

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -53,7 +53,7 @@ with JoblibBackend(n_jobs=1):
 import matplotlib.pyplot as plt
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 plot_dipole(dpls, ax=axes[0], layer='agg', show=False)
-net.plot_input(ax=axes[1])
+net.spikes.plot_input(ax=axes[1])
 
 ###############################################################################
 # Also, we can plot the spikes and write them to txt files.
@@ -84,4 +84,4 @@ with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
     dpls_sync = simulate_dipole(net_sync, n_trials=1)
 
 dpls_sync[0].plot()
-net_sync.plot_input()
+net_sync.spikes.plot_input()

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -82,5 +82,5 @@ dpl = simulate_dipole(net, n_trials=1)
 import matplotlib.pyplot as plt
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 dpl[0].plot(ax=axes[0], show=False)
-net.plot_input(ax=axes[1])
+net.spikes.plot_input(ax=axes[1])
 net.spikes.plot()

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -82,5 +82,5 @@ dpl = simulate_dipole(net, n_trials=1)
 import matplotlib.pyplot as plt
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 dpl[0].plot(ax=axes[0], show=False)
-net.spikes.plot_input(ax=axes[1])
+net.spikes.plot_hist(ax=axes[1])
 net.spikes.plot()

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -484,7 +484,7 @@ class Spikes(object):
             If None, all default spike types are plotted individually.
                 Default: ['common', 'evdist', 'evprox', 'extgauss', 'extpois']
             Valid strings also include leading characters of spike types
-                    Example: 'ext' is equivalent to ['extgauss', 'extpois']
+                Example: 'ext' is equivalent to ['extgauss', 'extpois']
         show : bool
             If True, show the figure.
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -9,7 +9,7 @@ import numpy as np
 from glob import glob
 
 from .params import create_pext
-from .viz import plot_hist_input, plot_spikes_raster, plot_cells
+from .viz import plot_hist, plot_spikes_raster, plot_cells
 
 
 def read_spikes(fname, gid_dict=None):
@@ -466,8 +466,8 @@ class Spikes(object):
         """
         return plot_spikes_raster(spikes=self, ax=ax, show=show)
 
-    def plot_input(self, ax=None, spike_types=None, show=True):
-        """Plot the histogram of input.
+    def plot_hist(self, ax=None, spike_types=None, show=True):
+        """Plot the histogram of spiking activity.
 
         Parameters
         ----------
@@ -481,8 +481,7 @@ class Spikes(object):
                 Ex: ['common', 'evdist']
             Dictionary of valid lists will plot list elements as a group.
                 Ex: {'Evoked': ['evdist', 'evprox'], 'External': ['extpois']}
-            If None, all default spike types are plotted individually.
-                Default: ['common', 'evdist', 'evprox', 'extgauss', 'extpois']
+            If None, all input spike types are plotted individually.
             Valid strings also include leading characters of spike types
                 Example: 'ext' is equivalent to ['extgauss', 'extpois']
         show : bool
@@ -493,7 +492,7 @@ class Spikes(object):
         fig : instance of matplotlib Figure
             The matplotlib figure handle.
         """
-        return plot_hist_input(
+        return plot_hist(
             self, ax=ax, spike_types=spike_types, show=show)
 
     def write(self, fname):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -9,7 +9,7 @@ import numpy as np
 from glob import glob
 
 from .params import create_pext
-from .viz import plot_hist, plot_spikes_raster, plot_cells
+from .viz import plot_spikes_hist, plot_spikes_raster, plot_cells
 
 
 def read_spikes(fname, gid_dict=None):
@@ -481,7 +481,8 @@ class Spikes(object):
                 Ex: ['common', 'evdist']
             Dictionary of valid lists will plot list elements as a group.
                 Ex: {'Evoked': ['evdist', 'evprox'], 'External': ['extpois']}
-            If None, all input spike types are plotted individually.
+            If None, all input spike types are plotted individually if any
+            are present. Otherwise spikes from all cells are plotted.
             Valid strings also include leading characters of spike types
                 Example: 'ext' is equivalent to ['extgauss', 'extpois']
         show : bool
@@ -492,7 +493,7 @@ class Spikes(object):
         fig : instance of matplotlib Figure
             The matplotlib figure handle.
         """
-        return plot_hist(
+        return plot_spikes_hist(
             self, ax=ax, spike_types=spike_types, show=show)
 
     def write(self, fname):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -328,7 +328,7 @@ class Network(object):
         fig : instance of matplotlib Figure
             The matplotlib figure handle.
         """
-        return plot_hist_input(spikes=self.spikes, ax=ax, show=show)
+        return self.spikes.plot_input()
 
 
 class Spikes(object):
@@ -484,7 +484,7 @@ class Spikes(object):
         """
         return plot_spikes_raster(spikes=self, ax=ax, show=show)
 
-    def plot_input(self, ax=None, show=True):
+    def plot_input(self, ax=None, spike_types=None, show=True):
         """Plot the histogram of input.
 
         Parameters
@@ -500,7 +500,8 @@ class Spikes(object):
         fig : instance of matplotlib Figure
             The matplotlib figure handle.
         """
-        return plot_hist_input(spikes=self, ax=ax, show=show)
+        return plot_hist_input(
+            self, ax=None, spike_types=spike_types, show=True)
 
     def write(self, fname):
         """Write spiking activity per trial to a collection of files.

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -467,7 +467,7 @@ class Spikes(object):
         return plot_spikes_raster(spikes=self, ax=ax, show=show)
 
     def plot_hist(self, ax=None, spike_types=None, show=True):
-        """Plot the histogram of spiking activity.
+        """Plot the histogram of spiking activity across trials.
 
         Parameters
         ----------

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -494,7 +494,7 @@ class Spikes(object):
             The matplotlib figure handle.
         """
         return plot_hist_input(
-            self, ax=None, spike_types=spike_types, show=True)
+            self, ax=ax, spike_types=spike_types, show=show)
 
     def write(self, fname):
         """Write spiking activity per trial to a collection of files.

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -328,7 +328,7 @@ class Network(object):
         fig : instance of matplotlib Figure
             The matplotlib figure handle.
         """
-        return plot_hist_input(net=self, ax=ax, show=show)
+        return plot_hist_input(spikes=self.spikes, ax=ax, show=show)
 
 
 class Spikes(object):
@@ -483,6 +483,24 @@ class Spikes(object):
             The matplotlib figure object.
         """
         return plot_spikes_raster(spikes=self, ax=ax, show=show)
+
+    def plot_input(self, ax=None, show=True):
+        """Plot the histogram of input.
+
+        Parameters
+        ----------
+        ax : instance of matplotlib axis | None
+            An axis object from matplotlib. If None,
+            a new figure is created.
+        show : bool
+            If True, show the figure.
+
+        Returns
+        -------
+        fig : instance of matplotlib Figure
+            The matplotlib figure handle.
+        """
+        return plot_hist_input(spikes=self, ax=ax, show=show)
 
     def write(self, fname):
         """Write spiking activity per trial to a collection of files.

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -312,24 +312,6 @@ class Network(object):
         """
         return plot_cells(net=self, ax=ax, show=show)
 
-    def plot_input(self, ax=None, show=True):
-        """Plot the histogram of input.
-
-        Parameters
-        ----------
-        ax : instance of matplotlib axis | None
-            An axis object from matplotlib. If None,
-            a new figure is created.
-        show : bool
-            If True, show the figure.
-
-        Returns
-        -------
-        fig : instance of matplotlib Figure
-            The matplotlib figure handle.
-        """
-        return self.spikes.plot_input()
-
 
 class Spikes(object):
     """The Spikes class.
@@ -492,6 +474,17 @@ class Spikes(object):
         ax : instance of matplotlib axis | None
             An axis object from matplotlib. If None,
             a new figure is created.
+        spike_types: string | list | dictionary | None
+            String input of a valid spike type is plotted individually.
+                Ex: 'common', 'evdist', 'evprox', 'extgauss', 'extpois'
+            List of valid string inputs will plot each spike type individually.
+                Ex: ['common', 'evdist']
+            Dictionary of valid lists will plot list elements as a group.
+                Ex: {'Evoked': ['evdist', 'evprox'], 'External': ['extpois']}
+            If None, all default spike types are plotted individually.
+                Default: ['common', 'evdist', 'evprox', 'extgauss', 'extpois']
+            Valid strings also include leading characters of spike types
+                    Example: 'ext' is equivalent to ['extgauss', 'extpois']
         show : bool
             If True, show the figure.
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -63,6 +63,7 @@ def test_spikes():
     spikegids = [[1, 3], [5, 7]]
     spiketypes = [['L2_pyramidal', 'L2_basket'], ['L5_pyramidal', 'L5_basket']]
     spikes = Spikes(times=spiketimes, gids=spikegids, types=spiketypes)
+    spikes.plot_input(show=False)
     spikes.write('/tmp/spk_%d.txt')
     assert spikes == read_spikes('/tmp/spk_*.txt')
     assert ("Spikes | 2 simulation trials" in repr(spikes))

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -79,6 +79,9 @@ def test_spikes():
                        "lists of the same length"):
         spikes = Spikes(times=[[2.3456, 7.89]], gids=spikegids,
                         types=spiketypes)
+    with pytest.raises(TypeError, match="spike_types should be str, "
+                                        "list, dict, or None"):
+        spikes.plot_input(spike_types=1)
 
     # Write spike file with no 'types' column
     # Check for gid_dict errors

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -63,7 +63,7 @@ def test_spikes():
     spikegids = [[1, 3], [5, 7]]
     spiketypes = [['L2_pyramidal', 'L2_basket'], ['L5_pyramidal', 'L5_basket']]
     spikes = Spikes(times=spiketimes, gids=spikegids, types=spiketypes)
-    spikes.plot_input(show=False)
+    spikes.plot_hist(show=False)
     spikes.write('/tmp/spk_%d.txt')
     assert spikes == read_spikes('/tmp/spk_*.txt')
     assert ("Spikes | 2 simulation trials" in repr(spikes))
@@ -79,9 +79,22 @@ def test_spikes():
                        "lists of the same length"):
         spikes = Spikes(times=[[2.3456, 7.89]], gids=spikegids,
                         types=spiketypes)
+
     with pytest.raises(TypeError, match="spike_types should be str, "
                                         "list, dict, or None"):
-        spikes.plot_input(spike_types=1)
+        spikes.plot_hist(spike_types=1, show=False)
+
+    with pytest.raises(TypeError, match=r"spike_types\[ev\] must be a list\. "
+                                        r"Got int\."):
+        spikes.plot_hist(spike_types={'ev': 1}, show=False)
+
+    with pytest.raises(ValueError, match=r"Elements of spike_types must map to"
+                       r" mutually exclusive input types\. L2_basket is found"
+                       r" more than once\."):
+        spikes.plot_hist(spike_types={'ev': ['L2_basket', 'L2_b']}, show=False)
+
+    with pytest.raises(ValueError, match="No input types found for ABC"):
+        spikes.plot_hist(spike_types='ABC', show=False)
 
     # Write spike file with no 'types' column
     # Check for gid_dict errors

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -68,7 +68,7 @@ def plot_hist_input(spikes, ax=None, spike_types=None, show=True):
         If None, all default spike types are plotted individually.
             Default: ['common', 'evdist', 'evprox', 'extgauss', 'extpois']
         Valid strings also include leading characters of spike types
-                Example: 'ext' is equivalent to ['extgauss', 'extpois']
+            Example: 'ext' is equivalent to ['extgauss', 'extpois']
     show : bool
         If True, show the figure.
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -96,8 +96,9 @@ def plot_hist_input(spikes, ax=None, spike_types=None, show=True):
     if isinstance(spike_types, dict):
         for spike_label in spike_types:
             if not isinstance(spike_types[spike_label], list):
-                raise TypeError(f'spike_types[{spike_label}] must be a list'
-                                f'Got {type(spike_types[spike_label])}')
+                raise TypeError(f'spike_types[{spike_label}] must be a list. '
+                                f'Got '
+                                f'{type(spike_types[spike_label]).__name__}.')
 
     if not isinstance(spike_types, dict):
         raise TypeError('spike_types should be str, list, dict, or None')

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -48,7 +48,7 @@ def plot_dipole(dpl, ax=None, layer='agg', show=True):
     return ax.get_figure()
 
 
-def plot_hist(spikes, ax=None, spike_types=None, show=True):
+def plot_spikes_hist(spikes, ax=None, spike_types=None, show=True):
     """Plot the histogram of spiking activity.
 
     Parameters
@@ -65,7 +65,8 @@ def plot_hist(spikes, ax=None, spike_types=None, show=True):
             Ex: ['common', 'evdist']
         Dictionary of valid lists will plot list elements as a group.
             Ex: {'Evoked': ['evdist', 'evprox'], 'External': ['extpois']}
-        If None, all input spike types are plotted individually.
+        If None, all input spike types are plotted individually if any
+        are present. Otherwise spikes from all cells are plotted.
         Valid strings also include leading characters of spike types
             Example: 'ext' is equivalent to ['extgauss', 'extpois']
     show : bool

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -4,6 +4,7 @@
 #          Sam Neymotin <samnemo@gmail.com>
 
 import numpy as np
+from cycler import cycler
 
 
 def plot_dipole(dpl, ax=None, layer='agg', show=True):
@@ -103,6 +104,9 @@ def plot_hist_input(spikes, ax=None, spike_types=None, show=True):
 
     if ax is None:
         fig, ax = plt.subplots(1, 1)
+
+    color_cycle = cycler('color', ['r', 'g', 'b', 'y', 'm', 'c'])
+    plt.rcParams["axes.prop_cycle"] = color_cycle
 
     for (s_key, s_mask) in spike_mask.items():
         if np.any(s_mask):

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -116,7 +116,7 @@ def plot_hist(spikes, ax=None, spike_types=None, show=True):
                         raise ValueError(f'Elements of spike_types must map to'
                                          f' mutually exclusive input types.'
                                          f' {unique_type} is found more than'
-                                         f' once')
+                                         f' once.')
                     spike_labels[unique_type] = spike_label
                     n_found += 1
             if n_found == 0:

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -92,15 +92,20 @@ def plot_hist_input(spikes, ax=None, spike_types=None, show=True):
         spike_types = {s_type: [s_type] for s_type in spike_types}
     elif spike_types is None:
         spike_types = {s_type: [s_type] for s_type in default_types}
-    else:
+    elif not isinstance(spike_types, dict):
         raise ValueError('Invalid spike_types input.')
 
-    spike_mask = {s_label: np.logical_or.reduce(
-        np.logical_or.reduce([
-            [s_mask for (s_key, s_mask) in spike_types_mask.items()
-                if s_key.startswith(s_type)]
-            for s_type in s_list]))
-        for (s_label, s_list) in spike_types.items()}
+    spike_mask = {}
+    for (s_label, s_list) in spike_types.items():
+        s_label_mask = []
+        for s_type in s_list:
+            s_mask_list = []
+            for (s_key, s_mask) in spike_types_mask.items():
+                if s_key.startswith(s_type):
+                    s_mask_list.append(s_mask)
+            s_mask_list = np.logical_or.reduce(s_mask_list)
+            s_label_mask.append(s_mask_list)
+        spike_mask[s_label] = np.logical_or.reduce(s_label_mask)
 
     bins = np.linspace(0, spike_times[-1], 50)
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -49,7 +49,7 @@ def plot_dipole(dpl, ax=None, layer='agg', show=True):
 
 
 def plot_spikes_hist(spikes, ax=None, spike_types=None, show=True):
-    """Plot the histogram of spiking activity.
+    """Plot the histogram of spiking activity across trials.
 
     Parameters
     ----------
@@ -130,14 +130,14 @@ def plot_spikes_hist(spikes, ax=None, spike_types=None, show=True):
 
     bins = np.linspace(0, spike_times[-1], 50)
     spike_color = dict()
-    for input_type, spike_label in spike_labels.items():
+    for spike_type, spike_label in spike_labels.items():
         label = "_nolegend_"
         if spike_label not in spike_color:
             spike_color[spike_label] = next(color_cycle)
             label = spike_label
 
         color = spike_color[spike_label]
-        ax.hist(spike_times[spike_types_mask[input_type]], bins,
+        ax.hist(spike_times[spike_types_mask[spike_type]], bins,
                 label=label, color=color)
     plt.legend()
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -86,12 +86,14 @@ def plot_hist_input(spikes, ax=None, spike_types=None, show=True):
     spike_types_mask = {s_type: np.in1d(spike_types_data, s_type)
                         for s_type in input_types}
 
-    if type(spike_types) is str:
+    if isinstance(spike_types, str):
         spike_types = {spike_types: [spike_types]}
-    elif type(spike_types) is list:
+    elif isinstance(spike_types, list):
         spike_types = {s_type: [s_type] for s_type in spike_types}
     elif spike_types is None:
         spike_types = {s_type: [s_type] for s_type in default_types}
+    else:
+        raise ValueError('Invalid spike_types input.')
 
     spike_mask = {s_label: np.logical_or.reduce(
         np.logical_or.reduce([

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -65,7 +65,7 @@ def plot_hist(spikes, ax=None, spike_types=None, show=True):
             Ex: ['common', 'evdist']
         Dictionary of valid lists will plot list elements as a group.
             Ex: {'Evoked': ['evdist', 'evprox'], 'External': ['extpois']}
-        If None, all input spike types are plotted individually. 
+        If None, all input spike types are plotted individually.
         Valid strings also include leading characters of spike types
             Example: 'ext' is equivalent to ['extgauss', 'extpois']
     show : bool

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -48,8 +48,8 @@ def plot_dipole(dpl, ax=None, layer='agg', show=True):
     return ax.get_figure()
 
 
-def plot_hist_input(spikes, ax=None, spike_types=None, show=True):
-    """Plot the histogram of input.
+def plot_hist(spikes, ax=None, spike_types=None, show=True):
+    """Plot the histogram of spiking activity.
 
     Parameters
     ----------
@@ -65,8 +65,7 @@ def plot_hist_input(spikes, ax=None, spike_types=None, show=True):
             Ex: ['common', 'evdist']
         Dictionary of valid lists will plot list elements as a group.
             Ex: {'Evoked': ['evdist', 'evprox'], 'External': ['extpois']}
-        If None, all default spike types are plotted individually.
-            Default: ['common', 'evdist', 'evprox', 'extgauss', 'extpois']
+        If None, all input spike types are plotted individually. 
         Valid strings also include leading characters of spike types
             Example: 'ext' is equivalent to ['extgauss', 'extpois']
     show : bool
@@ -81,16 +80,20 @@ def plot_hist_input(spikes, ax=None, spike_types=None, show=True):
     spike_times = np.array(sum(spikes._times, []))
     spike_types_data = np.array(sum(spikes._types, []))
 
-    cell_types = ['L5_pyramidal', 'L5_basket', 'L2_pyramidal', 'L2_basket']
-    input_types = np.setdiff1d(np.unique(spike_types_data), cell_types)
+    unique_types = np.unique(spike_types_data)
     spike_types_mask = {s_type: np.in1d(spike_types_data, s_type)
-                        for s_type in input_types}
+                        for s_type in unique_types}
+    cell_types = ['L5_pyramidal', 'L5_basket', 'L2_pyramidal', 'L2_basket']
+    input_types = np.setdiff1d(unique_types, cell_types)
 
     if isinstance(spike_types, str):
         spike_types = {spike_types: [spike_types]}
 
     if spike_types is None:
-        spike_types = input_types.tolist()
+        if any(input_types):
+            spike_types = input_types.tolist()
+        else:
+            spike_types = unique_types.tolist()
     if isinstance(spike_types, list):
         spike_types = {s_type: [s_type] for s_type in spike_types}
     if isinstance(spike_types, dict):
@@ -107,14 +110,14 @@ def plot_hist_input(spikes, ax=None, spike_types=None, show=True):
     for spike_label, spike_type_list in spike_types.items():
         for spike_type in spike_type_list:
             n_found = 0
-            for input_type in input_types:
-                if input_type.startswith(spike_type):
-                    if input_type in spike_labels:
+            for unique_type in unique_types:
+                if unique_type.startswith(spike_type):
+                    if unique_type in spike_labels:
                         raise ValueError(f'Elements of spike_types must map to'
                                          f' mutually exclusive input types.'
-                                         f' {input_type} is found more than'
+                                         f' {unique_type} is found more than'
                                          f' once')
-                    spike_labels[input_type] = spike_label
+                    spike_labels[unique_type] = spike_label
                     n_found += 1
             if n_found == 0:
                 raise ValueError(f'No input types found for {spike_type}')

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -93,7 +93,7 @@ def plot_hist_input(spikes, ax=None, spike_types=None, show=True):
     elif spike_types is None:
         spike_types = {s_type: [s_type] for s_type in default_types}
     elif not isinstance(spike_types, dict):
-        raise ValueError('Invalid spike_types input.')
+        raise TypeError('spike_types should be str, list, dict, or None')
 
     spike_mask = {}
     for (s_label, s_list) in spike_types.items():


### PR DESCRIPTION
closes #135. Moves `network.plot_input()` to `network.spikes.plot_input()` (tests and examples updated to reflect this). 

Adds new argument `spike_types` to function call. Examples calls included below:

`spikes.plot_input(spike_types=['evprox1', 'evdist1','evprox2']`
![image](https://user-images.githubusercontent.com/55253912/91492887-64a3b980-e884-11ea-8cdc-b765ef5b2315.png)

`spikes.plot_input(spike_types={'Early': ['evprox1', 'evdist1'], 'Late': ['evprox2']})`
![image](https://user-images.githubusercontent.com/55253912/91492497-c3b4fe80-e883-11ea-9667-8f712de1f724.png)

`spikes.plot_input(spike_types={'Evoked': ['ev']})`
![image](https://user-images.githubusercontent.com/55253912/91492995-9583ee80-e884-11ea-8396-950374fb4860.png)



