### PR TITLE
[MRG] ENH: print MPI simulation messages to console

### DIFF
--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -32,10 +32,8 @@ This backend will use MPI (Message Passing Interface) on the system to split neu
 
 **MacOS Dependencies**::
 
-    $ conda install --yes openmpi
-    $ pip install psutil mpi4py
-
-If you encounter difficulties installing mpi4py with pip (1st choice), then try with conda
+    $ conda install yes openmpi mpi4py
+    $ pip install psutil
 
 **MacOS Environment**::
 

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -32,8 +32,10 @@ This backend will use MPI (Message Passing Interface) on the system to split neu
 
 **MacOS Dependencies**::
 
-    $ conda install yes openmpi mpi4py
-    $ pip install psutil
+    $ conda install --yes openmpi
+    $ pip install psutil mpi4py
+
+If you encounter difficulties installing mpi4py with pip (1st choice), then try with conda
 
 **MacOS Environment**::
 

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -84,15 +84,14 @@ def run_mpi_simulation():
         if hasattr(data_iostream, 'buffer'):
             data_iostream = data_iostream.buffer
 
-        if len(sim_data) > 0:
-            # send back dpls and spikedata
-            pickled_string = pickle.dumps(sim_data)
+        # send back dpls and spikedata
+        pickled_string = pickle.dumps(sim_data)
 
-            # encode as base64 before sending to stderr
-            repickled_bytes = codecs.encode(pickled_string,
-                                            'base64')
+        # encode as base64 before sending to stderr
+        repickled_bytes = codecs.encode(pickled_string,
+                                        'base64')
 
-            data_iostream.write(repickled_bytes + b"===")
+        data_iostream.write(repickled_bytes + b"===")
 
     # flush anything in stderr (still points to str_err) to stdout
     sys.stderr.flush()

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -78,25 +78,21 @@ def run_mpi_simulation():
 
     # send results to stderr
     if rank == 0:
-        # send back dpls and spikedata
-        pickled_string = pickle.dumps(sim_data)
-
-        # pad data before encoding, always add at least 4 "=" to mark end
-        padding = len(pickled_string) % 4
-        pickled_string += b"=" * padding
-        pickled_string += b"=" * 4
-
-        # encode as base64 before sending to stderr
-        repickled_bytes = codecs.encode(pickled_string,
-                                        'base64')
-
         data_iostream = io.BytesIO()
 
         # Force the use of bytes streams under Python 3
         if hasattr(data_iostream, 'buffer'):
             data_iostream = data_iostream.buffer
 
-        data_iostream.write(repickled_bytes)
+        if len(sim_data) > 0:
+            # send back dpls and spikedata
+            pickled_string = pickle.dumps(sim_data)
+
+            # encode as base64 before sending to stderr
+            repickled_bytes = codecs.encode(pickled_string,
+                                            'base64')
+
+            data_iostream.write(repickled_bytes + b"===")
 
     # flush anything in stderr (still points to str_err) to stdout
     sys.stderr.flush()

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -303,7 +303,12 @@ class MPIBackend(object):
                 if stream == pipe_stdout_r:
                     buf = os.read(pipe_stdout_r, 1024)
                     # write processes stdout to our stdout (fd 0)
-                    os.write(sys.stdout.fileno(), buf)
+                    try:
+                        stdout_fd = sys.stdout.fileno()
+                    except AttributeError:
+                        # for sphinx-gallery that replaces sys.stdout
+                        stdout_fd = 0
+                    os.write(stdout_fd, buf)
                 else:
                     proc_stderr_bytes += os.read(pipe_stderr_r, 1024)
 

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -16,17 +16,6 @@ import select
 _BACKEND = None
 
 
-def _read_all_bytes(stream_in, chunk_size=4096):
-    all_data = b""
-    while True:
-        data = stream_in.read(chunk_size)
-        all_data += data
-        if len(data) < chunk_size:
-            break
-
-    return all_data
-
-
 def _gather_trial_data(sim_data, net, n_trials):
     """Arrange data by trial
 

--- a/hnn_core/tests/test_compare_hnn.py
+++ b/hnn_core/tests/test_compare_hnn.py
@@ -92,6 +92,12 @@ def test_compare_across_backends():
     # test consistency between mpi backend simulation (n_procs=2) and master
     dpls_reduced_mpi = run_hnn_core(backend='mpi')
 
+    try:
+        import mpi4py
+        mpi4py.__file__
+    except ImportError:
+        pytest.skip("mpi4py not available")
+
     # test consistency between joblib backend simulation (n_jobs=2) with master
     dpls_reduced_joblib = run_hnn_core(backend='joblib', n_jobs=2)
 
@@ -111,6 +117,8 @@ def test_compare_across_backends():
 
 def test_mpi_failure():
     """Test that an MPI failure is handled and error messages pass through"""
+    pytest.importorskip("mpi4py", reason="mpi4py not available")
+
     # this MPI paramter will cause a MPI job with more than one process to fail
     environ["OMPI_MCA_btl"] = "self"
 


### PR DESCRIPTION
Previously, we had to wait for the MPI simulation to complete before any
output would be printed on the console. This commit uses the non-blocking select
call to print stderr and stdout while the simulation is in progress.

With MPIBackend we pass the simulation results back via stderr, which means that
MPI error messages during the simulation. We use base64 padding characters to
separate the data from the MPI messages. A trick with base64 encoding is to use
b'===' to always ensure that the padding offset is correct, but also having
something to indicate the boundary before the error message.

Fixes #112