### PR TITLE
[MRG] fix build path in Makefile (and recursive rm)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@
 all: modl
 
 modl:
-	cd $(PWD)/mod/ && nrnivmodl
+	cd hnn_core/mod/ && nrnivmodl
 
 # clean
 .PHONY: clean
 clean :
-	rm -f hnn_core/mod/x86_64/*
+	rm -rf hnn_core/mod/x86_64/*


### PR DESCRIPTION
On starting with a fresh `hnn-core` clone, I found that the make-process was botched. Anyone else?