### PR TITLE
WIP: Convert CellResponse to list stored by Network

### DIFF
--- a/examples/plot_firing_pattern.py
+++ b/examples/plot_firing_pattern.py
@@ -38,18 +38,17 @@ gid_ranges = net.gid_ranges
 print(net.gid_ranges)
 
 ###############################################################################
-# Simulated voltage in the soma is stored in CellResponse as a dictionary.
+# Simulated voltage in the soma is stored in CellResponse.
 # The CellResponse object stores data produced by individual cells including
 # spikes, somatic voltages and currents.
-trial_idx = 0
-vsoma = net.cell_response.vsoma[trial_idx]
-print(vsoma.keys())
+trial_idx, gid = 0, 170
+vsoma = net.cell_response[gid].vsoma[trial_idx]
 
 ###############################################################################
 # We can plot the firing pattern of individual cells by indexing with the gid
 gid = 170
 plt.figure(figsize=(4, 4))
-plt.plot(net.cell_response.times, vsoma[gid])
+plt.plot(net.times, net.cell_response[gid].vsoma[trial_idx])
 plt.title('%s (gid=%d)' % (net.gid_to_type(gid), gid))
 plt.xlabel('Time (ms)')
 plt.ylabel('Voltage (mV)')
@@ -63,10 +62,8 @@ fig, axes = plt.subplots(3, 1, figsize=(5, 7), sharex=True)
 
 for idx in range(10):  # only 10 cells per cell-type
     gid = gid_ranges['L2_pyramidal'][idx]
-    axes[0].plot(net.cell_response.times, vsoma[gid], color='g')
+    axes[0].plot(net.times, net.cell_response[gid].vsoma[trial_idx], color='g')
     gid = gid_ranges['L5_pyramidal'][idx]
-    axes[0].plot(net.cell_response.times, vsoma[gid], color='r')
-net.cell_response.plot_spikes_raster(ax=axes[1])
-net.cell_response.plot_spikes_hist(ax=axes[2],
-                                   spike_types=['L5_pyramidal',
-                                                'L2_pyramidal'])
+    axes[0].plot(net.times, net.cell_response[gid].vsoma[trial_idx], color='r')
+net.plot_spikes_raster(ax=axes[1])
+net.plot_spikes_hist(ax=axes[2], spike_types=['L5_pyramidal', 'L2_pyramidal'])

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -53,8 +53,7 @@ with JoblibBackend(n_jobs=1):
 import matplotlib.pyplot as plt
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 plot_dipole(dpls, ax=axes[0], layer='agg', show=False)
-net.plot_spikes_hist(ax=axes[1],
-                                   spike_types=['evprox', 'evdist'])
+net.plot_spikes_hist(ax=axes[1], spike_types=['evprox', 'evdist'])
 
 ###############################################################################
 # Also, we can plot the spikes and write them to txt files.
@@ -69,12 +68,10 @@ print(cell_response[0])
 ###############################################################################
 # We can additionally calculate the mean spike rates for each cell class by
 # specifying a time window with tstart and tstop.
