### PR TITLE
[MRG]: BUG: fix MPI child communication, add several improvements w/ unit testing

### DIFF
--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -88,9 +88,10 @@ class MPISimulation(object):
         sys.stderr.write(pickled_bytes.decode())
         sys.stderr.flush()
 
-        # the parent process is waiting for "end_of_sim:[#bytes]" with the
-        # length of data
-        sys.stderr.write('end_of_data:%d' % len(pickled_bytes))
+        # the parent process is waiting for "@end_of_sim:[#bytes]@" with the
+        # length of data. The '@' is not found in base64 encoding, so we can
+        # be certain it is the border of the signal
+        sys.stderr.write('@end_of_data:%d@' % len(pickled_bytes))
         sys.stderr.flush()  # flush to ensure signal is not buffered
 
     def run(self, params):

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -170,6 +170,8 @@ class MPIBackend(object):
         if mpi4py could not be loaded.
     mpi_cmd_str : str
         The string of the mpi command with number of procs and options
+    proc_data_bytes: bytes object
+        This will contain data received from the MPI child process via stderr.
 
     """
     def __init__(self, n_procs=None, mpi_cmd='mpiexec'):
@@ -252,7 +254,7 @@ class MPIBackend(object):
     def _read_stderr(self, fd, mask):
         """read stderr from fd until end of simulation signal is received"""
         data = _read_all_bytes(fd)
-        if data:
+        if len(data) > 0:
             str_data = data.decode()
             if '@' in str_data:
                 # extract the signal
@@ -290,7 +292,7 @@ class MPIBackend(object):
     def _read_stdout(self, fd, mask):
         """read stdout fd until receiving the process simulation is complete"""
         data = _read_all_bytes(fd)
-        if data:
+        if len(data) > 0:
             str_data = data.decode()
             if str_data == 'end_of_sim':
                 return str_data

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -62,6 +62,17 @@ def _gather_trial_data(sim_data, net, n_trials):
     return dpls
 
 
+def _read_all_bytes(fd, chunk_size=4096):
+    all_data = b""
+    while True:
+        data = os.read(fd, chunk_size)
+        all_data += data
+        if len(data) < chunk_size:
+            break
+
+    return all_data
+
+
 class JoblibBackend(object):
     """The JoblibBackend class.
 
@@ -239,7 +250,7 @@ class MPIBackend(object):
 
     def _read_stderr(self, fd, mask):
         """read stderr from fd until end of simulation signal is received"""
-        data = os.read(fd, 4096)
+        data = _read_all_bytes(fd)
         if data:
             str_data = data.decode()
             if 'end_of_data' in str_data:
@@ -253,7 +264,7 @@ class MPIBackend(object):
 
     def _read_stdout(self, fd, mask):
         """read stdout fd until receiving the process simulation is complete"""
-        data = os.read(fd, 4096)
+        data = _read_all_bytes(fd)
         if data:
             str_data = data.decode()
             if str_data == 'end_of_sim' or str_data.startswith('end_of_data'):

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -401,9 +401,9 @@ class MPIBackend(object):
             if not proc.poll() is None:
                 if completed is True:
                     break
-                elif timeout > 9:
+                elif timeout > 4:
                     # This is indicative of a failure. For debugging purposes.
