### PR TITLE
[MRG] clarify alpha example by removing evoked inputs

### DIFF
--- a/examples/plot_simulate_alpha.py
+++ b/examples/plot_simulate_alpha.py
@@ -29,31 +29,29 @@ params = read_params(params_fname)
 print(params)
 
 ###############################################################################
-# Now, we update a few parameters
+# Remove all evoked proximal feed parameters
+evoked_prox_keys = params['*evprox*'].keys()
+for key in evoked_prox_keys:
+    del params[key]
+
+# Remove all evoked distal feed parameters
+evoked_dist_keys = params['*evdist*'].keys()
+for key in evoked_dist_keys:
+    del params[key]
+
+###############################################################################
+# Now, we update a few rhythmic feed parameters
 params.update({
     'dipole_scalefctr': 150000.0,
     'dipole_smooth_win': 0,
     'tstop': 310.0,
-    't0_input_prox': 2000.0,
-    'tstop_input_prox': 310.0,
     't0_input_dist': 50.0,
     'tstop_input_dist': 1001.0,
-    't_evprox_1': 1000,
-    'sigma_t_evprox_1': 2.5,
-    't_evprox_2': 2000.0,
-    'sigma_t_evprox_2': 7.0,
-    't_evdist_1': 2000.0,
-    'sigma_t_evdist_1': 6.0,
     'input_dist_A_weight_L2Pyr_ampa': 5.4e-5,
     'input_dist_A_weight_L5Pyr_ampa': 5.4e-5,
     'sync_evinput': 1,
     "prng_seedcore_input_dist": 3
 })
-
-###############################################################################
-# And we update all the conductances gbar related to the inputs
-# by using the pattern gbar_ev*
-params['gbar_ev*'] = 0.0
 
 ###############################################################################
 # Now let's simulate the dipole and plot it

--- a/examples/plot_simulate_alpha.py
+++ b/examples/plot_simulate_alpha.py
@@ -30,13 +30,11 @@ print(params)
 
 ###############################################################################
 # Remove all evoked proximal feed parameters
-evoked_prox_keys = params['*evprox*'].keys()
-for key in evoked_prox_keys:
+for key in params['*evprox*']:
     del params[key]
 
 # Remove all evoked distal feed parameters
-evoked_dist_keys = params['*evdist*'].keys()
-for key in evoked_dist_keys:
+for key in params['*evdist*']:
     del params[key]
 
 ###############################################################################


### PR DESCRIPTION
This clarifies which parameters are being changed in the default parameter set in order to create the alpha example. Specifically, I propose that we explicitly remove all parameters that pertain to proximal or distal evoked feeds. Note that the simulation produced on my branch (shown below) matches the [alpha simulation](https://jonescompneurolab.github.io/hnn-core/auto_examples/plot_simulate_alpha.html#sphx-glr-auto-examples-plot-simulate-alpha-py) produced on master.

![Screen Shot 2020-11-27 at 6 55 27 PM](https://user-images.githubusercontent.com/20212206/100489629-58c5ce80-30e3-11eb-934b-bbe151384063.png)