-all_rates = net.mean_rates(tstart=0, tstop=170,
-                                     gid_ranges=net.gid_ranges,
-                                     mean_type='all')
-trial_rates = net.mean_rates(tstart=0, tstop=170,
-                                       gid_ranges=net.gid_ranges,
-                                       mean_type='trial')
+all_rates = net.mean_rates(
+    tstart=0, tstop=170, gid_ranges=net.gid_ranges, mean_type='all')
+trial_rates = net.mean_rates(
+    tstart=0, tstop=170, gid_ranges=net.gid_ranges, mean_type='trial')
 print('Mean spike rates across trials:')
 print(all_rates)
 print('Mean spike rates for individual trials:')

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -53,7 +53,7 @@ with JoblibBackend(n_jobs=1):
 import matplotlib.pyplot as plt
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 plot_dipole(dpls, ax=axes[0], layer='agg', show=False)
-net.cell_response.plot_spikes_hist(ax=axes[1],
+net.plot_spikes_hist(ax=axes[1],
                                    spike_types=['evprox', 'evdist'])
 
 ###############################################################################
@@ -61,19 +61,18 @@ net.cell_response.plot_spikes_hist(ax=axes[1],
 # Note that we can use formatting syntax to specify the filename pattern
 # with which each trial will be written. To read spikes back in, we can use
 # wildcard expressions.
-net.cell_response.plot_spikes_raster()
+net.plot_spikes_raster()
 with tempfile.TemporaryDirectory() as tmp_dir_name:
-    net.cell_response.write(op.join(tmp_dir_name, 'spk_%d.txt'))
+    net.write(op.join(tmp_dir_name, 'spk_%d.txt'))
     cell_response = read_spikes(op.join(tmp_dir_name, 'spk_*.txt'))
-cell_response.plot_spikes_raster()
-
+print(cell_response[0])
 ###############################################################################
 # We can additionally calculate the mean spike rates for each cell class by
 # specifying a time window with tstart and tstop.
-all_rates = cell_response.mean_rates(tstart=0, tstop=170,
+all_rates = net.mean_rates(tstart=0, tstop=170,
                                      gid_ranges=net.gid_ranges,
                                      mean_type='all')
-trial_rates = cell_response.mean_rates(tstart=0, tstop=170,
+trial_rates = net.mean_rates(tstart=0, tstop=170,
                                        gid_ranges=net.gid_ranges,
                                        mean_type='trial')
 print('Mean spike rates across trials:')
@@ -100,4 +99,4 @@ with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
     dpls_sync = simulate_dipole(net_sync, n_trials=1)
 
 dpls_sync[0].plot()
-net_sync.cell_response.plot_spikes_hist()
+net_sync.plot_spikes_hist()

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -82,5 +82,5 @@ dpl = simulate_dipole(net, n_trials=1)
 import matplotlib.pyplot as plt
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 dpl[0].plot(ax=axes[0], show=False)
-net.cell_response.plot_spikes_hist(ax=axes[1])
-net.cell_response.plot_spikes_raster()
+net.plot_spikes_hist(ax=axes[1])
+net.plot_spikes_raster()

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -425,7 +425,7 @@ class CellResponse(object):
     gid : float | None
         Numeric cell identifier.
         Each gid corresponds to a type via Network::gid_ranges.
-    spike_type : str | None
+    cell_type : str | None
         Cell type (example: L2_basket)
     spike_times : list (n_trials,) of list (n_spikes,) of float, shape | None
         Each element of the outer list is a trial.
@@ -436,7 +436,7 @@ class CellResponse(object):
     gid : float | None
         Numeric cell identifier.
         Each gid corresponds to a type via Network::gid_ranges.
-    spike_type : str | None
+    cell_type : str | None
         Cell type (example: L2_basket)
     spike_times : list (n_trials,) of list (n_spikes,) of float, shape
         Each element of the outer list is a trial.
@@ -465,18 +465,18 @@ class CellResponse(object):
         Write spiking activity to a collection of spike trial files.
     """
 
-    def __init__(self, spike_times=None, gid=None, spike_type=None,
+    def __init__(self, spike_times=None, gid=None, cell_type=None,
                  times=None):
         if spike_times is None:
             spike_times = list()
         if gid is None:
             spike_gids = list()
-        if spike_type is None:
-            spike_type = list()
+        if cell_type is None:
+            cell_type = list()
 
         # Validate arguments
-        arg_names = ['spike_times', 'gid', 'spike_type']
-        for arg_idx, arg in enumerate([spike_times, spike_gids, spike_type]):
+        arg_names = ['spike_times', 'gid', 'cell_type']
+        for arg_idx, arg in enumerate([spike_times, spike_gids, cell_type]):
             # Validate outer list
             if not isinstance(arg, list):
                 raise TypeError('%s should be a list of lists'
@@ -495,7 +495,7 @@ class CellResponse(object):
                                  'lists of the same length')
         self._spike_times = spike_times
         self._gid = gid
-        self._spike_type = spike_type
+        self._cell_type = cell_type
         self._vsoma = list()
         self._isoma = list()
         if times is not None:
@@ -518,7 +518,7 @@ class CellResponse(object):
                        for trial in other._spike_times]
         return (times_self == times_other and
                 self._gid == other._gid and
-                self._spike_type == other._spike_type)
+                self._cell_type == other._cell_type)
 
     @property
     def spike_times(self):
@@ -529,8 +529,8 @@ class CellResponse(object):
         return self._gid
 
     @property
-    def spike_type(self):
-        return self._spike_type
+    def cell_type(self):
+        return self._cell_type
 
     @property
     def vsoma(self):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -54,7 +54,7 @@ def read_spikes(fname, gid_ranges=None):
 
     all_spike_gids = np.array(sum(spike_gids, []))
     all_spike_types = np.array(sum(spike_types, []))
-    gid_list = np.unique(all_spike_gids)
+    gid_list = np.arange(np.max(all_spike_gids))
 
     if gid_ranges is not None:
         validate_gid_ranges(gid_ranges)
@@ -67,17 +67,20 @@ def read_spikes(fname, gid_ranges=None):
                                                       cell_type=cell_type))
 
     else:
-        cell_response = [CellResponse(gid=gid) for
-                         gid in range(np.max(gid_list))]
+        cell_response = []
         for gid in gid_list:
-            cell_type_idx = np.where(all_spike_gids == gid)[0]
-            cell_response[gid].cell_type = all_spike_types[cell_type_idx]
+            cell_type_idx = np.where(all_spike_gids == gid)
+            if cell_type_idx:
+                cell_type = all_spike_types[cell_type_idx[0]]
+            else:
+                cell_type = None
+            cell_response.append(CellResponse(gid=gid, cell_type=cell_type))
 
     for trial in range(len(spike_times)):
         for cell_resp in cell_response:
             gid = cell_resp.gid
             gid_mask = np.array(spike_gids[trial]) == gid
-            gid_spike_times = np.array(spike_times)[trial][gid_mask].tolist()
+            gid_spike_times = np.array(spike_times[trial])[gid_mask].tolist()
             cell_response[gid].spike_times.append(gid_spike_times)
 
     return cell_response

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -181,7 +181,7 @@ class Network(object):
         # NB (only) used to initialise self.cell_response._times
         self.times = np.arange(0., params['tstop'] + params['dt'], params['dt'])
         # Create CellResponse object, initialised with simulation time points
-        self.cell_response = dict()
+        self.cell_response = list()
 
         # Source list of names, first real ones only!
         self.cellname_list = [

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -60,16 +60,19 @@ def read_spikes(fname, gid_ranges=None):
         validate_gid_ranges(gid_ranges)
         cell_response = []
         for cell_type, gid_range in gid_ranges.items():
-            for gid in gid_range:
-                cell_response.append(CellResponse(gid=gid, cell_type=cell_type))
+            if cell_type in ['L2_basket', 'L2_pyramidal', 'L5_basket', 'L5_pyramidal']:
+                for gid in gid_range:
+                    cell_response.append(CellResponse(gid=gid, cell_type=cell_type))
 
     else:
         cell_response = [CellResponse(gid=gid) for gid in range(np.max(gid_list))]
         for gid in gid_list:
             cell_type_idx = np.where(all_spike_gids == gid)[0]
+            cell_response[gid].cell_type = all_spike_types[cell_type_idx]
 
     for trial in range(len(spike_times)):
-        for gid in np.unique(spike_gids[trial]):
+        for cell_resp in cell_response:
+            gid = cell_resp.gid
             gid_mask = np.array(spike_gids[trial]) == gid
             gid_spike_times = np.array(spike_times)[trial][gid_mask].tolist()
             cell_response[gid].spike_times.append(gid_spike_times)

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -55,17 +55,20 @@ def read_spikes(fname, gid_ranges=None):
     all_spike_gids = np.array(sum(spike_gids, []))
     all_spike_types = np.array(sum(spike_types, []))
     gid_list = np.unique(all_spike_gids)
-        
+
     if gid_ranges is not None:
         validate_gid_ranges(gid_ranges)
         cell_response = []
         for cell_type, gid_range in gid_ranges.items():
-            if cell_type in ['L2_basket', 'L2_pyramidal', 'L5_basket', 'L5_pyramidal']:
+            if cell_type in ['L2_basket', 'L2_pyramidal',
+                             'L5_basket', 'L5_pyramidal']:
                 for gid in gid_range:
-                    cell_response.append(CellResponse(gid=gid, cell_type=cell_type))
+                    cell_response.append(CellResponse(gid=gid,
+                                                      cell_type=cell_type))
 
     else:
-        cell_response = [CellResponse(gid=gid) for gid in range(np.max(gid_list))]
+        cell_response = [CellResponse(gid=gid) for
+                         gid in range(np.max(gid_list))]
         for gid in gid_list:
             cell_type_idx = np.where(all_spike_gids == gid)[0]
             cell_response[gid].cell_type = all_spike_types[cell_type_idx]
@@ -78,6 +81,7 @@ def read_spikes(fname, gid_ranges=None):
             cell_response[gid].spike_times.append(gid_spike_times)
 
     return cell_response
+
 
 def validate_gid_ranges(gid_ranges):
     """Check for non-overlapping gid ranges.
@@ -96,8 +100,9 @@ def validate_gid_ranges(gid_ranges):
             gid_set_2 = set(all_gid_ranges[item_idx_2])
             if not gid_set_1.isdisjoint(gid_set_2):
                 raise ValueError('gid_ranges should contain only disjoint '
-                                    'sets of gid values')
+                                 'sets of gid values')
     return
+
 
 def _create_cell_coords(n_pyr_x, n_pyr_y, zdiff=1307.4):
     """Creates coordinate grid and place cells in it.
@@ -229,7 +234,8 @@ class Network(object):
 
         # Create array of equally sampled time points for simulating currents
         # NB (only) used to initialise self.cell_response._times
-        self.times = np.arange(0., params['tstop'] + params['dt'], params['dt'])
+        self.times = np.arange(0., params['tstop'] + params['dt'],
+                               params['dt'])
         # Create CellResponse object, initialised with simulation time points
         self.cell_response = list()
         self._spike_times = list()

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -260,6 +260,12 @@ class Network(object):
         # Every time pos_dict is updated, gid_ranges must be updated too
         self._update_gid_ranges()
 
+        for cell_type, gid_range in self.gid_ranges.items():
+            if cell_type in self.cellname_list:
+                for gid in gid_range:
+                    self.cell_response.append(
+                        CellResponse(gid=gid, cell_type=cell_type))
+
         # set n_cells, EXCLUDING Artificial ones
         self.n_cells = sum(len(self.pos_dict[src]) for src in
                            self.cellname_list)

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -422,40 +422,31 @@ class CellResponse(object):
 
     Parameters
     ----------
+    gid : float | None
+        Numeric cell identifier.
+        Each gid corresponds to a type via Network::gid_ranges.
+    spike_type : str | None
+        Cell type (example: L2_basket)
     spike_times : list (n_trials,) of list (n_spikes,) of float, shape | None
         Each element of the outer list is a trial.
         The inner list contains the time stamps of spikes.
-    spike_gids : list (n_trials,) of list (n_spikes,) of float, shape | None
-        Each element of the outer list is a trial.
-        The inner list contains the cell IDs of neurons that
-        spiked.
-    spike_types : list (n_trials,) of list (n_spikes,) of float, shape | None
-        Each element of the outer list is a trial.
-        The inner list contains the type of spike (e.g., evprox1
-        or L2_pyramidal) that occured at the corresonding time stamp.
-        Each gid corresponds to a type via Network().gid_ranges.
 
     Attributes
     ----------
+    gid : float | None
+        Numeric cell identifier.
+        Each gid corresponds to a type via Network::gid_ranges.
+    spike_type : str | None
+        Cell type (example: L2_basket)
     spike_times : list (n_trials,) of list (n_spikes,) of float, shape
         Each element of the outer list is a trial.
         The inner list contains the time stamps of spikes.
-    spike_gids : list (n_trials,) of list (n_spikes,) of float, shape
-        Each element of the outer list is a trial.
-        The inner list contains the cell IDs of neurons that
-        spiked.
-    spike_types : list (n_trials,) of list (n_spikes,) of float, shape
-        Each element of the outer list is a trial.
-        The inner list contains the type of spike (e.g., evprox1
-        or L2_pyramidal) that occured at the corresonding time stamp.
-        Each gid corresponds to a type via Network::gid_ranges.
     vsoma : list (n_trials,) of dict, shape
         Each element of the outer list is a trial.
         Dictionary indexed by gids containing somatic voltages.
     isoma : list (n_trials,) of dict, shape
         Each element of the outer list is a trial.
         Dictionary indexed by gids containing somatic currents.
-
     times : numpy array
         Array of time points for samples in continuous data.
         This includes vsoma and isoma.
@@ -474,18 +465,18 @@ class CellResponse(object):
         Write spiking activity to a collection of spike trial files.
     """
 
-    def __init__(self, spike_times=None, spike_gids=None, spike_types=None,
+    def __init__(self, spike_times=None, gid=None, spike_type=None,
                  times=None):
         if spike_times is None:
             spike_times = list()
-        if spike_gids is None:
+        if gid is None:
             spike_gids = list()
-        if spike_types is None:
-            spike_types = list()
+        if spike_type is None:
+            spike_type = list()
 
         # Validate arguments
-        arg_names = ['spike_times', 'spike_gids', 'spike_types']
-        for arg_idx, arg in enumerate([spike_times, spike_gids, spike_types]):
+        arg_names = ['spike_times', 'gid', 'spike_type']
+        for arg_idx, arg in enumerate([spike_times, spike_gids, spike_type]):
             # Validate outer list
             if not isinstance(arg, list):
                 raise TypeError('%s should be a list of lists'
@@ -503,8 +494,8 @@ class CellResponse(object):
                 raise ValueError('spike times, gids, and types should be '
                                  'lists of the same length')
         self._spike_times = spike_times
-        self._spike_gids = spike_gids
-        self._spike_types = spike_types
+        self._gid = gid
+        self._spike_type = spike_type
         self._vsoma = list()
         self._isoma = list()
         if times is not None:
@@ -526,88 +517,20 @@ class CellResponse(object):
         times_other = [[round(time, 3) for time in trial]
                        for trial in other._spike_times]
         return (times_self == times_other and
-                self._spike_gids == other._spike_gids and
-                self._spike_types == other._spike_types)
-
-    def __getitem__(self, gid_item):
-        """Returns a CellResponse object with a copied subset filtered by gid.
-
-        Parameters
-        ----------
-        gid_item : int | slice
-            Subset of gids .
-
-        Returns
-        -------
-        cell_response : instance of CellResponse
-            See below for use cases.
-        """
-
-        if isinstance(gid_item, slice):
-            gid_item = np.arange(gid_item.stop)[gid_item]
-        elif isinstance(gid_item, list):
-            gid_item = np.array(gid_item)
-        elif isinstance(gid_item, np.ndarray):
-            if gid_item.ndim > 1:
-                raise ValueError("ndarray cannot exceed 1 dimension")
-            else:
-                pass
-        elif isinstance(gid_item, int):
-            gid_item = np.array([gid_item])
-        else:
-            raise TypeError("indices must be int, slice, or array-like, "
-                            f"not {type(gid_item).__name__}")
-
-        if not np.issubdtype(gid_item.dtype, np.integer):
-            raise TypeError("gids must be of dtype int, "
-                            f"not {gid_item.dtype.name}")
-
-        n_trials = len(self._spike_times)
-        times_slice = []
-        gids_slice = []
-        types_slice = []
-        vsoma_slice = []
-        isoma_slice = []
-        for trial_idx in range(n_trials):
-            gid_mask = np.in1d(self._spike_gids[trial_idx], gid_item)
-            times_trial = np.array(
-                self._spike_times[trial_idx])[gid_mask].tolist()
-            gids_trial = np.array(
-                self._spike_gids[trial_idx])[gid_mask].tolist()
-            types_trial = np.array(
-                self._spike_types[trial_idx])[gid_mask].tolist()
-
-            vsoma_trial = {gid: self._vsoma[trial_idx][gid] for gid in gid_item
-                           if gid in self._vsoma[trial_idx].keys()}
-
-            isoma_trial = {gid: self._isoma[trial_idx][gid] for gid in gid_item
-                           if gid in self._isoma[trial_idx].keys()}
-
-            times_slice.append(times_trial)
-            gids_slice.append(gids_trial)
-            types_slice.append(types_trial)
-            vsoma_slice.append(vsoma_trial)
-            isoma_slice.append(isoma_trial)
-
-        cell_response_slice = CellResponse(spike_times=times_slice,
-                                           spike_gids=gids_slice,
-                                           spike_types=types_slice)
-        cell_response_slice._vsoma = vsoma_slice
-        cell_response_slice._isoma = isoma_slice
-
-        return cell_response_slice
+                self._gid == other._gid and
+                self._spike_type == other._spike_type)
 
     @property
     def spike_times(self):
         return self._spike_times
 
     @property
-    def spike_gids(self):
-        return self._spike_gids
+    def gid(self):
+        return self._gid
 
     @property
-    def spike_types(self):
-        return self._spike_types
+    def spike_type(self):
+        return self._spike_type
 
     @property
     def vsoma(self):
@@ -621,173 +544,173 @@ class CellResponse(object):
     def times(self):
         return self._times
 
-    def update_types(self, gid_ranges):
-        """Update spike types in the current instance of CellResponse.
+    # def update_types(self, gid_ranges):
+    #     """Update spike types in the current instance of CellResponse.
 
-        Parameters
-        ----------
-        gid_ranges : dict of lists or range objects
-            Dictionary with keys 'evprox1', 'evdist1' etc.
-            containing the range of Cell or input IDs of different
-            cell or input types.
-        """
+    #     Parameters
+    #     ----------
+    #     gid_ranges : dict of lists or range objects
+    #         Dictionary with keys 'evprox1', 'evdist1' etc.
+    #         containing the range of Cell or input IDs of different
+    #         cell or input types.
+    #     """
 
-        # Validate gid_ranges
-        all_gid_ranges = list(gid_ranges.values())
-        for item_idx_1 in range(len(all_gid_ranges)):
-            for item_idx_2 in range(item_idx_1 + 1, len(all_gid_ranges)):
-                gid_set_1 = set(all_gid_ranges[item_idx_1])
-                gid_set_2 = set(all_gid_ranges[item_idx_2])
-                if not gid_set_1.isdisjoint(gid_set_2):
-                    raise ValueError('gid_ranges should contain only disjoint '
-                                     'sets of gid values')
+    #     # Validate gid_ranges
+    #     all_gid_ranges = list(gid_ranges.values())
+    #     for item_idx_1 in range(len(all_gid_ranges)):
+    #         for item_idx_2 in range(item_idx_1 + 1, len(all_gid_ranges)):
+    #             gid_set_1 = set(all_gid_ranges[item_idx_1])
+    #             gid_set_2 = set(all_gid_ranges[item_idx_2])
+    #             if not gid_set_1.isdisjoint(gid_set_2):
+    #                 raise ValueError('gid_ranges should contain only disjoint '
+    #                                  'sets of gid values')
 
-        spike_types = list()
-        for trial_idx in range(len(self._spike_times)):
-            spike_types_trial = np.empty_like(self._spike_times[trial_idx],
-                                              dtype='<U36')
-            for gidtype, gids in gid_ranges.items():
-                spike_gids_mask = np.in1d(self._spike_gids[trial_idx], gids)
-                spike_types_trial[spike_gids_mask] = gidtype
-            spike_types += [list(spike_types_trial)]
-        self._spike_types = spike_types
+    #     spike_types = list()
+    #     for trial_idx in range(len(self._spike_times)):
+    #         spike_types_trial = np.empty_like(self._spike_times[trial_idx],
+    #                                           dtype='<U36')
+    #         for gidtype, gids in gid_ranges.items():
+    #             spike_gids_mask = np.in1d(self._spike_gids[trial_idx], gids)
+    #             spike_types_trial[spike_gids_mask] = gidtype
+    #         spike_types += [list(spike_types_trial)]
+    #     self._spike_types = spike_types
 
-    def mean_rates(self, tstart, tstop, gid_ranges, mean_type='all'):
-        """Mean spike rates (Hz) by cell type.
+    # def mean_rates(self, tstart, tstop, gid_ranges, mean_type='all'):
+    #     """Mean spike rates (Hz) by cell type.
 
-        Parameters
-        ----------
-        tstart : int | float | None
-            Value defining the start time of all trials.
-        tstop : int | float | None
-            Value defining the stop time of all trials.
-        gid_ranges : dict of lists or range objects
-            Dictionary with keys 'evprox1', 'evdist1' etc.
-            containing the range of Cell or input IDs of different
-            cell or input types.
-        mean_type : str
-            'all' : Average over trials and cells
-                Returns mean rate for cell types
-            'trial' : Average over cell types
-                Returns trial mean rate for cell types
-            'cell' : Average over individual cells
-                Returns trial mean rate for individual cells
+    #     Parameters
+    #     ----------
+    #     tstart : int | float | None
+    #         Value defining the start time of all trials.
+    #     tstop : int | float | None
+    #         Value defining the stop time of all trials.
+    #     gid_ranges : dict of lists or range objects
+    #         Dictionary with keys 'evprox1', 'evdist1' etc.
+    #         containing the range of Cell or input IDs of different
+    #         cell or input types.
+    #     mean_type : str
+    #         'all' : Average over trials and cells
+    #             Returns mean rate for cell types
+    #         'trial' : Average over cell types
+    #             Returns trial mean rate for cell types
+    #         'cell' : Average over individual cells
+    #             Returns trial mean rate for individual cells
 
-        Returns
-        -------
-        spike_rate : dict
-            Dictionary with keys 'L5_pyramidal', 'L5_basket', etc.
-        """
-        cell_types = ['L5_pyramidal', 'L5_basket', 'L2_pyramidal', 'L2_basket']
-        spike_rates = dict()
+    #     Returns
+    #     -------
+    #     spike_rate : dict
+    #         Dictionary with keys 'L5_pyramidal', 'L5_basket', etc.
+    #     """
+    #     cell_types = ['L5_pyramidal', 'L5_basket', 'L2_pyramidal', 'L2_basket']
+    #     spike_rates = dict()
 
-        if mean_type not in ['all', 'trial', 'cell']:
-            raise ValueError("Invalid mean_type. Valid arguments include "
-                             f"'all', 'trial', or 'cell'. Got {mean_type}")
+    #     if mean_type not in ['all', 'trial', 'cell']:
+    #         raise ValueError("Invalid mean_type. Valid arguments include "
+    #                          f"'all', 'trial', or 'cell'. Got {mean_type}")
 
-        # Validate tstart, tstop
-        if not isinstance(tstart, (int, float)) or not isinstance(
-                tstop, (int, float)):
-            raise ValueError('tstart and tstop must be of type int or float')
-        elif tstop <= tstart:
-            raise ValueError('tstop must be greater than tstart')
+    #     # Validate tstart, tstop
+    #     if not isinstance(tstart, (int, float)) or not isinstance(
+    #             tstop, (int, float)):
+    #         raise ValueError('tstart and tstop must be of type int or float')
+    #     elif tstop <= tstart:
+    #         raise ValueError('tstop must be greater than tstart')
 
-        for cell_type in cell_types:
-            cell_type_gids = np.array(gid_ranges[cell_type])
-            n_trials, n_cells = len(self._spike_times), len(cell_type_gids)
-            gid_spike_rate = np.zeros((n_trials, n_cells))
+    #     for cell_type in cell_types:
+    #         cell_type_gids = np.array(gid_ranges[cell_type])
+    #         n_trials, n_cells = len(self._spike_times), len(cell_type_gids)
+    #         gid_spike_rate = np.zeros((n_trials, n_cells))
 
-            trial_data = zip(self._spike_types, self._spike_gids)
-            for trial_idx, (spike_types, spike_gids) in enumerate(trial_data):
-                trial_type_mask = np.in1d(spike_types, cell_type)
-                gids, gid_counts = np.unique(np.array(
-                    spike_gids)[trial_type_mask], return_counts=True)
+    #         trial_data = zip(self._spike_types, self._spike_gids)
+    #         for trial_idx, (spike_types, spike_gids) in enumerate(trial_data):
+    #             trial_type_mask = np.in1d(spike_types, cell_type)
+    #             gids, gid_counts = np.unique(np.array(
+    #                 spike_gids)[trial_type_mask], return_counts=True)
 
-                gid_spike_rate[trial_idx, np.in1d(cell_type_gids, gids)] = (
-                    gid_counts / (tstop - tstart)) * 1000
+    #             gid_spike_rate[trial_idx, np.in1d(cell_type_gids, gids)] = (
+    #                 gid_counts / (tstop - tstart)) * 1000
 
-            if mean_type == 'all':
-                spike_rates[cell_type] = np.mean(
-                    gid_spike_rate.mean(axis=1))
-            if mean_type == 'trial':
-                spike_rates[cell_type] = np.mean(
-                    gid_spike_rate, axis=1).tolist()
-            if mean_type == 'cell':
-                spike_rates[cell_type] = [gid_trial_rate.tolist()
-                                          for gid_trial_rate in gid_spike_rate]
+    #         if mean_type == 'all':
+    #             spike_rates[cell_type] = np.mean(
+    #                 gid_spike_rate.mean(axis=1))
+    #         if mean_type == 'trial':
+    #             spike_rates[cell_type] = np.mean(
+    #                 gid_spike_rate, axis=1).tolist()
+    #         if mean_type == 'cell':
+    #             spike_rates[cell_type] = [gid_trial_rate.tolist()
+    #                                       for gid_trial_rate in gid_spike_rate]
 
-        return spike_rates
+    #     return spike_rates
 
-    def plot_spikes_raster(self, ax=None, show=True):
-        """Plot the aggregate spiking activity according to cell type.
+    # def plot_spikes_raster(self, ax=None, show=True):
+    #     """Plot the aggregate spiking activity according to cell type.
 
-        Parameters
-        ----------
-        ax : instance of matplotlib axis | None
-            An axis object from matplotlib. If None,
-            a new figure is created.
-        show : bool
-            If True, show the figure.
+    #     Parameters
+    #     ----------
+    #     ax : instance of matplotlib axis | None
+    #         An axis object from matplotlib. If None,
+    #         a new figure is created.
+    #     show : bool
+    #         If True, show the figure.
 
-        Returns
-        -------
-        fig : instance of matplotlib Figure
-            The matplotlib figure object.
-        """
-        return plot_spikes_raster(cell_response=self, ax=ax, show=show)
+    #     Returns
+    #     -------
+    #     fig : instance of matplotlib Figure
+    #         The matplotlib figure object.
+    #     """
+    #     return plot_spikes_raster(cell_response=self, ax=ax, show=show)
 
-    def plot_spikes_hist(self, ax=None, spike_types=None, show=True):
-        """Plot the histogram of spiking activity across trials.
+    # def plot_spikes_hist(self, ax=None, spike_types=None, show=True):
+    #     """Plot the histogram of spiking activity across trials.
 
-        Parameters
-        ----------
-        ax : instance of matplotlib axis | None
-            An axis object from matplotlib. If None,
-            a new figure is created.
-        spike_types: string | list | dictionary | None
-            String input of a valid spike type is plotted individually.
-                Ex: 'common', 'evdist', 'evprox', 'extgauss', 'extpois'
-            List of valid string inputs will plot each spike type individually.
-                Ex: ['common', 'evdist']
-            Dictionary of valid lists will plot list elements as a group.
-                Ex: {'Evoked': ['evdist', 'evprox'], 'External': ['extpois']}
-            If None, all input spike types are plotted individually if any
-            are present. Otherwise spikes from all cells are plotted.
-            Valid strings also include leading characters of spike types
-                Example: 'ext' is equivalent to ['extgauss', 'extpois']
-        show : bool
-            If True, show the figure.
+    #     Parameters
+    #     ----------
+    #     ax : instance of matplotlib axis | None
+    #         An axis object from matplotlib. If None,
+    #         a new figure is created.
+    #     spike_types: string | list | dictionary | None
+    #         String input of a valid spike type is plotted individually.
+    #             Ex: 'common', 'evdist', 'evprox', 'extgauss', 'extpois'
+    #         List of valid string inputs will plot each spike type individually.
+    #             Ex: ['common', 'evdist']
+    #         Dictionary of valid lists will plot list elements as a group.
+    #             Ex: {'Evoked': ['evdist', 'evprox'], 'External': ['extpois']}
+    #         If None, all input spike types are plotted individually if any
+    #         are present. Otherwise spikes from all cells are plotted.
+    #         Valid strings also include leading characters of spike types
+    #             Example: 'ext' is equivalent to ['extgauss', 'extpois']
+    #     show : bool
+    #         If True, show the figure.
 
-        Returns
-        -------
-        fig : instance of matplotlib Figure
-            The matplotlib figure handle.
-        """
-        return plot_spikes_hist(
-            self, ax=ax, spike_types=spike_types, show=show)
+    #     Returns
+    #     -------
+    #     fig : instance of matplotlib Figure
+    #         The matplotlib figure handle.
+    #     """
+    #     return plot_spikes_hist(
+    #         self, ax=ax, spike_types=spike_types, show=show)
 
-    def write(self, fname):
-        """Write spiking activity per trial to a collection of files.
+    # def write(self, fname):
+    #     """Write spiking activity per trial to a collection of files.
 
-        Parameters
-        ----------
-        fname : str
-            String format (e.g., '<pathname>/spk_%d.txt') of the
-            path to the output spike file(s).
+    #     Parameters
+    #     ----------
+    #     fname : str
+    #         String format (e.g., '<pathname>/spk_%d.txt') of the
+    #         path to the output spike file(s).
 
-        Outputs
-        -------
-        A tab separated txt file for each trial where rows
-            correspond to spikes, and columns correspond to
-            1) spike time (s),
-            2) spike gid, and
-            3) gid type
-        """
+    #     Outputs
+    #     -------
+    #     A tab separated txt file for each trial where rows
+    #         correspond to spikes, and columns correspond to
+    #         1) spike time (s),
+    #         2) spike gid, and
+    #         3) gid type
+    #     """
 
-        for trial_idx in range(len(self._spike_times)):
-            with open(str(fname) % (trial_idx,), 'w') as f:
-                for spike_idx in range(len(self._spike_times[trial_idx])):
-                    f.write('{:.3f}\t{}\t{}\n'.format(
-                        self._spike_times[trial_idx][spike_idx],
-                        int(self._spike_gids[trial_idx][spike_idx]),
-                        self._spike_types[trial_idx][spike_idx]))
+    #     for trial_idx in range(len(self._spike_times)):
+    #         with open(str(fname) % (trial_idx,), 'w') as f:
+    #             for spike_idx in range(len(self._spike_times[trial_idx])):
+    #                 f.write('{:.3f}\t{}\t{}\n'.format(
+    #                     self._spike_times[trial_idx][spike_idx],
+    #                     int(self._spike_gids[trial_idx][spike_idx]),
+    #                     self._spike_types[trial_idx][spike_idx]))

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -416,8 +416,6 @@ class NetworkBuilder(object):
                     cell.add_tonic_input(
                         **self.net.feed_times['tonic'][_short_name(src_type)])
                 cell.record_soma(record_vsoma, record_isoma)
-                self.net.cell_response.append(CellResponse(
-                    gid=gid, cell_type=src_type, times=self.net.times))
 
                 # this call could belong in init of a _Cell (with threshold)?
                 nrn_netcon = cell.setup_source_netcon(threshold)

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -10,7 +10,6 @@ from neuron import h
 from .cell import _ArtificialCell
 from .pyramidal import L2Pyr, L5Pyr
 from .basket import L2Basket, L5Basket
-from .network import CellResponse
 
 # a few globals
 _PC = None

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -416,8 +416,8 @@ class NetworkBuilder(object):
                     cell.add_tonic_input(
                         **self.net.feed_times['tonic'][_short_name(src_type)])
                 cell.record_soma(record_vsoma, record_isoma)
-                self.net.cell_response[gid] = CellResponse(
-                    gid=gid, cell_type=src_type, times=self.net.times)
+                self.net.cell_response.append(CellResponse(
+                    gid=gid, cell_type=src_type, times=self.net.times))
 
                 # this call could belong in init of a _Cell (with threshold)?
                 nrn_netcon = cell.setup_source_netcon(threshold)

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -10,6 +10,7 @@ from neuron import h
 from .cell import _ArtificialCell
 from .pyramidal import L2Pyr, L5Pyr
 from .basket import L2Basket, L5Basket
+from .network import CellResponse
 
 # a few globals
 _PC = None
@@ -46,7 +47,7 @@ def _simulate_single_trial(neuron_net, trial_idx):
     h.dt = neuron_net.net.params['dt']  # simulation duration and time-step
     h.celsius = neuron_net.net.params['celsius']  # 37.0 - set temperature
 
-    times = neuron_net.net.cell_response.times
+    times = neuron_net.net.times
 
     # sets the default max solver step in ms (purposefully large)
     _PC.set_maxstep(10)
@@ -305,8 +306,8 @@ class NetworkBuilder(object):
 
         # Create a h.Vector() with size 1xself.N_t, zero'd
         self.dipoles = {
-            'L5_pyramidal': h.Vector(self.net.cell_response.times.size, 0),
-            'L2_pyramidal': h.Vector(self.net.cell_response.times.size, 0),
+            'L5_pyramidal': h.Vector(self.net.times.size, 0),
+            'L2_pyramidal': h.Vector(self.net.times.size, 0),
         }
 
         self._gid_assign()
@@ -415,6 +416,8 @@ class NetworkBuilder(object):
                     cell.add_tonic_input(
                         **self.net.feed_times['tonic'][_short_name(src_type)])
                 cell.record_soma(record_vsoma, record_isoma)
+                self.net.cell_response[gid] = CellResponse(
+                    gid=gid, cell_type=src_type, times=self.net.times)
 
                 # this call could belong in init of a _Cell (with threshold)?
                 nrn_netcon = cell.setup_source_netcon(threshold)

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -53,6 +53,9 @@ def _gather_trial_data(sim_data, net, n_trials, postproc):
         spike_times = spikedata[0]
         spike_gids = spikedata[1]
         net.gid_ranges = spikedata[2]  # only have one gid_ranges
+        net._spike_times.append(spike_times)
+        net._spike_gids.append(spike_gids)
+        net.update_types(net.gid_ranges)
         for cell_type, gid_range in net.gid_ranges.items():
             if cell_type in net.cellname_list:
                 for gid in gid_range:

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -100,29 +100,27 @@ def test_cell_response_backends(run_hnn_core_fixture):
                                          record_vsoma=True)
     _, mpi_net = run_hnn_core_fixture(backend='mpi', n_procs=2, reduced=True,
                                       record_isoma=True, record_vsoma=True)