-                    warn("Timed out (10s) waiting for end of data after child "
+                    warn("Timed out (5s) waiting for end of data after child "
                          "process stopped")
                     break
                 else:

--- a/hnn_core/tests/conftest.py
+++ b/hnn_core/tests/conftest.py
@@ -1,0 +1,59 @@
+""" Example from pytest documentation
+
+https://pytest.org/en/stable/example/simple.html#incremental-testing-test-steps
+"""
+
+from typing import Dict, Tuple
+import pytest
+
+# store history of failures per test class name and per index in parametrize
+# (if parametrize used)
+_test_failed_incremental: Dict[str, Dict[Tuple[int, ...], str]] = {}
+
+
+def pytest_runtest_makereport(item, call):
+
+    if "incremental" in item.keywords:
+        # incremental marker is used
+        if call.excinfo is not None and not call.excinfo.typename == "Skipped":
+            # the test has failed, but was not skiped
+
+            # retrieve the class name of the test
+            cls_name = str(item.cls)
+            # retrieve the index of the test (if parametrize is used in
+            # combination with incremental)
+            parametrize_index = (
+                tuple(item.callspec.indices.values())
+                if hasattr(item, "callspec")
+                else ()
+            )
+            # retrieve the name of the test function
+            test_name = item.originalname or item.name
+            # store in _test_failed_incremental the original name of the
+            # failed test
+            _test_failed_incremental.setdefault(cls_name, {}).setdefault(
+                parametrize_index, test_name
+            )
+
+
+def pytest_runtest_setup(item):
+    if "incremental" in item.keywords:
+        # retrieve the class name of the test
+        cls_name = str(item.cls)
+        # check if a previous test has failed for this class
+        if cls_name in _test_failed_incremental:
+            # retrieve the index of the test (if parametrize is used in
+            # combination with incremental)
+            parametrize_index = (
+                tuple(item.callspec.indices.values())
+                if hasattr(item, "callspec")
+                else ()
+            )
+            # retrieve the name of the first test function to fail for this
+            # class name and index
+            test_name = _test_failed_incremental[cls_name].get(
+                parametrize_index, None)
+            # if name found, test has failed for the combination of class name
+            # and test name
+            if test_name is not None:
+                pytest.xfail("previous test failed ({})".format(test_name))

--- a/hnn_core/tests/conftest.py
+++ b/hnn_core/tests/conftest.py
@@ -15,6 +15,12 @@ def pytest_runtest_makereport(item, call):
 
     if "incremental" in item.keywords:
         # incremental marker is used
+
+        # The following condition was modifed from the example linked above.
+        # We don't want to step out of the incremental testing block if
+        # a previous test was marked "Skipped". For instance if MPI tests
+        # are skipped because mpi4py is not installed, still continue with
+        # all other tests that do not require mpi4py
         if call.excinfo is not None and not call.excinfo.typename == "Skipped":
             # the test has failed, but was not skiped
 

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -37,9 +37,10 @@ def test_child_run():
                 mpi_sim._write_data_stderr(sim_data)
                 stdout = buf_out.getvalue()
             stderr = buf_err.getvalue()
-        assert "end_of_data:" in stdout
+        assert "end_of_data:" in stderr
 
-        data = stderr.encode()
+        # data will all be before "end_of_data"
+        data = stderr.split('end_of_data')[0].encode()
         expected_len = len(data)
         backend = MPIBackend()
         sim_data = backend._process_child_data(data, expected_len)

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -34,6 +34,12 @@ def test_read_stderr():
     with pytest.raises(ValueError, match="Invalid signal start"):
         backend._read_stderr(pipe_stderr_r, selectors.EVENT_READ)
 
+    stderr.write("blahblah@end_of_data:100")
+    stderr.flush()
+    # actually invalid end (only match first part of string)
+    with pytest.raises(ValueError, match="Invalid signal start"):
+        backend._read_stderr(pipe_stderr_r, selectors.EVENT_READ)
+
     stderr.write("@end_of_data:@")
     stderr.flush()
     with pytest.raises(ValueError, match="Completion signal from child MPI "

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -13,17 +13,7 @@ from hnn_core import simulate_dipole, Network, read_params
 from hnn_core import MPIBackend, JoblibBackend
 
 
-def run_hnn_core(backend=None, n_jobs=1):
-    """Test to check if hnn-core does not break."""
-    # small snippet of data on data branch for now. To be deleted
-    # later. Data branch should have only commit so it does not
-    # pollute the history.
-    data_url = ('https://raw.githubusercontent.com/jonescompneurolab/'
-                'hnn-core/test_data/dpl.txt')
-    if not op.exists('dpl.txt'):
-        _fetch_file(data_url, 'dpl.txt')
-    dpl_master = loadtxt('dpl.txt')
-
+def run_hnn_core_reduced(backend=None, n_jobs=1):
     hnn_core_root = op.dirname(hnn_core.__file__)
 
     # default params
@@ -38,21 +28,48 @@ def run_hnn_core(backend=None, n_jobs=1):
                            't_evprox_2': 20,
                            'N_trials': 2})
 
