### PR TITLE
[MRG] MAINT: move neuron -> neuron_network

### DIFF
--- a/examples/plot_firing_pattern.py
+++ b/examples/plot_firing_pattern.py
@@ -16,7 +16,7 @@ import os.path as op
 
 import hnn_core
 from hnn_core import read_params, Network
-from hnn_core.neuron import NeuronNetwork
+from hnn_core.network_builder import NetworkBuilder
 
 hnn_core_root = op.dirname(hnn_core.__file__)
 
@@ -30,11 +30,11 @@ params = read_params(params_fname)
 import matplotlib.pyplot as plt
 
 net = Network(params)
-with NeuronNetwork(net) as neuron_network:
-    neuron_network.cells[0].plot_voltage()
+with NetworkBuilder(net) as network_builder:
+    network_builder.cells[0].plot_voltage()
 
     # The cells are stored in the network object as a list
-    cells = neuron_network.cells
+    cells = network_builder.cells
     print(cells[:5])
 
     # We have different kinds of cells with different cell IDs (gids)
@@ -43,13 +43,13 @@ with NeuronNetwork(net) as neuron_network:
         print(cells[gid].name)
 
     # We can plot the firing pattern of individual cells
-    neuron_network.cells[0].plot_voltage()
+    network_builder.cells[0].plot_voltage()
     plt.title('%s (gid=%d)' % (cells[0].name, gid))
 
 ###############################################################################
-# Let's do this for the rest of the cell types with a new NeuronNetwork object
-with NeuronNetwork(net) as neuron_network:
+# Let's do this for the rest of the cell types with a new NetworkBuilder object
+with NetworkBuilder(net) as network_builder:
     fig, axes = plt.subplots(1, 2, sharey=True, figsize=(8, 4))
     for gid, ax in zip([35, 170], axes):