-    n_times = len(joblib_net.cell_response.times)
+    n_times = len(joblib_net.times)
 
-    assert len(joblib_net.cell_response.vsoma) == n_trials
-    assert len(joblib_net.cell_response.isoma) == n_trials
-    assert len(joblib_net.cell_response.vsoma[trial_idx][gid]) == n_times
-    assert len(joblib_net.cell_response.isoma[
-               trial_idx][gid]['soma_gabaa']) == n_times
+    assert len(joblib_net.cell_response[gid].vsoma) == n_trials
+    assert len(joblib_net.cell_response[gid].isoma) == n_trials
+    assert len(joblib_net.cell_response[gid].vsoma[trial_idx]) == n_times
+    assert len(joblib_net.cell_response[gid].isoma[
+               trial_idx]['soma_gabaa']) == n_times
 
-    assert len(mpi_net.cell_response.vsoma) == n_trials
-    assert len(mpi_net.cell_response.isoma) == n_trials
-    assert len(mpi_net.cell_response.vsoma[trial_idx][gid]) == n_times
-    assert len(mpi_net.cell_response.isoma[
-               trial_idx][gid]['soma_gabaa']) == n_times
-    assert mpi_net.cell_response.vsoma == joblib_net.cell_response.vsoma
-    assert mpi_net.cell_response.isoma == joblib_net.cell_response.isoma
+    assert len(mpi_net.cell_response[gid].vsoma) == n_trials
+    assert len(mpi_net.cell_response[gid].isoma) == n_trials
+    assert len(mpi_net.cell_response[gid].vsoma[trial_idx]) == n_times
+    assert len(mpi_net.cell_response[gid].isoma[
+               trial_idx]['soma_gabaa']) == n_times
+    assert mpi_net.cell_response == joblib_net.cell_response
 
     # Test if spike time falls within depolarization window above v_thresh
     v_thresh = 0.0
