### PR TITLE
Add 'spec_cmap' paramter for use by HNN GUI

### DIFF
--- a/hnn_core/params_default.py
+++ b/hnn_core/params_default.py
@@ -135,6 +135,7 @@ def get_params_default(nprox=2, ndist=1):
         # analysis
         'save_spec_data': 0,
         'f_max_spec': 40.,
+        'spec_cmap': 'jet',  # only used in GUI
         'dipole_scalefctr': 30e3,  # scale factor for dipole - default at 30e3
         # based on scaling needed to match model ongoing rhythms from
         # jones 2009 - for ERPs can use 300

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -63,17 +63,6 @@ def test_base_params():
     params = Params()
     assert params == params_base
 
-
-def test_param_set():
-    """Test that a parameter value can be changed"""
-    param_url = ('https://raw.githubusercontent.com/jonescompneurolab/'
-                 'hnn-core/test_data/base.json')
-    params_base_fname = op.join(hnn_core_root, 'param', 'base.json')
-    if not op.exists(params_base_fname):
-        _fetch_file(param_url, params_base_fname)
-
-    params_base = read_params(params_base_fname)
     params_base['spec_cmap'] = 'viridis'
-
     params = Params(params_base)
     assert params == params_base

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -62,3 +62,18 @@ def test_base_params():
     params_base = read_params(params_base_fname)
     params = Params()
     assert params == params_base
+
+
+def test_param_set():
+    """Test that a parameter value can be changed"""
+    param_url = ('https://raw.githubusercontent.com/jonescompneurolab/'
+                 'hnn-core/test_data/base.json')
+    params_base_fname = op.join(hnn_core_root, 'param', 'base.json')
+    if not op.exists(params_base_fname):
+        _fetch_file(param_url, params_base_fname)
+
+    params_base = read_params(params_base_fname)
+    params_base['spec_cmap'] = 'viridis'
+
+    params = Params(params_base)
+    assert params == params_base


### PR DESCRIPTION
HNN GUI needs this parameter and the only want to have it load into a `Params` object is to have a default value. When spectrograms are implemented in hnn-core such that they can be used by the GUI in dialogs, then this parameter can probably be removed.