-    # run the simulation on full model (1 trial) and a reduced model (2 trials)
-    net = Network(params)
+    # run the simulation a reduced model (2 trials)
     net_reduced = Network(params_reduced)
 
     if backend == 'mpi':
         with MPIBackend(mpi_cmd='mpiexec'):
-            dpl = simulate_dipole(net)[0]
             dpls_reduced = simulate_dipole(net_reduced)
     elif backend == 'joblib':
         with JoblibBackend(n_jobs=n_jobs):
-            dpl = simulate_dipole(net)[0]
             dpls_reduced = simulate_dipole(net_reduced)
     else:
-        dpl = simulate_dipole(net)[0]
         dpls_reduced = simulate_dipole(net_reduced)
+
+    return dpls_reduced
+
+
+def run_hnn_core(backend=None, n_jobs=1):
+    # small snippet of data on data branch for now. To be deleted
+    # later. Data branch should have only commit so it does not
+    # pollute the history.
+    data_url = ('https://raw.githubusercontent.com/jonescompneurolab/'
+                'hnn-core/test_data/dpl.txt')
+    if not op.exists('dpl.txt'):
+        _fetch_file(data_url, 'dpl.txt')
+    dpl_master = loadtxt('dpl.txt')
+
+    hnn_core_root = op.dirname(hnn_core.__file__)
+
+    # default params
+    params_fname = op.join(hnn_core_root, 'param', 'default.json')
+    params = read_params(params_fname)
+
+    # run the simulation on full model (1 trial)
+    net = Network(params)
+
+    if backend == 'mpi':
+        with MPIBackend(mpi_cmd='mpiexec'):
+            dpl = simulate_dipole(net)[0]
+    elif backend == 'joblib':
+        with JoblibBackend(n_jobs=n_jobs):
+            dpl = simulate_dipole(net)[0]
+    else:
+        dpl = simulate_dipole(net)[0]
 
     # write the dipole to a file and compare
     fname = './dpl2.txt'
@@ -79,65 +96,78 @@ def run_hnn_core(backend=None, n_jobs=1):
                                 'L5_basket': 85,
                                 'evdist1': 234,
                                 'evprox2': 269}
-    return dpls_reduced
 
 
-def test_compare_across_backends():
-    """Test that trials are generated consistently across parallel backends."""
+# The purpose of this incremental mark is to avoid running the full length
+# simulation when there are failures in previous (faster) tests. When a test
+# in the sequence fails, all subsequent tests will be marked "xfailed" rather
+# than skipped.
 
-    # test consistency between default backend simulation and master
-    dpls_reduced_default = run_hnn_core(None)
 
-    try:
-        import mpi4py
-        mpi4py.__file__
-        # test consistency between mpi backend simulation & master
-        dpls_reduced_mpi = run_hnn_core(backend='mpi')
-    except ImportError:
-        print("Skipping MPIBackend test and dipole comparison because mpi4py "
-              "could not be imported...")
-        dpls_reduced_mpi = None
+@pytest.mark.incremental
+class TestParallelBackends():
+    dpls_reduced_mpi = None
+    dpls_reduced_default = None
+    dpls_reduced_joblib = None
 