-    times = np.array(joblib_net.cell_response.times)
-    spike_times = np.array(joblib_net.cell_response.spike_times[trial_idx])
-    spike_gids = np.array(joblib_net.cell_response.spike_gids[trial_idx])
-    vsoma = np.array(joblib_net.cell_response.vsoma[trial_idx][gid])
+    times = np.array(joblib_net.times)
+    spike_times = np.array(joblib_net.cell_response[gid].spike_times[trial_idx])
+    vsoma = np.array(joblib_net.cell_response[gid].vsoma[trial_idx])
 
     v_mask = vsoma > v_thresh
-    assert np.all([spike_times[spike_gids == gid] > times[v_mask][0],
-                   spike_times[spike_gids == gid] < times[v_mask][-1]])
+    assert np.all([spike_times > times[v_mask][0],
+                   spike_times < times[v_mask][-1]])

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -86,7 +86,7 @@ def test_dipole_simulation():
     params['tstop'] = 0.1
     net = Network(params)
     simulate_dipole(net, n_trials=1)
-    net.cell_response.plot_spikes_raster()
+    net.plot_spikes_raster()
 
 
 @requires_mpi4py

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -118,7 +118,8 @@ def test_cell_response_backends(run_hnn_core_fixture):
     # Test if spike time falls within depolarization window above v_thresh
     v_thresh = 0.0
     times = np.array(joblib_net.times)
