### PR TITLE
[MRG] Refactor creation of network 'feeds' (to allow new mechanism for adding network drives)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,8 @@ Changelog
 
 - Add ability to record somatic voltages from all cells, by `Nick Tolley`_ in `#190 <https://github.com/jonescompneurolab/hnn-core/pull/190>`_
 
+- Add ability to instantiate external feed event times of a network prior to building it, by `Christopher Bailey`_ in `#191 <https://github.com/jonescompneurolab/hnn-core/pull/191>`_
+
 Bug
 ~~~
 

--- a/examples/plot_firing_pattern.py
+++ b/examples/plot_firing_pattern.py
@@ -34,8 +34,8 @@ dpls = simulate_dipole(net, n_trials=1, record_vsoma=True)
 
 ###############################################################################
 # The cell IDs (gids) are stored in the network object as a dictionary
-gid_dict = net.gid_dict
-print(net.gid_dict)
+gid_ranges = net.gid_ranges
+print(net.gid_ranges)
 
 ###############################################################################
 # Simulated voltage in the soma is stored in the Spikes object as a dictionary.
@@ -46,9 +46,8 @@ print(vsoma.keys())
 ###############################################################################
 # We can plot the firing pattern of individual cells by indexing with the gid
 gid = 170
-times = net.spikes.times[trial_idx]
 plt.figure(figsize=(4, 4))
-plt.plot(times, vsoma[gid])
+plt.plot(net.spikes.times, vsoma[gid])
 plt.title('%s (gid=%d)' % (net.gid_to_type(gid), gid))
 plt.xlabel('Time (ms)')
 plt.ylabel('Voltage (mV)')
@@ -61,9 +60,9 @@ plt.show()
 fig, axes = plt.subplots(3, 1, figsize=(5, 7), sharex=True)
 
 for idx in range(10):  # only 10 cells per cell-type
-    gid = gid_dict['L2_pyramidal'][idx]
-    axes[0].plot(times, vsoma[gid], color='g')
-    gid = gid_dict['L5_pyramidal'][idx]
-    axes[0].plot(times, vsoma[gid], color='r')
+    gid = gid_ranges['L2_pyramidal'][idx]
+    axes[0].plot(net.spikes.times, vsoma[gid], color='g')
+    gid = gid_ranges['L5_pyramidal'][idx]
+    axes[0].plot(net.spikes.times, vsoma[gid], color='r')
 net.spikes.plot(ax=axes[1])
 net.spikes.plot_hist(ax=axes[2], spike_types=['L5_pyramidal', 'L2_pyramidal'])

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -69,9 +69,9 @@ spikes.plot()
 ###############################################################################
 # We can additionally calculate the mean spike rates for each cell class by
 # specifying a time window with tstart and tstop.
