### PR TITLE
DEMO discrepancy between feed_times and spike_times

### DIFF
--- a/hnn_core/tests/conftest.py
+++ b/hnn_core/tests/conftest.py
@@ -84,7 +84,7 @@ def run_hnn_core_fixture():
         if reduced:
             params.update({'N_pyr_x': 3,
                            'N_pyr_y': 3,
-                           'tstop': 25,
+                           'tstop': 40,
                            't_evprox_1': 5,
                            't_evdist_1': 10,
                            't_evprox_2': 20,

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -141,4 +141,5 @@ def test_cell_response_backends(run_hnn_core_fixture):
                 assert_allclose(np.array(event_times), np.array(net_ets))
             except:
                 print(f'FAIL! {feed_name}: cell {id_dr} with gid '
-                      f"{id_dr}; should be {event_times}, getting {net_ets}")
+                      f"{gid_ran[id_dr]}; should be {event_times}, "
+                      f"getting {net_ets}")


### PR DESCRIPTION
In trying to debug _tiny_ discrepancies between simulation results in #221 vs. master, I came across this oddity. (Run with `py.test -s hnn_core/tests/test_dipole.py`)

The very last block in `test_dipole.py` passes for every default feed type, _except_ `evprox2`. What's worse, it's a few cells, not all. Finding those gids requires digging deep into `network_builder.py:_connect_celltypes`.

Is there _any_ reason for a proximal `_ArtificialCell` not to fire at the requested `event_time`? 

```python
FAIL! evprox2: cell 0 with gid 74; should be [27.83270991828835], getting []
FAIL! evprox2: cell 4 with gid 78; should be [35.82577495811374], getting []
FAIL! evprox2: cell 6 with gid 80; should be [27.00261785495775], getting []
FAIL! evprox2: cell 7 with gid 81; should be [27.074776340688196], getting []
FAIL! evprox2: cell 17 with gid 91; should be [33.57955000926374], getting []
FAIL! evprox2: cell 18 with gid 92; should be [26.19296528522625], getting []
```