### PR TITLE
[MRG] fix inconsistent random state assignment between parallel trials

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,6 +42,8 @@ Bug
 
 - Connections now cannot be removed by setting the weights to 0., by `Mainak Jas`_ and `Ryan Thorpe`_ in `#162 <https://github.com/jonescompneurolab/hnn-core/pull/162>`_
 
+- MPI and Joblib backends now apply jitter across multiple trials identically, by `Ryan Thorpe`_ in `#171 <https://github.com/jonescompneurolab/hnn-core/pull/171>`_
+
 API
 ~~~
 

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -60,13 +60,17 @@ def run_mpi_simulation():
 
     params = comm.bcast(params, root=0)
     net = Network(params)
-    neuron_net = NetworkBuilder(net)
 
     sim_data = []
-    for trial in range(params['N_trials']):
+    for trial_idx in range(params['N_trials']):
+        # update rng seed state with new trial
+        #if rank == 0:
+        net.trial_idx = trial_idx
+        for param_key in net.params['prng_*'].keys():
+            net.params[param_key] += trial_idx
+        neuron_net = NetworkBuilder(net)
         dpl = _simulate_single_trial(neuron_net)
         if rank == 0:
-            net.trial_idx += 1
             spikedata = neuron_net.get_data_from_neuron()
             sim_data.append((dpl, spikedata))
 

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -66,6 +66,7 @@ def run_mpi_simulation():
     for trial in range(params['N_trials']):
         dpl = _simulate_single_trial(neuron_net)
         if rank == 0:
+            net.trial_idx += 1
             spikedata = neuron_net.get_data_from_neuron()
             sim_data.append((dpl, spikedata))
 

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -11,6 +11,7 @@ from .feed import ExtFeed
 from .cell import _ArtificialCell
 from .pyramidal import L2Pyr, L5Pyr
 from .basket import L2Basket, L5Basket
+from .params import create_pext
 
 # a few globals
 _PC = None
@@ -120,8 +121,6 @@ def _simulate_single_trial(neuron_net):
         dpl.convert_fAm_to_nAm()
         dpl.scale(neuron_net.net.params['dipole_scalefctr'])
         dpl.smooth(neuron_net.net.params['dipole_smooth_win'] / h.dt)
-
-    neuron_net.net.trial_idx += 1
 
     return dpl
 
@@ -353,6 +352,11 @@ class NetworkBuilder(object):
         External inputs are not targets.
         """
         params = self.net.params
+        # Re-create external feed param dictionaries
+        # Note that the only thing being updated here are the param['prng_*']
+        # values
+        self.net.p_common, self.net.p_unique = create_pext(params,
+                                                           params['tstop'])
 
         # loop through gids on this node
         for gid in self.net._gid_list:

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -24,7 +24,7 @@ _CVODE = None
 _LAST_NETWORK = None
 
 
-def _simulate_single_trial(neuron_net):
+def _simulate_single_trial(neuron_net, trial_idx):
     """Simulate one trial."""
 
     from .dipole import Dipole
@@ -41,7 +41,7 @@ def _simulate_single_trial(neuron_net):
     _PC.barrier()  # sync for output to screen
     if rank == 0:
         print("running trial %d on %d cores" %
-              (neuron_net.net.trial_idx + 1, nhosts))
+              (trial_idx + 1, nhosts))
 
     # create or reinitialize scalars in NEURON (hoc) context
     h("dp_total_L2 = 0.")

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -86,12 +86,13 @@ class JoblibBackend(object):
         from hnn_core.network_builder import NetworkBuilder
         from hnn_core.network_builder import _simulate_single_trial
 
+        # XXX this should be built into NetworkBuilder
+        # update prng_seedcore params to provide jitter between trials
         for param_key in net.params['prng_*'].keys():
             net.params[param_key] += trial_idx
 
         neuron_net = NetworkBuilder(net)
-        neuron_net.net.trial_idx = trial_idx
-        dpl = _simulate_single_trial(neuron_net)
+        dpl = _simulate_single_trial(neuron_net, trial_idx)
 
         spikedata = neuron_net.get_data_from_neuron()
 

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -90,6 +90,7 @@ class JoblibBackend(object):
             net.params['prng_*'] = trial_idx
 
         neuron_net = NetworkBuilder(net)
+        neuron_net.net.trial_idx = trial_idx
         dpl = _simulate_single_trial(neuron_net)
 
         spikedata = neuron_net.get_data_from_neuron()

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -86,8 +86,8 @@ class JoblibBackend(object):
         from hnn_core.network_builder import NetworkBuilder
         from hnn_core.network_builder import _simulate_single_trial
 
-        if trial_idx != 0:
-            net.params['prng_*'] = trial_idx
+        for param_key in net.params['prng_*'].keys():
+            net.params[param_key] += trial_idx
 
         neuron_net = NetworkBuilder(net)
         neuron_net.net.trial_idx = trial_idx


### PR DESCRIPTION
fixes #136 

Running the code [here](https://gist.github.com/rythorpe/e7bac070bff41f108996b98c8b58ac14) creates this plot with `MPI_Backend`:
![mn_mpi_10trials](https://user-images.githubusercontent.com/20212206/92980315-a8411a80-f463-11ea-926f-54720dd8d25e.png)

and this plot for `JoblibBackend`:

![mn_joblib_10trials](https://user-images.githubusercontent.com/20212206/92980331-c3138f00-f463-11ea-997b-624657c21b3b.png)

Note that while individual trials are not exactly the same between the two versions (most likely due to an inconsistency in the trajectories of random states), both show 10 distinct trials that emerged from distinct random states. If anyone can readily spot where the discrepancy is occurring it be much appreciated. Otherwise we might want to address that in another PR since the tests are still passing.

This PR also addresses some of the inconsistent messaging that gets output during a simulation in the terminal.