-    spike_times = np.array(joblib_net.cell_response[gid].spike_times[trial_idx])
+    spike_times = np.array(
+        joblib_net.cell_response[gid].spike_times[trial_idx])
     vsoma = np.array(joblib_net.cell_response[gid].vsoma[trial_idx])
 
     v_mask = vsoma > v_thresh

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -173,22 +173,22 @@ def test_network(tmpdir):
     test_rate = (1 / (tstop - tstart)) * 1000
 
     assert net.mean_rates(tstart, tstop, gid_ranges) == {
-        'L5_pyramidal': test_rate / 2,
-        'L5_basket': test_rate / 2,
-        'L2_pyramidal': test_rate / 2,
-        'L2_basket': test_rate / 2}
+        'L5_pyramidal': test_rate / 4,
+        'L5_basket': test_rate / 4,
+        'L2_pyramidal': test_rate / 4,
+        'L2_basket': test_rate / 4}
     assert net.mean_rates(tstart, tstop, gid_ranges,
                                     mean_type='trial') == {
-        'L5_pyramidal': [0.0, test_rate],
-        'L5_basket': [0.0, test_rate],
-        'L2_pyramidal': [test_rate, 0.0],
-        'L2_basket': [test_rate, 0.0]}
+        'L5_pyramidal': [0.0, test_rate / 2],
+        'L5_basket': [0.0, test_rate / 2],
+        'L2_pyramidal': [test_rate / 2, 0.0],
+        'L2_basket': [test_rate / 2, 0.0]}
     assert net.mean_rates(tstart, tstop, gid_ranges,
                                     mean_type='cell') == {
-        'L5_pyramidal': [[0.0], [test_rate]],
-        'L5_basket': [[0.0], [test_rate]],
-        'L2_pyramidal': [[test_rate], [0.0]],
-        'L2_basket': [[test_rate], [0.0]]}
+        'L5_pyramidal': [[0.0, 0.0], [0.0, test_rate]],
+        'L5_basket': [[0.0, 0.0], [0.0, test_rate]],
+        'L2_pyramidal': [[0.0, test_rate], [0.0, 0.0]],
+        'L2_basket': [[0.0, test_rate], [0.0, 0.0]]}
 
     # Write spike file with no 'types' column
     # Check for gid_ranges errors

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -43,7 +43,13 @@ def test_network():
         assert len(net.gid_ranges[type_key]) == net.n_cells
 
     # Assert that an empty CellResponse object is created as an attribute