-    # test consistency between joblib backend simulation (n_jobs=2) with master
-    dpls_reduced_joblib = run_hnn_core(backend='joblib', n_jobs=2)
+    def test_run_default(self):
+        """Test consistency between default backend simulation and master"""
+        global dpls_reduced_default
+        dpls_reduced_default = run_hnn_core_reduced(None)
+        # test consistency across all parallel backends for multiple trials
+        assert_raises(AssertionError, assert_array_equal,
+                      dpls_reduced_default[0].data['agg'],
+                      dpls_reduced_default[1].data['agg'])
 
-    # test consistency across all parallel backends for multiple trials
-    assert_raises(AssertionError, assert_array_equal,
-                  dpls_reduced_default[0].data['agg'],
-                  dpls_reduced_default[1].data['agg'])
+    def test_run_joblibbackend(self):
+        """Test consistency between joblib backend simulation with master"""
+        global dpls_reduced_default, dpls_reduced_joblib
 
-    for trial_idx in range(len(dpls_reduced_default)):
-        # account for rounding error incured during MPI parallelization
-        if dpls_reduced_mpi:
+        dpls_reduced_joblib = run_hnn_core_reduced(backend='joblib', n_jobs=2)
+
+        for trial_idx in range(len(dpls_reduced_default)):
+            assert_array_equal(dpls_reduced_default[trial_idx].data['agg'],
+                               dpls_reduced_joblib[trial_idx].data['agg'])
+
+    def test_mpi_nprocs(self):
+        """Test that MPIBackend can use more than 1 processor"""
+        # if only 1 processor is available, then MPIBackend tests will not
+        # be valid
+        pytest.importorskip("mpi4py", reason="mpi4py not available")
+
+        backend = MPIBackend()
+        assert backend.n_procs > 1
+
+    def test_run_mpibackend(self):
+        global dpls_reduced_default, dpls_reduced_mpi
+        pytest.importorskip("mpi4py", reason="mpi4py not available")
+        dpls_reduced_mpi = run_hnn_core_reduced(backend='mpi')
+        for trial_idx in range(len(dpls_reduced_default)):
+            # account for rounding error incured during MPI parallelization
             assert_allclose(dpls_reduced_default[trial_idx].data['agg'],
                             dpls_reduced_mpi[trial_idx].data['agg'], rtol=0,
                             atol=1e-14)
-        assert_array_equal(dpls_reduced_default[trial_idx].data['agg'],
-                           dpls_reduced_joblib[trial_idx].data['agg'])
+
+    def test_compare_hnn_core(self):
+        """Test to check if hnn-core does not break."""
+        # run one trial of each
+        run_hnn_core(backend='mpi')
+        run_hnn_core(backend='joblib')
 
 
+# there are no dependencies if this unit tests fails, so not necessary to
+# be part of incremental class
 def test_mpi_failure():
-    """Test that an MPI failure is handled and error messages pass through"""
+    """Test that an MPI failure is handled and messages are printed"""
     pytest.importorskip("mpi4py", reason="mpi4py not available")
 
-    # this MPI paramter will cause a MPI job with more than one process to fail
+    # this MPI paramter will cause a MPI job to fail
     environ["OMPI_MCA_btl"] = "self"
 
     with io.StringIO() as buf, redirect_stdout(buf):
         with pytest.raises(RuntimeError, match="MPI simulation failed"):
-            run_hnn_core(backend='mpi')
+            run_hnn_core_reduced(backend='mpi')
         stdout = buf.getvalue()
     assert "MPI processes are unable to reach each other" in stdout
 
     del environ["OMPI_MCA_btl"]
-
-
-def test_mpi_nprocs():
-    """Test that MPIBackend can use more than 1 processor"""
-
-    # if only 1 processor is available, then MPIBackend tests will not
-    # be valid
-    pytest.importorskip("mpi4py", reason="mpi4py not available")
-
-    backend = MPIBackend()
-    assert backend.n_procs > 1

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -1,14 +1,14 @@
 import os.path as op
 from os import environ
-import pytest
 import io
 from contextlib import redirect_stdout
 from multiprocessing import cpu_count