-        neuron_network.cells[gid].plot_voltage(ax)
+        network_builder.cells[gid].plot_voltage(ax)
         ax.set_title('%s (gid=%d)' % (cells[gid].name, gid))

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -365,7 +365,7 @@ class _Cell(object):
         nc : instance of h.NetCon
             A network connection object.
         """
-        from .neuron import _PC
+        from .network_builder import _PC
 
         nc = _PC.gid_connect(gid_presyn, postsyn)
         # calculate distance between cell positions with pardistance()

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -37,7 +37,7 @@ def run_mpi_simulation():
     sys.stderr = str_err
 
     from hnn_core import Network
-    from hnn_core.neuron import NeuronNetwork, _simulate_single_trial
+    from hnn_core.network_builder import NetworkBuilder, _simulate_single_trial
 
     # using template for reading stdin from:
     # https://github.com/cloudpipe/cloudpickle/blob/master/tests/testutils.py
@@ -60,7 +60,7 @@ def run_mpi_simulation():
 
     params = comm.bcast(params, root=0)
     net = Network(params)
-    neuron_net = NeuronNetwork(net)
+    neuron_net = NetworkBuilder(net)
 
     sim_data = []
     for trial in range(params['N_trials']):

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -1,4 +1,4 @@
-"""Neuron simulation functions and NeuronNetwork class."""
+"""Neuron simulation functions and NetworkBuilder class."""
 
 # Authors: Mainak Jas <mainak.jas@telecom-paristech.fr>
 #          Sam Neymotin <samnemo@gmail.com>
@@ -17,9 +17,9 @@ _PC = None
 _CVODE = None
 
 # We need to maintain a reference to the last
-# NeuronNetwork instance that ran pc.gid_clear(). Even if
+# NetworkBuilder instance that ran pc.gid_clear(). Even if
 # pc is global, if pc.gid_clear() is called within a new
-# NeuronNetwork, it will seg fault.
+# NetworkBuilder, it will seg fault.
 _LAST_NETWORK = None
 
 
@@ -223,8 +223,8 @@ def _create_parallel_context(n_cores=None):
         _PC.done()
 
 
-class NeuronNetwork(object):
-    """The NeuronNetwork class.
+class NetworkBuilder(object):
+    """The NetworkBuilder class.
 
     Parameters
     ----------
@@ -244,10 +244,10 @@ class NeuronNetwork(object):
 
     Notes
     -----
-    NeuronNetwork is not a pickleable class because it contains many NEURON
+    NetworkBuilder is not a pickleable class because it contains many NEURON
     objects once it has been instantiated. This is important for the Joblib
     backend that passes a pickled Network object to each forked process (job)
-    and only instantiates NeuronNetwork after the fork.
+    and only instantiates NetworkBuilder after the fork.
 
     The `_build` routine can be called again to run more simulations without
     creating new `nrniv` processes. Instead, the NERUON objects are recreated
@@ -307,7 +307,7 @@ class NeuronNetwork(object):
             print('[Done]')
 
     def __enter__(self):
-        """Context manager to cleanly build NeuronNetwork objects"""
+        """Context manager to cleanly build NetworkBuilder objects"""
         return self
 
     def __exit__(self, cell_type, value, traceback):

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -83,12 +83,13 @@ class JoblibBackend(object):
 
     def _clone_and_simulate(self, net, trial_idx):
         # avoid relative lookups after being forked by joblib
-        from hnn_core.neuron import NeuronNetwork, _simulate_single_trial
+        from hnn_core.network_builder import NetworkBuilder
+        from hnn_core.network_builder import _simulate_single_trial
 
         if trial_idx != 0:
             net.params['prng_*'] = trial_idx
 
-        neuron_net = NeuronNetwork(net)
+        neuron_net = NetworkBuilder(net)
         dpl = _simulate_single_trial(neuron_net)
 
         spikedata = neuron_net.get_data_from_neuron()

--- a/hnn_core/tests/test_cell.py
+++ b/hnn_core/tests/test_cell.py
@@ -5,7 +5,7 @@ import os.path as op
 
 import hnn_core
 from hnn_core import read_params, Network
-from hnn_core.neuron import NeuronNetwork
+from hnn_core.network_builder import NetworkBuilder
 from hnn_core.cell import _ArtificialCell, _Cell
 from hnn_core.pyramidal import L5Pyr
 from hnn_core.params_default import get_L5Pyr_params_default
@@ -20,7 +20,7 @@ def test_cell():
     params = read_params(params_fname)
 
     net = Network(params)
-    with NeuronNetwork(net) as neuron_net:
+    with NetworkBuilder(net) as neuron_net:
         neuron_net.cells[0].plot_voltage()
 
     # test that ExpSyn always takes nrn.Segment, not float

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -8,7 +8,7 @@ import pytest
 
 import hnn_core
 from hnn_core import read_params, Network, Spikes, read_spikes
-from hnn_core.neuron import NeuronNetwork
+from hnn_core.network_builder import NetworkBuilder
 
 
 def test_network():
@@ -24,14 +24,14 @@ def test_network():
                    'input_prox_A_weight_L5Pyr_ampa': 5.4e-5,
                    't0_input_prox': 50})
     net = Network(deepcopy(params))
-    neuron_network = NeuronNetwork(net)  # needed to populate net.cells
+    network_builder = NetworkBuilder(net)  # needed to populate net.cells
 
     # Assert that params are conserved across Network initialization
     for p in params:
         assert params[p] == net.params[p]
     assert len(params) == len(net.params)
-    print(neuron_network)
-    print(neuron_network.cells[:2])
+    print(network_builder)
+    print(network_builder.cells[:2])
 
     # Assert that proper number of gids are created for Network inputs
     assert len(net.gid_dict['common']) == 2
@@ -49,10 +49,10 @@ def test_network():
     n_pois_sources = 270
     n_gaus_sources = 270
     n_common_sources = 2
-    assert len(neuron_network._feed_cells) == (n_evoked_sources +
-                                               n_pois_sources +
-                                               n_gaus_sources +
-                                               n_common_sources)
+    assert len(network_builder._feed_cells) == (n_evoked_sources +
+                                                n_pois_sources +
+                                                n_gaus_sources +
+                                                n_common_sources)
 
 
 def test_spikes():

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -131,8 +131,8 @@ def plot_cells(net, ax=None, show=True):
 
     Parameters
     ----------
-    net : instance of NeuronNetwork
-        The NeuronNetwork object.
+    net : instance of NetworkBuilder
+        The NetworkBuilder object.
     ax : instance of matplotlib Axes3D | None
         An axis object from matplotlib. If None,
         a new figure is created.


### PR DESCRIPTION
@blakecaldwell I was having trouble doing import of "from neuron import h" in the same folder as `hnn_core` because there was this file with the same name. I think this name is clearer and avoids this problem. Let me know what you think.