-    assert net.cell_response == CellResponse()
+    cell_response = []
+    for cell_type, gid_range in net.gid_ranges.items():
+        if cell_type in net.cellname_list:
+            for gid in gid_range:
+                cell_response.append(CellResponse(gid=gid, cell_type=cell_type))
+    assert net.cell_response == cell_response
+
     # array of simulation times is created in Network.__init__, but passed
     # to CellResponse-constructor for storage (Network is agnostic of time)
     with pytest.raises(TypeError,
@@ -189,16 +195,13 @@ def test_cell_response(tmpdir):
     """Test CellResponse object."""
 
     # Round-trip test
-    spike_times = [[2.3456, 7.89], [4.2812, 93.2]]
-    gid = 1
-    cell_type = 'L2_pyramidal'
-    tstart, tstop = 0.1, 98.4
-    gid_ranges = {'L2_pyramidal': range(1, 2), 'L2_basket': range(3, 4),
-                  'L5_pyramidal': range(5, 6), 'L5_basket': range(7, 8)}
-    cell_response = CellResponse(spike_times=spike_times,
-                                 gid=gid,
-                                 cell_type=cell_type)
-    assert cell_response == read_spikes(tmpdir.join('spk_*.txt'), gid_ranges)
+    # spike_times = [[2.3456, 7.89], [4.2812, 93.2]]
+    # gid = 1
+    # cell_type = 'L2_pyramidal'
+    # gid_ranges = {'L2_pyramidal': range(0, 2), 'L2_basket': range(2, 4),
+    #               'L5_pyramidal': range(4, 6), 'L5_basket': range(6, 8)}
+  
+    # assert cell_response == read_spikes(tmpdir.join('spk_*.txt'), gid_ranges)
 
     assert ("CellResponse | 2 simulation trials" in repr(cell_response))
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -137,7 +137,9 @@ def test_network(tmpdir):
     net.cell_response = cell_response
 
     net.write(tmpdir.join('spk_%d.txt'))
-    assert net.cell_response == read_spikes(tmpdir.join('spk_*.txt'), gid_ranges)
+    cell_response_read = read_spikes(tmpdir.join('spk_*.txt'), gid_ranges)
+    assert ("CellResponse | 2 simulation trials" in repr(cell_response[0]))
+    assert net.cell_response == cell_response_read
 
     with pytest.raises(TypeError, match="spike_types should be str, "
                                         "list, dict, or None"):
@@ -218,7 +220,7 @@ def test_cell_response(tmpdir):
   
     # assert cell_response == read_spikes(tmpdir.join('spk_*.txt'), gid_ranges)
 
-    assert ("CellResponse | 2 simulation trials" in repr(cell_response))
+    # assert ("CellResponse | 2 simulation trials" in repr(cell_response))
 
     with pytest.raises(TypeError,
                        match="spike_times should be a list of lists"):

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -47,7 +47,8 @@ def test_network(tmpdir):
     for cell_type, gid_range in net.gid_ranges.items():
         if cell_type in net.cellname_list:
             for gid in gid_range:
-                cell_response.append(CellResponse(gid=gid, cell_type=cell_type))
+                cell_response.append(CellResponse(gid=gid,
+                                                  cell_type=cell_type))
     assert net.cell_response == cell_response
 
     # array of simulation times is created in Network.__init__, but passed
@@ -126,12 +127,13 @@ def test_network(tmpdir):
     for cell_type, gid_range in gid_ranges.items():
         for gid in gid_range:
             cell_response.append(CellResponse(gid=gid, cell_type=cell_type))
-            
+
     for trial in range(len(net._spike_times)):
         for cell_resp in cell_response:
             gid = cell_resp.gid
             gid_mask = np.array(net._spike_gids[trial]) == gid
-            gid_spike_times = np.array(net._spike_times)[trial][gid_mask].tolist()
+            gid_spike_times = np.array(
+                net._spike_times)[trial][gid_mask].tolist()
             cell_response[gid].spike_times.append(gid_spike_times)
 
     net.cell_response = cell_response
@@ -153,8 +155,7 @@ def test_network(tmpdir):
                        r" mutually exclusive input types\. L2_basket is found"
                        r" more than once\."):
         net.plot_spikes_hist(spike_types={'ev':
-                                       ['L2_basket', 'L2_b']},
-                                       show=False)
+                             ['L2_basket', 'L2_b']}, show=False)
 
     with pytest.raises(ValueError, match="No input types found for ABC"):
         net.plot_spikes_hist(spike_types='ABC', show=False)