-
 from numpy import loadtxt
 from numpy.testing import assert_array_equal, assert_allclose, assert_raises
 
+import pytest
 from mne.utils import _fetch_file
+
 import hnn_core
 from hnn_core import simulate_dipole, Network, read_params
 from hnn_core import MPIBackend, JoblibBackend
@@ -99,7 +99,7 @@ class TestParallelBackends():
         """Test running MPIBackend with oversubscribed number of procs"""
         pytest.importorskip("mpi4py", reason="mpi4py not available")
 
-        oversubscribed = cpu_count() * 1
+        oversubscribed = round(cpu_count() * 1.5)
         run_hnn_core(backend='mpi', n_procs=oversubscribed, reduced=True)
 
     @pytest.mark.parametrize("backend", ['mpi', 'joblib'])

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -14,7 +14,21 @@ from hnn_core import simulate_dipole, Network, read_params
 from hnn_core import MPIBackend, JoblibBackend
 
 
-def run_hnn_core(params, backend=None, n_procs=None, n_jobs=1):
+def run_hnn_core(backend=None, n_procs=None, n_jobs=1, reduced=False):
+    hnn_core_root = op.dirname(hnn_core.__file__)
+
+    # default params
+    params_fname = op.join(hnn_core_root, 'param', 'default.json')
+    params = read_params(params_fname)
+
+    if reduced:
+        params.update({'N_pyr_x': 3,
+                       'N_pyr_y': 3,
+                       'tstop': 25,
+                       't_evprox_1': 5,
+                       't_evdist_1': 10,
+                       't_evprox_2': 20,
+                       'N_trials': 2})
     net = Network(params)
 
     if backend == 'mpi':
@@ -27,72 +41,6 @@ def run_hnn_core(params, backend=None, n_procs=None, n_jobs=1):
         dpls = simulate_dipole(net)
 
     return dpls, net
-
-
-def run_hnn_core_reduced(backend=None, n_procs=None, n_jobs=1):
-    hnn_core_root = op.dirname(hnn_core.__file__)
-
-    # default params
-    params_fname = op.join(hnn_core_root, 'param', 'default.json')
-    params = read_params(params_fname)
-    params_reduced = params.copy()
-    # reduced model params (2 trials)
-    params_reduced.update({'N_pyr_x': 3,
-                           'N_pyr_y': 3,
-                           'tstop': 25,
-                           't_evprox_1': 5,
-                           't_evdist_1': 10,
-                           't_evprox_2': 20,
-                           'N_trials': 2})
-
-    return run_hnn_core(params_reduced, backend=backend, n_procs=n_procs,
-                        n_jobs=n_jobs)
-
-
-def compare_hnn_core(backend=None, n_jobs=1):
-    # small snippet of data on data branch for now. To be deleted
-    # later. Data branch should have only commit so it does not
-    # pollute the history.
-    data_url = ('https://raw.githubusercontent.com/jonescompneurolab/'
-                'hnn-core/test_data/dpl.txt')
-    if not op.exists('dpl.txt'):
-        _fetch_file(data_url, 'dpl.txt')
-    dpl_master = loadtxt('dpl.txt')
-
-    hnn_core_root = op.dirname(hnn_core.__file__)
-
-    # default params
-    params_fname = op.join(hnn_core_root, 'param', 'default.json')
-    params = read_params(params_fname)
-
-    dpls, net = run_hnn_core(params, backend)
-    dpl = dpls[0]
-
-    # write the dipole to a file and compare
-    fname = './dpl2.txt'
-    dpl.write(fname)
-
-    dpl_pr = loadtxt(fname)
-    assert_array_equal(dpl_pr[:, 2], dpl_master[:, 2])  # L2
-    assert_array_equal(dpl_pr[:, 3], dpl_master[:, 3])  # L5
-
-    # Test spike type counts
-    spiketype_counts = {}
-    for spikegid in net.spikes.gids[0]:
-        if net.gid_to_type(spikegid) not in spiketype_counts:
-            spiketype_counts[net.gid_to_type(spikegid)] = 0
-        else:
-            spiketype_counts[net.gid_to_type(spikegid)] += 1
-    assert 'common' not in spiketype_counts
-    assert 'exgauss' not in spiketype_counts
-    assert 'extpois' not in spiketype_counts
-    assert spiketype_counts == {'evprox1': 269,
-                                'L2_basket': 54,
-                                'L2_pyramidal': 113,
-                                'L5_pyramidal': 395,
-                                'L5_basket': 85,
-                                'evdist1': 234,
-                                'evprox2': 269}
 
 
 # The purpose of this incremental mark is to avoid running the full length
