### PR TITLE
[MRG] Fix raster with no spikes

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,7 +41,7 @@ Changelog
 
 - Add ability to add tonic inputs to cell types with :func:`hnn_core.Network.add_tonic_input`, by `Mainak Jas`_ in `#209 <https://github.com/jonescompneurolab/hnn-core/pull/209>`_
 
-- Modify plot_spikes_raster() to display individual gids, by `Nick Tolley`_ in `#231 <https://github.com/jonescompneurolab/hnn-core/pull/231>`_
+- Modify plot_spikes_raster() to display individual cells, by `Nick Tolley`_ in `#231 <https://github.com/jonescompneurolab/hnn-core/pull/231>`_
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,7 +41,7 @@ Changelog
 
 - Add ability to add tonic inputs to cell types with :func:`hnn_core.Network.add_tonic_input`, by `Mainak Jas`_ in `#209 <https://github.com/jonescompneurolab/hnn-core/pull/209>`_
 
-- Modify plot_spikes_raster() to display individual cells, by `Nick Tolley`_ in `#231 <https://github.com/jonescompneurolab/hnn-core/pull/231>`_
+- Modify :func:`hnn_core.viz.plot_spikes_raster` to display individual cells, by `Nick Tolley`_ in `#231 <https://github.com/jonescompneurolab/hnn-core/pull/231>`_
 
 Bug
 ~~~

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -82,6 +82,12 @@ def test_dipole_simulation():
     with pytest.raises(TypeError, match="record_isoma must be bool, got int"):
         simulate_dipole(net, n_trials=1, record_vsoma=False, record_isoma=0)
 
+    # Test raster plot with no spikes
+    params['tstop'] = 0.1
+    net = Network(params)
+    simulate_dipole(net, n_trials=1)
+    net.cell_response.plot_spikes_raster()
+
 
 @requires_mpi4py
 def test_cell_response_backends(run_hnn_core_fixture):

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -186,7 +186,7 @@ def plot_spikes_raster(cell_response, ax=None, show=True):
             cell_type_ypos.append(np.repeat(ypos, len(gid_time)))
             ypos = ypos - 1
 
-        if any(cell_type_times):
+        if cell_type_times:
             cell_type_times = np.concatenate(cell_type_times)
             cell_type_ypos = np.concatenate(cell_type_ypos)
         else:

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -186,8 +186,12 @@ def plot_spikes_raster(cell_response, ax=None, show=True):
             cell_type_ypos.append(np.repeat(ypos, len(gid_time)))
             ypos = ypos - 1
 
-        cell_type_times = np.concatenate(cell_type_times)
-        cell_type_ypos = np.concatenate(cell_type_ypos)
+        if any(cell_type_times):
+            cell_type_times = np.concatenate(cell_type_times)
+            cell_type_ypos = np.concatenate(cell_type_ypos)
+        else:
+            cell_type_times = []
+            cell_type_ypos = []
 
         ax.scatter(cell_type_times, cell_type_ypos, label=cell_type,
                    color=cell_type_colors[cell_type])


### PR DESCRIPTION
closes #240. Quick fix for raster plot when no spikes occur during simulation. Now a blank plot is returned.

Decided against raising a warning as a lack of spikes is pretty self explanatory. 

Also snuck that doc nitpick in @jasmainak ;)