-all_rates = spikes.mean_rates(tstart=0, tstop=170, gid_dict=net.gid_dict,
+all_rates = spikes.mean_rates(tstart=0, tstop=170, gid_ranges=net.gid_ranges,
                               mean_type='all')
-trial_rates = spikes.mean_rates(tstart=0, tstop=170, gid_dict=net.gid_dict,
+trial_rates = spikes.mean_rates(tstart=0, tstop=170, gid_ranges=net.gid_ranges,
                                 mean_type='trial')
 print('Mean spike rates across trials:')
 print(all_rates)

--- a/hnn_core/basket.py
+++ b/hnn_core/basket.py
@@ -21,9 +21,9 @@ class BasketSingle(_Cell):
         names of section locations that are proximal or distal.
     """
 
-    def __init__(self, gid, pos, cell_name='Basket'):
+    def __init__(self, pos, cell_name='Basket', gid=None):
         self.props = self._get_soma_props(cell_name, pos)
-        _Cell.__init__(self, gid, self.props)
+        _Cell.__init__(self, self.props, gid=gid)
         # store cell name for later
         self.name = cell_name
 
@@ -62,12 +62,22 @@ class BasketSingle(_Cell):
 
 
 class L2Basket(BasketSingle):
-    """Class for layer 2 basket cells."""
+    """Class for layer 2 basket cells.
 
-    def __init__(self, gid=-1, pos=-1):
+    Parameters
+    ----------
+    pos : tuple
+        Coordinates of cell soma in xyz-space
+    gid : int or None (optional)
+        Each cell in a network is uniquely identified by it's "global ID": GID.
+        The GID is an integer from 0 to n_cells, or None if the cell is not
+        yet attached to a network. Once the GID is set, it cannot be changed.
+    """
+
+    def __init__(self, pos, gid=None):
         # BasketSingle.__init__(self, pos, L, diam, Ra, cm)
         # Note: Basket cell properties set in BasketSingle())
-        BasketSingle.__init__(self, gid, pos, 'L2Basket')
+        BasketSingle.__init__(self, pos, cell_name='L2Basket', gid=gid)
         self.celltype = 'L2_basket'
 
         self._synapse_create()
@@ -76,11 +86,21 @@ class L2Basket(BasketSingle):
 
 
 class L5Basket(BasketSingle):
-    """Class for layer 5 basket cells."""
+    """Class for layer 5 basket cells.
 
-    def __init__(self, gid=-1, pos=-1):
+    Parameters
+    ----------
+    pos : tuple
+        Coordinates of cell soma in xyz-space
+    gid : int or None (optional)
+        Each cell in a network is uniquely identified by it's "global ID": GID.
+        The GID is an integer from 0 to n_cells, or None if the cell is not
+        yet attached to a network. Once the GID is set, it cannot be changed.
+    """
+
+    def __init__(self, pos, gid=None):
         # Note: Cell properties are set in BasketSingle()
-        BasketSingle.__init__(self, gid, pos, 'L5Basket')
+        BasketSingle.__init__(self, pos, cell_name='L5Basket', gid=gid)
         self.celltype = 'L5_basket'
 
         self._synapse_create()

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -53,18 +53,20 @@ class _ArtificialCell:
         self.nrn_netcon = h.NetCon(self.nrn_vecstim, None)
         self.nrn_netcon.threshold = threshold
 
-        self._assigned_gid = gid
+        self._gid = None
+        if gid is not None:
+            self.gid = gid  # use setter method to check input argument gid
 
     @property
     def gid(self):
-        return self._assigned_gid
+        return self._gid
 
     @gid.setter
     def gid(self, gid):
         if not isinstance(gid, int):
             raise ValueError('gid must be an integer')
-        if self._assigned_gid is None:
-            self._assigned_gid = gid
+        if self._gid is None:
+            self._gid = gid
         else:
             raise RuntimeError('Global ID for this cell already assigned!')
 
@@ -103,7 +105,9 @@ class _Cell(ABC):
         self.soma_props = soma_props
         self.create_soma()
         self.rec_v = h.Vector()
-        self._assigned_gid = gid
+        self._gid = None
+        if gid is not None:
+            self.gid = gid  # use setter method to check input argument gid
 
     def __repr__(self):
         class_name = self.__class__.__name__
@@ -115,14 +119,14 @@ class _Cell(ABC):
 
     @property
     def gid(self):
-        return self._assigned_gid
+        return self._gid
 
     @gid.setter
     def gid(self, gid):
         if not isinstance(gid, int):
             raise ValueError('gid must be an integer')
-        if self._assigned_gid is None:
-            self._assigned_gid = gid
+        if self._gid is None:
+            self._gid = gid
         else:
             raise RuntimeError('Global ID for this cell already assigned!')
 

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -53,8 +53,7 @@ class _ArtificialCell:
         self.nrn_netcon = h.NetCon(self.nrn_vecstim, None)
         self.nrn_netcon.threshold = threshold
 
-        self._assigned_gid = None
-        self.gid = gid
+        self._assigned_gid = gid
 
     @property
     def gid(self):
@@ -62,9 +61,9 @@ class _ArtificialCell:
 
     @gid.setter
     def gid(self, gid):
-        if gid is None:
-            pass
-        elif self._assigned_gid is None:
+        if not isinstance(gid, int):
+            raise ValueError('gid must be an integer')
+        if self._assigned_gid is None:
             self._assigned_gid = gid
         else:
             raise RuntimeError('Global ID for this cell already assigned!')
@@ -104,8 +103,7 @@ class _Cell(ABC):
         self.soma_props = soma_props
         self.create_soma()
         self.rec_v = h.Vector()
-        self._assigned_gid = None
-        self.gid = gid
+        self._assigned_gid = gid
 
     def __repr__(self):
         class_name = self.__class__.__name__
@@ -121,9 +119,9 @@ class _Cell(ABC):
 
     @gid.setter
     def gid(self, gid):
-        if gid is None:
-            pass
-        elif self._assigned_gid is None:
+        if not isinstance(gid, int):
+            raise ValueError('gid must be an integer')
+        if self._assigned_gid is None:
             self._assigned_gid = gid
         else:
             raise RuntimeError('Global ID for this cell already assigned!')

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -44,6 +44,7 @@ def simulate_dipole(net, n_trials=None, record_vsoma=False):
 
     if n_trials is not None:
         net.params['N_trials'] = n_trials
+        net._instantiate_feeds()  # need to redo these if n_trials changed!
     else:
         n_trials = net.params['N_trials']
 

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -44,7 +44,8 @@ def simulate_dipole(net, n_trials=None, record_vsoma=False):
 
     if n_trials is not None:
         net.params['N_trials'] = n_trials
-        net._instantiate_feeds()  # need to redo these if n_trials changed!
+        # need to redo these if n_trials changed after net.__init__()!
+        net._instantiate_feeds(n_trials=n_trials)
     else:
         n_trials = net.params['N_trials']
 

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -100,13 +100,10 @@ class MPISimulation(object):
         from hnn_core import Network
         from hnn_core.parallel_backends import _clone_and_simulate
 
-        prng_seedcore_initial = params['prng_*']
-
         net = Network(params)
         sim_data = []
         for trial_idx in range(params['N_trials']):
-            single_sim_data = _clone_and_simulate(net, trial_idx,
-                                                  prng_seedcore_initial)
+            single_sim_data = _clone_and_simulate(net, trial_idx)
 
             # go ahead and append trial data for each rank, though
             # only rank 0 has data that should be sent back to MPIBackend

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -173,10 +173,8 @@ class Network(object):
         # place to keep this information
         self.gid_ranges = dict()
 
-        # Number of time points
-        # Originally used to create the empty vec for synaptic currents,
-        # ensuring that they exist on this node irrespective of whether
-        # or not cells of relevant type actually
+        # Create array of equally sampled time points for simulating currents
+        # NB (only) used to initialise self.spikes._times
         times = np.arange(0., params['tstop'] + params['dt'], params['dt'])
         # Create spikes object, initialised with simulation time points
         self.spikes = Spikes(times=times)
@@ -447,8 +445,8 @@ class Spikes(object):
         self._spike_types = spike_types
         self._vsoma = list()
         if times is not None:
-            assert isinstance(times, np.ndarray),\
-                "'times' is an array of simulation times"
+            if not isinstance(times, np.ndarray):
+                raise TypeError("'times' is an np.ndarray of simulation times")
         self._times = times
 
     def __repr__(self):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -177,10 +177,9 @@ class Network(object):
         # Originally used to create the empty vec for synaptic currents,
         # ensuring that they exist on this node irrespective of whether
         # or not cells of relevant type actually
-        self.times = np.arange(0., params['tstop'] + params['dt'],
-                               params['dt'])
-        # Create empty spikes object
-        self.spikes = Spikes()
+        times = np.arange(0., params['tstop'] + params['dt'], params['dt'])
+        # Create spikes object, initialised with simulation time points
+        self.spikes = Spikes(times=times)
 
         # Source list of names, first real ones only!
         self.cellname_list = [
@@ -397,8 +396,8 @@ class Spikes(object):
         Each gid corresponds to a type via Network::gid_ranges.
     vsoma : dict
         Dictionary indexed by gids containing somatic voltages
-    times : list
-        List of time points for samples in continuous data.
+    times : numpy array
+        Array of time points for samples in continuous data.
         This includes vsoma.
 
     Methods
@@ -415,7 +414,8 @@ class Spikes(object):
         Write spiking activity to a collection of spike trial files.
     """
 
-    def __init__(self, spike_times=None, spike_gids=None, spike_types=None):
+    def __init__(self, spike_times=None, spike_gids=None, spike_types=None,
+                 times=None):
         if spike_times is None:
             spike_times = list()
         if spike_gids is None:
@@ -446,7 +446,10 @@ class Spikes(object):
         self._spike_gids = spike_gids
         self._spike_types = spike_types
         self._vsoma = list()
-        self._times = list()
+        if times is not None:
+            assert isinstance(times, np.ndarray),\
+                "'times' is an array of simulation times"
+        self._times = times
 
     def __repr__(self):
         class_name = self.__class__.__name__

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -255,20 +255,24 @@ class Network(object):
         self._update_gid_ranges()
 
         # Create the feed dynamics (event_times)
-        self._instantiate_feeds()
+        self._instantiate_feeds(n_trials=self.params['N_trials'])
 
-    def _instantiate_feeds(self):
-        '''Creates event_time vectors for all feeds and all trials
+    def _instantiate_feeds(self, n_trials=1):
+        """Creates event_time vectors for all feeds and all trials
+
+        Parameters
+        ----------
+        n_trials : int
+            Number of trials to create events for (default: 1)
 
         NB this must be a separate method because dipole.py:simulate_dipole
         accepts an n_trials-argument, which overrides the N_trials-parameter
         used at intialisation time. The good news is that only the event_times
         need to be recalculated, all the GIDs etc remain the same.
-        '''
+        """
         # each trial needs unique event time vectors
 
         self.trial_event_times = []  # reset if called again from dipole.py
-        n_trials = self.params['N_trials']
 
         cur_params = self.params.copy()  # these get mangled below!
         for trial_idx in range(n_trials):

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -278,12 +278,6 @@ class NetworkBuilder(object):
         self._feed_cells = []
         self.ncs = dict()
 
-        # To allow incremental building up of cells and drives in the
-        # network, hold off on initialising the GID dict of the Network
-        # until user calls NetworkBuilder. This method may be dropped later
-        # if GIDs can safely also be created on-the-fly, incrementally.
-        self.net._create_gid_dict()
-
         self._build()
 
     def _build(self):
@@ -300,6 +294,10 @@ class NetworkBuilder(object):
         self._clear_last_network_objects()
 
         self._gid_assign()
+
+        # initialise vectors for synaptic currents based on simulation params
+        n_times = np.arange(0., self.net.params['tstop'],
+                            self.net.params['dt']).size + 1
 
         # Create a h.Vector() with size 1xself.N_t, zero'd
         self.current = {

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -46,7 +46,7 @@ def _simulate_single_trial(neuron_net, trial_idx):
     h.dt = neuron_net.net.params['dt']  # simulation duration and time-step
     h.celsius = neuron_net.net.params['celsius']  # 37.0 - set temperature
 
-    times = neuron_net.net.times
+    times = neuron_net.net.spikes.times
 
     # sets the default max solver step in ms (purposefully large)
     _PC.set_maxstep(10)
@@ -304,19 +304,15 @@ class NetworkBuilder(object):
 
         self._clear_last_network_objects()
 
-        # initialise vectors for synaptic currents based on simulation params
-        n_times = np.arange(0., self.net.params['tstop'],
-                            self.net.params['dt']).size + 1
-
         # Create a h.Vector() with size 1xself.N_t, zero'd
         self.current = {
-            'L5_pyramidal_soma': h.Vector(n_times, 0),
-            'L2_pyramidal_soma': h.Vector(n_times, 0),
+            'L5_pyramidal_soma': h.Vector(self.net.spikes.times.size, 0),
+            'L2_pyramidal_soma': h.Vector(self.net.spikes.times.size, 0),
         }
 
         self.dipoles = {
-            'L5_pyramidal': h.Vector(n_times, 0),
-            'L2_pyramidal': h.Vector(n_times, 0),
+            'L5_pyramidal': h.Vector(self.net.spikes.times.size, 0),
+            'L2_pyramidal': h.Vector(self.net.spikes.times.size, 0),
         }
 
         self._gid_assign()
@@ -423,7 +419,7 @@ class NetworkBuilder(object):
                 if record_vsoma:
                     cell.record_voltage_soma()
 
-                # this calls seems to belong in init of a _Cell (w/threshold)?
+                # this call could belong in init of a _Cell (with threshold)?
                 nrn_netcon = cell.setup_source_netcon(threshold)
                 _PC.cell(cell.gid, nrn_netcon)
                 self.cells.append(cell)

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -54,7 +54,6 @@ def _gather_trial_data(sim_data, net, n_trials):
         net.gid_ranges = spikedata[2]  # only have one gid_ranges
         net.spikes.update_types(net.gid_ranges)
         net.spikes._vsoma.append(spikedata[3])
-        net.spikes._times.append(net.times.tolist())
 
     return dpls
 

--- a/hnn_core/pyramidal.py
+++ b/hnn_core/pyramidal.py
@@ -22,16 +22,16 @@ class Pyr(_Cell):
 
     Parameters
     ----------
-    gid : int
-        The cell ID
-    soma_props : dict
-        The soma properties
     pos : tuple
-        The position of the cell.
+        Coordinates of cell soma in xyz-space
     celltype : str
         Either 'L2_Pyramidal' or 'L5_Pyramidal'
-    params : dict
-        The params dictionary.
+    override_params : dict or None (optional)
+        Parameters specific to L2 pyramidal neurons to override the default set
+    gid : int or None (optional)
+        Each cell in a network is uniquely identified by it's "global ID": GID.
+        The GID is an integer from 0 to n_cells, or None if the cell is not
+        yet attached to a network. Once the GID is set, it cannot be changed..
 
     Attributes
     ----------
@@ -51,19 +51,24 @@ class Pyr(_Cell):
         The synapses that the cell can use for connections.
     """
 
-    def __init__(self, gid, pos, celltype, params):
+    def __init__(self, pos, celltype, override_params=None, gid=None):
 
         if celltype == 'L5_pyramidal':
             p_all_default = get_L5Pyr_params_default()
         elif celltype == 'L2_pyramidal':
             p_all_default = get_L2Pyr_params_default()
+        else:
+            raise ValueError(f'Unknown pyramidal cell type: {celltype}')
 
-        p_all = compare_dictionaries(p_all_default, params)
+        p_all = p_all_default
+        if override_params is not None:
+            assert isinstance(override_params, dict)
+            p_all = compare_dictionaries(p_all_default, override_params)
 
-        # Get somatic, dendirtic, and synapse properties
+        # Get somatic, dendritic, and synapse properties
         soma_props = self._get_soma_props(pos, p_all)
 
-        _Cell.__init__(self, gid, soma_props)
+        _Cell.__init__(self, soma_props, gid=gid)
         self.create_soma()
         # store cell_name as self variable for later use
         self.name = soma_props['name']
@@ -295,12 +300,14 @@ class L2Pyr(Pyr):
 
     Parameters
     ----------
-    gid : int
-        The cell id.
-    pos : tuple | None
-        The position of the cell.
-    params : dict | None
-        The parameters dictionary.
+    pos : tuple
+        Coordinates of cell soma in xyz-space
+    override_params : dict or None (optional)
+        Parameters specific to L2 pyramidal neurons to override the default set
+    gid : int or None (optional)
+        Each cell in a network is uniquely identified by it's "global ID": GID.
+        The GID is an integer from 0 to n_cells, or None if the cell is not
+        yet attached to a network. Once the GID is set, it cannot be changed.
 
     Attributes
     ----------
@@ -315,8 +322,8 @@ class L2Pyr(Pyr):
         The synapses that the cell can use for connections.
     """
 
-    def __init__(self, gid=-1, pos=None, params=None):
-        Pyr.__init__(self, gid, pos, 'L2_pyramidal', params)
+    def __init__(self, pos=None, override_params=None, gid=None):
+        Pyr.__init__(self, pos, 'L2_pyramidal', override_params, gid=gid)
 
     def _get_soma_props(self, pos, p_all):
         """Hardcoded somatic properties."""
@@ -432,12 +439,14 @@ class L5Pyr(Pyr):
 
     Parameters
     ----------
-    gid : int
-        The cell ID
-    pos : tuple | None
-        The position of the cell
-    params : dict | None
-        The params dictionary
+    pos : tuple
+        Coordinates of cell soma in xyz-space
+    override_params : dict or None (optional)
+        Parameters specific to L2 pyramidal neurons to override the default set
+    gid : int or None (optional)
+        Each cell in a network is uniquely identified by it's "global ID": GID.
+        The GID is an integer from 0 to n_cells, or None if the cell is not
+        yet attached to a network. Once the GID is set, it cannot be changed.
 
     Attributes
     ----------
@@ -452,10 +461,10 @@ class L5Pyr(Pyr):
         The synapses that the cell can use for connections.
     """
 
-    def __init__(self, gid=-1, pos=None, params=None):
+    def __init__(self, pos=None, override_params=None, gid=None):
         """Get default L5Pyr params and update them with
             corresponding params in p."""
-        Pyr.__init__(self, gid, pos, 'L5_pyramidal', params)
+        Pyr.__init__(self, pos, 'L5_pyramidal', override_params, gid=gid)
 
     def secs(self):
         """The geometry of the default sections in the Neuron."""

--- a/hnn_core/tests/test_cell.py
+++ b/hnn_core/tests/test_cell.py
@@ -27,13 +27,18 @@ def test_cell():
     with pytest.raises(RuntimeError,
                        match='Global ID for this cell already assigned!'):
         cell.gid += 1
+    # ... or later
+    cell = Cell(soma_props=soma_props)  # cells can exist fine without gid
+    assert cell.gid is None  # check that it's initialised to None
     with pytest.raises(ValueError,
                        match='gid must be an integer'):
         cell.gid = [1]
-    # ... or later
-    cell = Cell(soma_props=soma_props)  # cells can exist fine without gid
     cell.gid = 42
     assert cell.gid == 42
+    with pytest.raises(ValueError,
+                       match='gid must be an integer'):
+        cell = Cell(soma_props=soma_props, gid='one')  # test init checks gid
+
     with pytest.raises(TypeError, match='secloc must be instance of'):
         cell.syn_create(0.5, e=0., tau1=0.5, tau2=5.)
 
@@ -63,5 +68,9 @@ def test_artificial_cell():
         cell.gid = [1]
     # ... or later
     cell = _ArtificialCell(event_times, threshold)  # fine without gid
+    assert cell.gid is None  # check that it's initialised to None
     cell.gid = 42
     assert cell.gid == 42
+    with pytest.raises(ValueError,  # test init checks gid
+                       match='gid must be an integer'):
+        cell = _ArtificialCell(event_times, threshold, gid='one')

--- a/hnn_core/tests/test_cell.py
+++ b/hnn_core/tests/test_cell.py
@@ -27,6 +27,9 @@ def test_cell():
     with pytest.raises(RuntimeError,
                        match='Global ID for this cell already assigned!'):
         cell.gid += 1
+    with pytest.raises(ValueError,
+                       match='gid must be an integer'):
+        cell.gid = [1]
     # ... or later
     cell = Cell(soma_props=soma_props)  # cells can exist fine without gid
     cell.gid = 42
@@ -55,6 +58,9 @@ def test_artificial_cell():
     with pytest.raises(RuntimeError,
                        match='Global ID for this cell already assigned!'):
         cell.gid += 1
+    with pytest.raises(ValueError,
+                       match='gid must be an integer'):
+        cell.gid = [1]
     # ... or later
     cell = _ArtificialCell(event_times, threshold)  # fine without gid
     cell.gid = 42

--- a/hnn_core/tests/test_feed.py
+++ b/hnn_core/tests/test_feed.py
@@ -22,7 +22,7 @@ def test_extfeed():
     pytest.raises(ValueError, ExtFeed,
                   'ev', None, p_bogus, 0)  # ambiguous
 
-    # XXX 'unique' external feeds are always created; why?
+    # 'unique' external feeds are always created
     for feed_type in ['extpois', 'extgauss']:
         feed = ExtFeed(feed_type=feed_type,
                        target_cell_type='L2_basket',
@@ -30,7 +30,7 @@ def test_extfeed():
                        gid=0)
         print(feed)  # test repr
 
-    # XXX but 'common' (rhythmic) feeds are not
+    # but 'common' (rhythmic) feeds are not
     for ii in range(len(p_common)):  # len == 0 for def. params
         feed = ExtFeed(feed_type='common',
                        target_cell_type=None,

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -44,6 +44,12 @@ def test_network():
 
     # Assert that an empty Spikes object is created as an attribute
     assert net.spikes == Spikes()
+    # array of simulation times is created in Network.__init__, but passed
+    # to Spikes-constructor for storage (Network is agnostic of time)
+    # times should be a Numpy ND-array, not a list
+    with pytest.raises(TypeError,
+                       match="'times' is an array of simulation times"):
+        _ = Spikes(times=[1, 2, 3])
 
     # Assert that all external feeds are initialized
     n_evoked_sources = net.n_cells * 3

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -47,7 +47,7 @@ def test_network():
     # array of simulation times is created in Network.__init__, but passed
     # to Spikes-constructor for storage (Network is agnostic of time)
     # times should be a Numpy ND-array, not a list
-    with pytest.raises(TypeError,
+    with pytest.raises(AssertionError,
                        match="'times' is an array of simulation times"):
         _ = Spikes(times=[1, 2, 3])
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -46,9 +46,8 @@ def test_network():
     assert net.spikes == Spikes()
     # array of simulation times is created in Network.__init__, but passed
     # to Spikes-constructor for storage (Network is agnostic of time)
-    # times should be a Numpy ND-array, not a list
-    with pytest.raises(AssertionError,
-                       match="'times' is an array of simulation times"):
+    with pytest.raises(TypeError,
+                       match="'times' is an np.ndarray of simulation times"):
         _ = Spikes(times=[1, 2, 3])
 
     # Assert that all external feeds are initialized

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -31,6 +31,9 @@ def run_hnn_core(backend=None, n_procs=None, n_jobs=1, reduced=False):
                        'N_trials': 2})
     net = Network(params)
 
+    # number of trials simulated
+    assert len(net.trial_event_times) == params['N_trials']
+
     if backend == 'mpi':
         with MPIBackend(n_procs=n_procs, mpi_cmd='mpiexec'):
             dpls = simulate_dipole(net)


### PR DESCRIPTION
Based on the work done in #177, continue creating new API for adding (and activating/simulating) external drives of the network (currently 'feeds'). Some ideas are discussed in a separate Doc (contact @cjayb for access). This is going to be a test-breaking PR due to very idiosyncratic handling of random seeds used in HNN-GUI feed assignment.

Edit 6 Nov:
Discussed GID-handling with @jasmainak and figured much could be won by disentangling it from NetworkBuilder. As it stands, `Network` creates the `gid_dict` on initialisation, so all that's really left for `Builder` to do is assign them to the different nodes (ranks).

Aims
- [x] clarify GID creation & handling
- [x] move all `ExtFeed` calls into `Network`, allowing instantiation of all external drives before `NetworkBuilder` is called (check old "API" still works)
- [x] move `parallel_backends.py:_clone_and_simulate:L34-35` to `NetworkBuilder` in order to "provide jitter between trials" (`prng_seedcore` needs to be different)
  * turned out not to be needed
- [x] generally refactor `Network` and `NetworkBuilder` so that building a new mechanism easier (separate PR)

For future PR
- demonstrate API ideas to allow incrementally adding drives
- create new tests of `Network` event times
- create new visualisations of `Network` event times 
- discuss and settle on seed handling 
- probably more...

Closes #104 
