### PR TITLE
[MRG] Separate external "feed" creation in Network from real cells

### DIFF
--- a/hnn_core/feed.py
+++ b/hnn_core/feed.py
@@ -125,6 +125,8 @@ class ExtFeed(object):
 
     # new external pois designation
     def _create_extpois(self):
+        # XXX Check whether both AMPA and NMDA connections are zero
+        # If so, return without updating self.event_times (from empty list)
         if self.params[self.cell_type][0] <= 0.0 and \
                 self.params[self.cell_type][1] <= 0.0:
             return False  # 0 ampa and 0 nmda weight

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -67,11 +67,7 @@ def _create_coords(n_pyr_x, n_pyr_y, zdiff=1307.4):
         The number of Pyramidal cells in x direction.
     n_pyr_y : int
         The number of Pyramidal cells in y direction.
-    n_common_feeds : int
-        The number of common feeds.
-    p_unique_keys : list of str
-        The keys of the dictionary p_unique. Could be 'extpois',
-        'extgauss', or 'evdist_*', or 'evprox_*'
+
     zdiff : float
         Expressed as a positive DEPTH of L5 relative to L2
         This is a deviation from the original, where L5 was defined at 0
@@ -212,6 +208,13 @@ class Network(object):
         return '<%s | %s>' % (class_name, s)
 
     def _assign_external_feeds_coords(self, n_common_feeds, p_unique_keys):
+        """
+        n_common_feeds : int
+            The number of common feeds.
+        p_unique_keys : list of str
+            The keys of the dictionary p_unique. Could be 'extpois',
+            'extgauss', or 'evdist_*', or 'evprox_*'
+        """
         origin = self.pos_dict['origin']
 
         # COMMON FEEDS
@@ -234,18 +237,16 @@ class Network(object):
         self._assign_external_feeds_coords(self.n_common_feeds,
                                            self.p_unique.keys())
 
-        # in particular order (cells, common, names of unique inputs)
-        self.src_list_new = self._create_src_list()
-
         # self._count_cells()  # sets n_cells, includes Artificial ones too!
+
+        # in particular order (cells, common, names of unique inputs)
+        self.src_list_new = self._update_list_of_all_cells()
 
         # count external sources
         self._count_extsrcs()
 
-        self._create_gid_dict()
-
-    def _create_src_list(self):
-        """ creates the immutable source list along with corresponding numbers of cells
+    def _update_list_of_all_cells(self):
+        """creates the immutable list of cell names (real ones and feeds)
         """
         # base source list of tuples, name and number, in this order
         self.extname_list = []

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -184,7 +184,6 @@ class Network(object):
         # by ALL nodes
         # XXX structure of pos_dict determines all downstream inferences of
         # cell counts, real and artificial
-        self.pos_dict = dict.fromkeys(self.cellname_list)
         self.pos_dict = _create_cell_coords(n_pyr_x=self.params['N_pyr_x'],
                                             n_pyr_y=self.params['N_pyr_y'],
                                             zdiff=1307.4)

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -417,12 +417,14 @@ class NetworkBuilder(object):
             # external inputs can also be Poisson- or Gaussian-
             # distributed, or 'evoked' inputs (proximal or distal)
             # these are cell-specific ('unique')
+            # XXX src_type is 'common', 'evprox1', 'evdist1', 'evgauss', etc.
             elif src_type in self.net.p_unique.keys():
                 gid_target = gid - self.net.gid_dict[src_type][0]
                 target_cell_type = self.net.gid_to_type(gid_target)
 
                 # new ExtFeed, where now both feed type and target cell type
-                # specified because these feeds have cell-specific parameters
+                # specified because these feeds have cell-specific
+                # CONNECTION parameters, i.e., AMPA and NMDA weights
                 feed = ExtFeed(feed_type=src_type,
                                target_cell_type=target_cell_type,
                                params=self.net.p_unique[src_type],

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -276,6 +276,9 @@ class NetworkBuilder(object):
         # initialized by _ArtificialCell()
         self._feed_cells = []
         self.ncs = dict()
+
+        self.net._create_gid_dict()
+
         self._build()
 
     def _build(self):

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -277,6 +277,10 @@ class NetworkBuilder(object):
         self._feed_cells = []
         self.ncs = dict()
 
+        # To allow incremental building up of cells and drives in the
+        # network, hold off on initialising the GID dict of the Network
+        # until user calls NetworkBuilder. This method may be dropped later
+        # if GIDs can safely also be created on-the-fly, incrementally.
         self.net._create_gid_dict()
 
         self._build()

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -355,6 +355,10 @@ def create_pext(p, tstop):
     # (for backwards compatibility)
     # could cause differences between output of param files
     # since some nmda weights should be 0 while others > 0
+
+    # XXX dangerzone: params are modified in-place, values are imputed if
+    # deemed missing (e.g. if 'gbar_evprox_1_L2Pyr_nmda' is not defined, the
+    # code adds it to the p-dict with value: p['gbar_evprox_1_L2Pyr'])
     check_evoked_synkeys(p, nprox, ndist)
 
     # Create proximal evoked response parameters

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -218,7 +218,7 @@ def plot_cells(net, ax=None, show=True):
     markers = {'L5_pyramidal': '^', 'L2_pyramidal': '^',
                'L5_basket': 'x', 'L2_basket': 'x'}
 
-    for cell_type in net.pos_dict:
+    for cell_type in net.cellname_list:
         x = [pos[0] for pos in net.pos_dict[cell_type]]
         y = [pos[1] for pos in net.pos_dict[cell_type]]
         z = [pos[2] for pos in net.pos_dict[cell_type]]


### PR DESCRIPTION
This PR has very limited scope: all it really does is

- [x] general cleanup and naming
- [x] logical separation of real cell and 'feed' (artificial cell) creation

The latter is mostly done in `Network`, with minor consequences to `NetworkBuilder`.

Note that nothing has happened to the creation of the 'feed' spike sequences, which will be addressed in a subsequent PR.

Partial PR on the way to #104 

