### PR TITLE
MRG: fix reference to initial prng seedcore params

### DIFF
--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -274,7 +274,7 @@ class Network(object):
         cur_params = self.params.copy()  # these get mangled below!
         for trial_idx in range(n_trials):
 
-            prng_seedcore_initial = cur_params['prng_*'].copy()
+            prng_seedcore_initial = self.params['prng_*'].copy()
             for param_key in prng_seedcore_initial.keys():
                 cur_params[param_key] =\
                     prng_seedcore_initial[param_key] + trial_idx

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -273,11 +273,8 @@ class Network(object):
 
         cur_params = self.params.copy()  # these get mangled below!
         for trial_idx in range(n_trials):
-
-            prng_seedcore_initial = self.params['prng_*'].copy()
-            for param_key in prng_seedcore_initial.keys():
-                cur_params[param_key] =\
-                    prng_seedcore_initial[param_key] + trial_idx
+            for param_key in self.params['prng_*'].keys():
+                cur_params[param_key] = self.params[param_key] + trial_idx
             # needs to be re-run to create the dicts going into ExtFeed
             # the only thing changing is the initial seed
             p_common, p_unique = create_pext(cur_params,


### PR DESCRIPTION
This fixes a silent discrepancy that emerged from time-to-time where a change in the codebase causes the random state for inter-trial variance to iterate recursively across trials. For example, the current master branch will take a gid of 1 and iterate the next trial's prng_seedcore value using the previous trial's value as reference. The set of prng_seedcore values across trials is thus {1+0=1, 1+1=2, 2+2=4, 4+3=7, ...} when we expect it to be {1+0=1, 1+1=2, 1+2=3, ...}.

The plot below shows that with https://github.com/jonescompneurolab/hnn-core/commit/959f94681c41edbc2dab5795d4c31d9771557f67, the output of 4 trials run with `default.json`/`default.param` is consistent between hnn and hnn-core. The top plot shows trials generated with hnn-core, the bottom plot shows trials generated from hnn that have been read back into hnn-core. Note that the default parameter set *only* contains evoked inputs and thus addresses #113 *only* within the context of evoked inputs.

![Screenshot from 2020-11-24 16-42-19](https://user-images.githubusercontent.com/20212206/100155194-d20bba00-2e74-11eb-80ac-a7c9b06b31e4.png)