@@ -162,7 +163,7 @@ def test_network(tmpdir):
     with pytest.raises(ValueError, match="tstart and tstop must be of type "
                        "int or float"):
         net.mean_rates(tstart=0.1, tstop='ABC',
-                                 gid_ranges=gid_ranges)
+                       gid_ranges=gid_ranges)
 
     with pytest.raises(ValueError, match="tstop must be greater than tstart"):
         net.mean_rates(tstart=0.1, tstop=-1.0, gid_ranges=gid_ranges)
@@ -170,7 +171,7 @@ def test_network(tmpdir):
     with pytest.raises(ValueError, match="Invalid mean_type. Valid "
                        "arguments include 'all', 'trial', or 'cell'."):
         net.mean_rates(tstart=tstart, tstop=tstop,
-                                 gid_ranges=gid_ranges, mean_type='ABC')
+                       gid_ranges=gid_ranges, mean_type='ABC')
 
     test_rate = (1 / (tstop - tstart)) * 1000
 
@@ -180,13 +181,13 @@ def test_network(tmpdir):
         'L2_pyramidal': test_rate / 4,
         'L2_basket': test_rate / 4}
     assert net.mean_rates(tstart, tstop, gid_ranges,
-                                    mean_type='trial') == {
+                          mean_type='trial') == {
         'L5_pyramidal': [0.0, test_rate / 2],
         'L5_basket': [0.0, test_rate / 2],
         'L2_pyramidal': [test_rate / 2, 0.0],
         'L2_basket': [test_rate / 2, 0.0]}
     assert net.mean_rates(tstart, tstop, gid_ranges,
-                                    mean_type='cell') == {
+                          mean_type='cell') == {
         'L5_pyramidal': [[0.0, 0.0], [0.0, test_rate]],
         'L5_basket': [[0.0, 0.0], [0.0, test_rate]],
         'L2_pyramidal': [[0.0, test_rate], [0.0, 0.0]],
@@ -212,26 +213,14 @@ def test_cell_response(tmpdir):
     """Test CellResponse object."""
 
     # Round-trip test
-    # spike_times = [[2.3456, 7.89], [4.2812, 93.2]]
-    # gid = 1
-    # cell_type = 'L2_pyramidal'
-    # gid_ranges = {'L2_pyramidal': range(0, 2), 'L2_basket': range(2, 4),
-    #               'L5_pyramidal': range(4, 6), 'L5_basket': range(6, 8)}
-  
-    # assert cell_response == read_spikes(tmpdir.join('spk_*.txt'), gid_ranges)
-
-    # assert ("CellResponse | 2 simulation trials" in repr(cell_response))
+    gid = 1
+    cell_type = 'L2_pyramidal'
 
     with pytest.raises(TypeError,
                        match="spike_times should be a list of lists"):
-        cell_response = CellResponse(spike_times=([2.3456, 7.89],
-                                     [4.2812, 93.2]),
-                                     gid=gid, cell_type=cell_type)
+        CellResponse(spike_times=([2.3456, 7.89], [4.2812, 93.2]),
+                     gid=gid, cell_type=cell_type)
 
     with pytest.raises(TypeError,
                        match="spike_times should be a list of lists"):
-        cell_response = CellResponse(spike_times=[1, 2], gid=gid,
-                                     cell_type=cell_type)
-
-    cell_response = CellResponse(spike_times=spike_times,
-                                 gid=gid, cell_type=cell_type)
+        CellResponse(spike_times=[1, 2], gid=gid, cell_type=cell_type)

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -103,7 +103,7 @@ class TestParallelBackends():
 
         # Test spike type counts
         spike_type_counts = {}
-        for spike_gid in net.cell_response.spike_gids[0]:
+        for spike_gid in net._spike_gids[0]:
             if net.gid_to_type(spike_gid) not in spike_type_counts:
                 spike_type_counts[net.gid_to_type(spike_gid)] = 0
             else:


### PR DESCRIPTION
This is working towards creating a more flexible API to access data recorded during simulations. @jasmainak suggested on possible way the API could look:
```py
>>> net = Network(...)
>>> net.cells[50].spikes
>>> net.plot_spikes()
>>> net.cells[50].vsoma
>>> plt.plot(net.cells[50].vsoma)
```
I don't plan to finalize the API in this PR but converting `CellResponse` to a list stored by `Network` should help simplify its development.