@@ -110,7 +58,7 @@ class TestParallelBackends():
     def test_run_default(self):
         """Test consistency between default backend simulation and master"""
         global dpls_reduced_default
-        dpls_reduced_default, _ = run_hnn_core_reduced(None)
+        dpls_reduced_default, _ = run_hnn_core(None, reduced=True)
         # test consistency across all parallel backends for multiple trials
         assert_raises(AssertionError, assert_array_equal,
                       dpls_reduced_default[0].data['agg'],
@@ -120,8 +68,8 @@ class TestParallelBackends():
         """Test consistency between joblib backend simulation with master"""
         global dpls_reduced_default, dpls_reduced_joblib
 
-        dpls_reduced_joblib, _ = run_hnn_core_reduced(backend='joblib',
-                                                      n_jobs=2)
+        dpls_reduced_joblib, _ = run_hnn_core(backend='joblib',
+                                              n_jobs=2, reduced=True)
 
         for trial_idx in range(len(dpls_reduced_default)):
             assert_array_equal(dpls_reduced_default[trial_idx].data['agg'],
@@ -140,7 +88,7 @@ class TestParallelBackends():
         """Test running a MPIBackend on reduced model"""
         global dpls_reduced_default, dpls_reduced_mpi
         pytest.importorskip("mpi4py", reason="mpi4py not available")
-        dpls_reduced_mpi, _ = run_hnn_core_reduced(backend='mpi')
+        dpls_reduced_mpi, _ = run_hnn_core(backend='mpi', reduced=True)
         for trial_idx in range(len(dpls_reduced_default)):
             # account for rounding error incured during MPI parallelization
             assert_allclose(dpls_reduced_default[trial_idx].data['agg'],
@@ -152,13 +100,54 @@ class TestParallelBackends():
         pytest.importorskip("mpi4py", reason="mpi4py not available")
 
         oversubscribed = cpu_count() * 1
-        run_hnn_core_reduced(backend='mpi', n_procs=oversubscribed)
+        run_hnn_core(backend='mpi', n_procs=oversubscribed, reduced=True)
 
-    def test_compare_hnn_core(self):
+    @pytest.mark.parametrize("backend", ['mpi', 'joblib'])
+    def test_compare_hnn_core(self, backend, n_jobs=1):
         """Test hnn-core does not break."""
-        # run one trial of each
-        compare_hnn_core(backend='mpi')
-        compare_hnn_core(backend='joblib')
+        # small snippet of data on data branch for now. To be deleted
+        # later. Data branch should have only commit so it does not
+        # pollute the history.
+        data_url = ('https://raw.githubusercontent.com/jonescompneurolab/'
+                    'hnn-core/test_data/dpl.txt')
+        if not op.exists('dpl.txt'):
+            _fetch_file(data_url, 'dpl.txt')
+        dpl_master = loadtxt('dpl.txt')
+
+        hnn_core_root = op.dirname(hnn_core.__file__)
+
+        # default params
+        params_fname = op.join(hnn_core_root, 'param', 'default.json')
+        params = read_params(params_fname)
+
+        dpls, net = run_hnn_core(params, backend)
+        dpl = dpls[0]
+
+        # write the dipole to a file and compare
+        fname = './dpl2.txt'
+        dpl.write(fname)
+
+        dpl_pr = loadtxt(fname)
+        assert_array_equal(dpl_pr[:, 2], dpl_master[:, 2])  # L2
+        assert_array_equal(dpl_pr[:, 3], dpl_master[:, 3])  # L5
+
+        # Test spike type counts
+        spiketype_counts = {}
+        for spikegid in net.spikes.gids[0]:
+            if net.gid_to_type(spikegid) not in spiketype_counts:
+                spiketype_counts[net.gid_to_type(spikegid)] = 0
+            else:
+                spiketype_counts[net.gid_to_type(spikegid)] += 1
+        assert 'common' not in spiketype_counts
+        assert 'exgauss' not in spiketype_counts
+        assert 'extpois' not in spiketype_counts
+        assert spiketype_counts == {'evprox1': 269,
+                                    'L2_basket': 54,
+                                    'L2_pyramidal': 113,
+                                    'L5_pyramidal': 395,
+                                    'L5_basket': 85,
+                                    'evdist1': 234,
+                                    'evprox2': 269}
 
 
 # there are no dependencies if this unit tests fails; no need to be in
@@ -173,7 +162,7 @@ def test_mpi_failure():
     with pytest.warns(UserWarning) as record:
         with io.StringIO() as buf, redirect_stdout(buf):
             with pytest.raises(RuntimeError, match="MPI simulation failed"):
-                run_hnn_core_reduced(backend='mpi')
+                run_hnn_core(backend='mpi', reduced=True)
             stdout = buf.getvalue()
 
     assert "MPI processes are unable to reach each other" in stdout

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -178,7 +178,7 @@ def test_mpi_failure():
 
     assert "MPI processes are unable to reach each other" in stdout
 
-    expected_string = "Timed out (10s) waiting for end of data " + \
+    expected_string = "Timed out (5s) waiting for end of data " + \
         "after child process stopped"
     assert len(record) == 1
     assert record[0].message.args[0] == expected_string

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    incremental: run tests with prerequisites in incremental order


### PR DESCRIPTION
This should address the issues with #190, finally (I've tested on a rebased branch with code from #190). The key fix was simple: 2e425c53ad60fe223ede18050a52d047c2202447. When the system is slow (e.g. Travis) is might accumulate more than 4k in the stderr buffer and only the first 4k would get read.

During the search for this bug, I made many improvements that should make life easier for everyone going forward. The changes to the MPI child communication scheme have a bunch of unit tests. The largest change for discussion is the testing scheme code for parallel backends... @jasmainak @rythorpe @ntolley 

It drove me mad trying to fix Travis issues when the time to complete tests and print errors is ~10 minutes. While we are still validating the MPIBackend and adding new simuatlion outputs, I think having the full simulation is useful. So I updated `test_parallel_backends.py` to make my life easier, and it's included in this PR.

1. There is a custom pytest marker `incremental` that is defined in `conftest.py` and declared in `pytest.ini`. It allows a failing test (e.g. a reduced mpi simulation) to cancel subsequent tests (e.g. the full lengthl mpi and joblib comparison test). This was an example from pytest's documentation and it doesn't require any additional modules.
2. If `mpi4py` isn't installed, then MPI tests are skipped, but that does cause subsequent tests to be skipped (as long as they don't require `mpi4py`). This seems to be the appropriate solution to the issue @ntolley ran into when testing locally without `mpi4py`.
3. The test `test_mpi_nprocs` is pretty important to make a prerequisite for later mpi tests. If there is truly only one processor available, then mpi tests aren't useful tests (and the user should be aware).
4. Each test in `test_parallel_backends.py` performs a specific purpose. Code for running simulations is made as modular as possible. I find this easier to follow than the previous `test_compare_hnn` that ran reduced and full-length simulations all together.