### PR TITLE
[MRG] DOC: update somato example

### DIFF
--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -218,7 +218,7 @@ net.cell_response.plot_spikes_hist(ax=axes[0],
 axes[1].axhline(0, c='k', ls=':', label='_nolegend_')
 axes[1].plot(1e3 * stc.times, dipole_tc, 'r--')
 average_dipoles(dpls).plot(ax=axes[1], show=False)
-axes[1].legend(['MNE vertex', 'HNN simulation'])
+axes[1].legend(['MNE label average', 'HNN simulation'])
 axes[1].set_ylabel('Current Dipole (nAm)')
 net.cell_response.plot_spikes_raster(ax=axes[2])
 

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -222,7 +222,7 @@ net.cell_response.plot_spikes_hist(ax=axes[0],
                                    spike_types=['evprox', 'evdist'],
                                    show=False)
 axes[1].axhline(0, c='k', ls=':', label='_nolegend_')
-axes[1].plot(1e3 * stc_mne.times, dipole_tc, 'r--')
+axes[1].plot(1e3 * stc.times, dipole_tc, 'r--')
 average_dipoles(dpls).plot(ax=axes[1], show=False)
 axes[1].legend(['MNE vertex', 'HNN simulation'])
 axes[1].set_ylabel('Current Dipole (nAm)')

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -1,7 +1,7 @@
 """
-=================================
+================================================
 05. From MEG sensor-space data to HNN simulation
-=================================
+================================================
 
 This example demonstrates how to calculate the inverse solution of the median
 nerve evoked response in the MNE somatosensory dataset, and then simulate a
@@ -181,7 +181,7 @@ with MPIBackend(n_procs=2):
 # nerve evoked response waveforms, and output spike histogram.
 fig, axes = plt.subplots(3, 1, sharex=True, figsize=(6, 6))
 net.cell_response.plot_spikes_hist(ax=axes[0],
-                                   spike_types=['evprox', 'evdist']
+                                   spike_types=['evprox', 'evdist'],
                                    show=False)
 axes[1].axhline(0, c='k', ls=':', label='_nolegend_')
 axes[1].plot(1e3 * stc.times, stc.data[pick_vertex, :].T * 1e9, 'r--')

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -1,11 +1,11 @@
 """
 =================================
-05. Source reconstruction and HNN
+05. From MEG sensor-space data to HNN simulation
 =================================
 
 This example demonstrates how to calculate the inverse solution of the median
 nerve evoked response in the MNE somatosensory dataset, and then simulate a
-matching inverse solution with HNN.
+biophysical model network that reproduces the observed dynamics.
 """
 
 # Authors: Mainak Jas <mainakjas@gmail.com>
@@ -65,8 +65,8 @@ inv = make_inverse_operator(epochs.info, fwd, cov)
 # moment, we do not offer explicit recommendations on which source
 # reconstruction technique is best for HNN. However, we do want our users
 # to note that the dipole currents simulated with HNN are assumed to be normal
-# to the cortical surface. Hence, using the option ``pick_ori='normal'``
-# seems to make most sense.
+# to the cortical surface. Hence, using the option ``pick_ori='normal'`` is
+# appropriate.
 method = "MNE"
 snr = 3.
 lambda2 = 1. / snr ** 2
@@ -76,9 +76,9 @@ stc = apply_inverse(evoked, inv, lambda2, method=method, pick_ori="normal",
 
 ###############################################################################
 # We isolate and plot the single most active vertex in the distributed minimum
-# norm estimate by calculating the L2 norm of the time course emerging from
-# each vertex. The time course from the vertex with the greatest L2 norm
-# represents the location of cortex with greatest response to stimulus.
+# norm estimate by calculating the L2 norm of the time course emerging at each
+# vertex. The time course from the vertex with the greatest L2 norm represents
+# the location of cortex with greatest response to stimulus.
 pick_vertex = np.argmax(np.linalg.norm(stc.data, axis=1))
 
 plt.figure()
@@ -94,7 +94,8 @@ plt.show()
 # parameters from ``N20.json`` and instantiate the network.
 
 import hnn_core
-from hnn_core import simulate_dipole, read_params, Network, MPIBackend, average_dipoles
+from hnn_core import simulate_dipole, read_params, Network, MPIBackend
+from hnn_core import average_dipoles
 
 hnn_core_root = op.dirname(hnn_core.__file__)
 
@@ -172,7 +173,7 @@ net.add_evoked_drive(
 # match to the empirical waveform, set ``n_trials`` to be >=25.
 n_trials = 2
 # n_trials = 25
-with MPIBackend(n_procs=6, mpi_cmd='mpiexec'):
+with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
     dpls = simulate_dipole(net, n_trials=n_trials)
 
 ###############################################################################

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -91,7 +91,9 @@ label_s1 = mne.read_labels_from_annot(subject, parc='aparc.a2009s', hemi=hemi,
 # upwards (from deep to superficial) and downwards (from superficial to deep)
 # current flow, respectively. Uncomment the following code to open an
 # interactive 3D render of the brain and its surface activation (requires the
-# ``pyvista`` python library).
+# ``pyvista`` python library). You should get something like this that shows
+# the MNE activation at 0.040 sec around the post-central gyrus (outlined in
+# orange): |mne_example_fig|
 '''
 stc_label = stc.in_label(label_s1)
 brain = stc_label.plot(subjects_dir=subjects_dir, hemi='rh', surface='white',
@@ -228,3 +230,4 @@ net.cell_response.plot_spikes_raster(ax=axes[2])
 #
 # .. _MNE: https://mne.tools/
 # .. _this MNE-python example: https://mne.tools/stable/auto_examples/inverse/plot_label_source_activations.html#sphx-glr-auto-examples-inverse-plot-label-source-activations-py # noqa
+# .. |mne_example_fig| image:: https://user-images.githubusercontent.com/5610076/106361333-ac3fdd00-631d-11eb-8817-9d95db44a554.png # noqa

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -41,7 +41,8 @@ subjects_dir = op.join(data_path, 'derivatives', 'freesurfer', 'subjects')
 
 # Read and band-pass filter the raw data
 raw = mne.io.read_raw_fif(raw_fname, preload=True)
-raw.filter(1, 40)
+l_freq, h_freq = 1, 40
+raw.filter(l_freq, h_freq)
 
 # Identify stimulus events associated with MEG time series in the dataset
 events = mne.find_events(raw, stim_channel='STI 014')
@@ -141,7 +142,7 @@ net = Network(params)
 # proximal drive. Note that setting ``sync_within_trial=True`` creates drives
 # with synchronous input (arriving to and transmitted by hypothetical granular
 # cells at the center of the network) to all pyramidal and basket cells that
-# receive distal drive.
+# receive distal drive. Note that granule cells are not explicitly modelled within HNN. 
 
 # Early proximal drive
 weights_ampa_p = {'L2_basket': 0.0036, 'L2_pyramidal': 0.0039,
@@ -182,7 +183,7 @@ net.add_evoked_drive(
     weights_ampa=weights_ampa_d, weights_nmda=weights_nmda_d,
     location='distal', synaptic_delays=synaptic_delays_d, seedcore=6)
 
-# Late distal input
+# Late distal drive
 weights_ampa_d = {'L2_basket': 0.0041, 'L2_pyramidal': 0.0019,
                   'L5_pyramidal': 0.0018}
 weights_nmda_d = {'L2_basket': 0.0032, 'L2_pyramidal': 0.0018,

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -94,10 +94,10 @@ stc_label = stc.in_label(label_s1)
 
 brain = stc_label.plot(subjects_dir=subjects_dir, hemi='rh', surface='white',
                        smoothing_steps='nearest', view_layout='horizontal',
-                       backend='pyvista')
+                       initial_time=0.04, backend='matplotlib')
 # note that adding a border to the rendered 3D object may not work with the
 # matplotlib backend
-brain.add_label(label_s1, borders=True)
+# brain.add_label(label_s1, borders=True)
 
 # extract pca-flipped time course from S1
 flip_data = stc.extract_label_time_course(label_s1, inv['src'],
@@ -209,9 +209,9 @@ net.add_evoked_drive(
 # ``MPIBackend`` to reduce the simulation time by parallizing across cells in
 # the network. However, no parallel backend is necessary. For a better
 # match to the empirical waveform, set ``n_trials`` to be >=25.
-n_trials = 2
+n_trials = 10
 # n_trials = 25
-with MPIBackend(n_procs=2):
+with MPIBackend(n_procs=6):
     dpls = simulate_dipole(net, n_trials=n_trials)
 
 ###############################################################################

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -173,7 +173,7 @@ net.add_evoked_drive(
 # match to the empirical waveform, set ``n_trials`` to be >=25.
 n_trials = 2
 # n_trials = 25
-with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
+with MPIBackend(n_procs=2):
     dpls = simulate_dipole(net, n_trials=n_trials)
 
 ###############################################################################

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -128,7 +128,7 @@ plt.show()
 # network parameters from ``N20.json`` and instantiate the network.
 
 import hnn_core
-from hnn_core import simulate_dipole, read_params, Network, MPIBackend
+from hnn_core import simulate_dipole, read_params, Network, JoblibBackend
 from hnn_core import average_dipoles
 
 hnn_core_root = op.dirname(hnn_core.__file__)
@@ -208,7 +208,7 @@ net.add_evoked_drive(
 # match to the empirical waveform, set ``n_trials`` to be >=25.
 n_trials = 2
 # n_trials = 25
-with MPIBackend(n_procs=2):
+with JoblibBackend(n_jobs=2):
     dpls = simulate_dipole(net, n_trials=n_trials)
 
 ###############################################################################

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -184,7 +184,6 @@ net.cell_response.plot_spikes_hist(ax=axes[0],
                                    spike_types=['evprox1', 'evdist1',
                                                 'evdist2', 'evprox2'],
                                    show=False)
-axes[0].legend()
 axes[1].axhline(0, c='k', ls=':', label='_nolegend_')
 axes[1].plot(1e3 * stc.times, stc.data[pick_vertex, :].T * 1e9, 'r--')
 average_dipoles(dpls).plot(ax=axes[1], show=False)

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -91,15 +91,20 @@ label_s1 = mne.read_labels_from_annot(subject, parc='aparc.a2009s', hemi=hemi,
 # upwards (from deep to superficial) and downwards (from superficial to deep)
 # current flow, respectively. Uncomment the following code to open an
 # interactive 3D render of the brain and its surface activation (requires the
-# ``pyvista`` python library). You should get something like this that shows
-# the MNE activation at 0.040 sec around the post-central gyrus (outlined in
-# orange): |mne_example_fig|
+# ``pyvista`` python library). You should get 2 plots, the first showing the
+# post-central gyrus label from which the dipole time course was extracted and
+# the second showing MNE activation at 0.040 sec that resemble the following
+# images:
+# |mne_label_fig|
+# |mne_activity_fig|
 '''
+Brain = mne.viz.get_brain_class()
+brain_label = Brain(subject, hemi, 'white', subjects_dir=subjects_dir)
+brain_label.add_label(label_s1, color='green', alpha=0.9)
 stc_label = stc.in_label(label_s1)
-brain = stc_label.plot(subjects_dir=subjects_dir, hemi='rh', surface='white',
-                       smoothing_steps='nearest', view_layout='horizontal',
-                       initial_time=0.04, backend='pyvista')
-brain.add_label(label_s1, borders=True)
+brain = stc_label.plot(subjects_dir=subjects_dir, hemi=hemi, surface='white',
+                       view_layout='horizontal', initial_time=0.04,
+                       backend='pyvista')
 '''
 
 ###############################################################################
@@ -230,4 +235,7 @@ net.cell_response.plot_spikes_raster(ax=axes[2])
 #
 # .. _MNE: https://mne.tools/
 # .. _this MNE-python example: https://mne.tools/stable/auto_examples/inverse/plot_label_source_activations.html#sphx-glr-auto-examples-inverse-plot-label-source-activations-py # noqa
-# .. |mne_example_fig| image:: https://user-images.githubusercontent.com/5610076/106361333-ac3fdd00-631d-11eb-8817-9d95db44a554.png # noqa
+# .. |mne_label_fig| image:: https://user-images.githubusercontent.com/20212206/106524603-cfe75c80-64b0-11eb-9607-3415195c3e7a.png # noqa
+#   :width: 400
+# .. |mne_activity_fig| image:: https://user-images.githubusercontent.com/20212206/106524542-b514e800-64b0-11eb-835e-497454e75eb9.png # noqa
+#   :width: 400

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -38,24 +38,22 @@ fwd_fname = op.join(data_path, 'derivatives', 'sub-{}'.format(subject),
 subjects_dir = op.join(data_path, 'derivatives', 'freesurfer', 'subjects')
 
 ###############################################################################
-# Then, we get the raw data and estimate the inverse operator. This includes
-# reading and band-pass filtering the raw data,
+# Then, we get the raw data and estimate the inverse operator.
+
+# Read and band-pass filter the raw data
 raw = mne.io.read_raw_fif(raw_fname, preload=True)
 raw.filter(1, 40)
 
-###############################################################################
-# isolating events associated with each MEG time series in the dataset,
+# Identify stimulus events associated with MEG time series in the dataset
 events = mne.find_events(raw, stim_channel='STI 014')
 
-###############################################################################
-# defining epochs within the time series,
+# Define epochs within the time series
 event_id, tmin, tmax = 1, -.2, .17
 baseline = None
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax, baseline=baseline,
                     reject=dict(grad=4000e-13, eog=350e-6), preload=True)
 
-###############################################################################
-# and finally computing the inverse operator.
+# Compute the inverse operator
 fwd = mne.read_forward_solution(fwd_fname)
 cov = mne.compute_covariance(epochs)
 inv = make_inverse_operator(epochs.info, fwd, cov)
@@ -69,7 +67,6 @@ inv = make_inverse_operator(epochs.info, fwd, cov)
 # to note that the dipole currents simulated with HNN are assumed to be normal
 # to the cortical surface. Hence, using the option ``pick_ori='normal'``
 # seems to make most sense.
-
 method = "MNE"
 snr = 3.
 lambda2 = 1. / snr ** 2
@@ -83,6 +80,7 @@ stc = apply_inverse(evoked, inv, lambda2, method=method, pick_ori="normal",
 # each vertex. The time course from the vertex with the greatest L2 norm
 # represents the location of cortex with greatest response to stimulus.
 pick_vertex = np.argmax(np.linalg.norm(stc.data, axis=1))
+
 plt.figure()
 plt.plot(1e3 * stc.times, stc.data[pick_vertex, :].T * 1e9, 'ro-')
 plt.xlabel('time (ms)')
@@ -93,8 +91,7 @@ plt.show()
 
 ###############################################################################
 # Now, let us try to simulate the same with hnn-core. We read in the network
-# parameters from ``N20.json`` and explicitly create two distal and one
-# proximal evoked drive.
+# parameters from ``N20.json`` and instantiate the network.
 
 import hnn_core
 from hnn_core import simulate_dipole, read_params, Network, MPIBackend, average_dipoles
@@ -106,39 +103,57 @@ params = read_params(params_fname)
 
 net = Network(params)
 
-# Distal evoked drives share connection parameters
+###############################################################################
+# To simulate the source of the median nerve evoked response, we create a
+# sequence of synchronous evoked drives: 1 proximal, 2 distal, and 1 final
+# proximal drive. Note that setting ``sync_within_trial=True`` creates drives
+# with synchronous input (arriving to and transmitted by hypothetical granular
+# cells at the center of the network) to all pyramidal and basket cells that
+# receive distal drive.
+
+# Proximal drives share connection parameters
+weights_ampa_p = {'L2_basket': 0.003, 'L2_pyramidal': 0.0025,
+                  'L5_basket': 0.004, 'L5_pyramidal': 0.001}
+weights_nmda_p = {'L2_basket': 0.003, 'L5_basket': 0.004}
+synaptic_delays_p = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
+                     'L5_basket': 1.0, 'L5_pyramidal': 1.0}
+
+# Early proximal drive
+net.add_evoked_drive(
+    'evprox1', mu=20.0, sigma=3., numspikes=1, sync_within_trial=True,
+    weights_ampa=weights_ampa_p, weights_nmda=weights_nmda_p,
+    location='proximal', synaptic_delays=synaptic_delays_p, seedcore=6)
+
+# Late proximal drive
+net.add_evoked_drive(
+    'evprox2', mu=130.0, sigma=3., numspikes=1, sync_within_trial=True,
+    weights_ampa=weights_ampa_p, weights_nmda=weights_nmda_p,
+    location='proximal', synaptic_delays=synaptic_delays_p, seedcore=6)
+
+# Early distal drive
 weights_ampa_d = {'L2_basket': 0.003, 'L2_pyramidal': 0.0045,
                   'L5_pyramidal': 0.001}
 weights_nmda_d = {'L2_basket': 0.003, 'L2_pyramidal': 0.0045,
                   'L5_pyramidal': 0.001}
 synaptic_delays_d = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
                      'L5_pyramidal': 0.1}
-# early distal input
+
+# Late distal drive
 net.add_evoked_drive(
     'evdist1', mu=32., sigma=3., numspikes=1, sync_within_trial=True,
     weights_ampa=weights_ampa_d, weights_nmda=weights_nmda_d,
     location='distal', synaptic_delays=synaptic_delays_d, seedcore=6)
-# late distal input
+
+# Late distal input
 net.add_evoked_drive(
     'evdist2', mu=82., sigma=3., numspikes=1, sync_within_trial=True,
     weights_ampa=weights_ampa_d, weights_nmda=weights_nmda_d,
     location='distal', synaptic_delays=synaptic_delays_d, seedcore=2)
 
-# proximal input occurs before distals
-weights_ampa_p = {'L2_basket': 0.003, 'L2_pyramidal': 0.0025,
-                  'L5_basket': 0.004, 'L5_pyramidal': 0.001}
-weights_nmda_p = {'L2_basket': 0.003, 'L5_basket': 0.004}
-synaptic_delays_p = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
-                     'L5_basket': 1.0, 'L5_pyramidal': 1.0}
-net.add_evoked_drive(
-    'evprox1', mu=20.0, sigma=3., numspikes=1, sync_within_trial=True,
-    weights_ampa=weights_ampa_p, weights_nmda=weights_nmda_p,
-    location='proximal', synaptic_delays=synaptic_delays_p, seedcore=6)
-
 # n_trials = 25
-n_trials = 1
+n_trials = 2
 with MPIBackend(n_procs=6, mpi_cmd='mpiexec'):
-    dpls = simulate_dipole(net, n_trials=25)
+    dpls = simulate_dipole(net, n_trials=n_trials)
 
 fig, axes = plt.subplots(3, 1, sharex=True, figsize=(6, 6))
 axes[1].plot(1e3 * stc.times, stc.data[pick_vertex, :].T * 1e9, 'r-')

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -180,13 +180,16 @@ with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
 # Finally, we plot the driving spike histogram, empirical and simulated median
 # nerve evoked response waveforms, and output spike histogram.
 fig, axes = plt.subplots(3, 1, sharex=True, figsize=(6, 6))
-net.cell_response.plot_spikes_hist(ax=axes[0], show=False)
-axes[0].legend(['evdist_1', 'evdist_2', 'evprox_1', 'evprox_2'])
-axes[0].set_ylabel('Counts')
-axes[1].axhline(0, c='k', ls=':')
+net.cell_response.plot_spikes_hist(ax=axes[0],
+                                   spike_types=['evprox1', 'evdist1',
+                                                'evdist2', 'evprox2'],
+                                   show=False)
+axes[0].legend()
+axes[1].axhline(0, c='k', ls=':', label='_nolegend_')
 axes[1].plot(1e3 * stc.times, stc.data[pick_vertex, :].T * 1e9, 'r--')
-axes[1].set_ylabel('Current Dipole (nAm)')
 average_dipoles(dpls).plot(ax=axes[1], show=False)
+axes[1].legend(['MNE vertex', 'HNN simulation'])
+axes[1].set_ylabel('Current Dipole (nAm)')
 net.cell_response.plot_spikes_raster(ax=axes[2])
 
 ###############################################################################

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -15,11 +15,11 @@ simulate a biophysical model network that reproduces the observed dynamics.
 
 ###############################################################################
 # First, we will import the packages needed for computing the inverse solution
-# from the MNE somatosensory dataset. `MNE`_ can be installed with
-# ``pip install mne``, and the somatosensory dataset can be downloaded by
-# importing ``somato`` from ``mne.datasets``.
+# from the MNE somatosensory dataset. `MNE`_ along with one of its 3D rendering
+# dependencies, `pyvista`, can be installed with ``pip install mne pyvista``,
+# and the somatosensory dataset can be downloaded by importing ``somato`` from
+# ``mne.datasets``.
 import os.path as op
-import numpy as np
 import matplotlib.pyplot as plt
 
 import mne
@@ -93,11 +93,8 @@ label_s1 = mne.read_labels_from_annot(subject, parc='aparc.a2009s', hemi=hemi,
 stc_label = stc.in_label(label_s1)
 brain = stc_label.plot(subjects_dir=subjects_dir, hemi='rh', surface='white',
                        smoothing_steps='nearest', view_layout='horizontal',
-                       initial_time=0.04, backend='matplotlib')
-
-# Uncomment the line below to render a border around the selected label for S1.
-# Note that this requires that you set `backend='pyvista'` above.
-# brain.add_label(label_s1, borders=True)
+                       initial_time=0.04, backend='pyvista')
+brain.add_label(label_s1, borders=True)
 
 ###############################################################################
 # Now we extract the pca-flipped time course from S1. Note that the most

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -97,11 +97,14 @@ brain = stc_label.plot(subjects_dir=subjects_dir, hemi='rh', surface='white',
 brain.add_label(label_s1, borders=True)
 
 ###############################################################################
-# Now we extract the pca-flipped time course from S1. Note that the most
-# prominent component of the median nerve response occurs in the posterior wall
-# of the central sulcus at ~0.040 sec. Since the dipolar activity here is
-# negative, we orient the extracted waveform so that the deflection at ~0.040
-# sec is pointed downwards.
+# Now we extract the representative time course of dipole activation in our
+# labeled brain region using ``mode='pca_flip'`` (see 'this MNE-python
+# example`_ for more details). Note that the most prominent component of the
+# median nerve response occurs in the posterior wall of the central sulcus at
+# ~0.040 sec. Since the dipolar activity here is negative, we orient the
+# extracted waveform so that the deflection at ~0.040 sec is pointed downwards.
+# Thus, the ~0.040 sec deflection corresponds to current flow traveling from
+# superficial to deep layers of cortex.
 flip_data = stc.extract_label_time_course(label_s1, inv['src'],
                                           mode='pca_flip')
 dipole_tc = -flip_data[0] * 1e9
@@ -219,3 +222,4 @@ net.cell_response.plot_spikes_raster(ax=axes[2])
 # .. LINKS
 #
 # .. _MNE: https://mne.tools/
+# .. _this MNE-python example: https://mne.tools/stable/auto_examples/inverse/plot_label_source_activations.html#sphx-glr-auto-examples-inverse-plot-label-source-activations-py

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -4,8 +4,8 @@
 ================================================
 
 This example demonstrates how to calculate the inverse solution of the median
-nerve evoked response in the MNE somatosensory dataset, and then simulate a
-biophysical model network that reproduces the observed dynamics.
+nerve evoked response in S1 from the MNE somatosensory dataset, and then
+simulate a biophysical model network that reproduces the observed dynamics.
 """
 
 # Authors: Mainak Jas <mainakjas@gmail.com>
@@ -149,7 +149,7 @@ synaptic_delays_p = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
                      'L5_basket': 1.0, 'L5_pyramidal': 1.0}
 
 net.add_evoked_drive(
-    'evprox1', mu=20.0, sigma=3., numspikes=1, sync_within_trial=True,
+    'evprox1', mu=21., sigma=4., numspikes=1, sync_within_trial=True,
     weights_ampa=weights_ampa_p, weights_nmda=weights_nmda_p,
     location='proximal', synaptic_delays=synaptic_delays_p, seedcore=6)
 
@@ -162,7 +162,7 @@ synaptic_delays_p = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
                      'L5_basket': 1.0, 'L5_pyramidal': 1.0}
 
 net.add_evoked_drive(
-    'evprox2', mu=130.0, sigma=3., numspikes=1, sync_within_trial=True,
+    'evprox2', mu=134., sigma=4.5, numspikes=1, sync_within_trial=True,
     weights_ampa=weights_ampa_p, weights_nmda=weights_nmda_p,
     location='proximal', synaptic_delays=synaptic_delays_p, seedcore=6)
 
@@ -175,7 +175,7 @@ synaptic_delays_d = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
                      'L5_pyramidal': 0.1}
 
 net.add_evoked_drive(
-    'evdist1', mu=32., sigma=3., numspikes=1, sync_within_trial=True,
+    'evdist1', mu=32., sigma=2.5, numspikes=1, sync_within_trial=True,
     weights_ampa=weights_ampa_d, weights_nmda=weights_nmda_d,
     location='distal', synaptic_delays=synaptic_delays_d, seedcore=6)
 
@@ -188,7 +188,7 @@ synaptic_delays_d = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
                      'L5_pyramidal': 0.1}
 
 net.add_evoked_drive(
-    'evdist2', mu=82., sigma=3., numspikes=1, sync_within_trial=True,
+    'evdist2', mu=84., sigma=4.5, numspikes=1, sync_within_trial=True,
     weights_ampa=weights_ampa_d, weights_nmda=weights_nmda_d,
     location='distal', synaptic_delays=synaptic_delays_d, seedcore=2)
 

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -165,9 +165,11 @@ net.add_evoked_drive(
 
 ###############################################################################
 # Now we run the simulation over 2 trials so that we can plot the average
-# aggregate dipole. Note that we can use ``MPIBackend`` to reduce the
-# simulation time, however, no parallel backend is necessary. For a better
-# match to the empirical waveform, run simulation with >=25 trials.
+# aggregate dipole. As in :ref:`the MPIBackend example
+# <sphx_glr_auto_examples_plot_simulate_mpi_backend.py>`, we can use
+# ``MPIBackend`` to reduce the simulation time by parallizing across cells in
+# the network. However, no parallel backend is necessary. For a better
+# match to the empirical waveform, set ``n_trials`` to be >=25.
 n_trials = 2
 # n_trials = 25
 with MPIBackend(n_procs=6, mpi_cmd='mpiexec'):

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -94,9 +94,7 @@ label_s1 = mne.read_labels_from_annot(subject, parc='aparc.a2009s', hemi=hemi,
 # ``pyvista`` python library). You should get 2 plots, the first showing the
 # post-central gyrus label from which the dipole time course was extracted and
 # the second showing MNE activation at 0.040 sec that resemble the following
-# images:
-# |mne_label_fig|
-# |mne_activity_fig|
+# images.
 '''
 Brain = mne.viz.get_brain_class()
 brain_label = Brain(subject, hemi, 'white', subjects_dir=subjects_dir)
@@ -106,6 +104,11 @@ brain = stc_label.plot(subjects_dir=subjects_dir, hemi=hemi, surface='white',
                        view_layout='horizontal', initial_time=0.04,
                        backend='pyvista')
 '''
+
+###############################################################################
+# |mne_label_fig|
+#
+# |mne_activity_fig|
 
 ###############################################################################
 # Now we extract the representative time course of dipole activation in our
@@ -206,11 +209,8 @@ net.add_evoked_drive(
 
 ###############################################################################
 # Now we run the simulation over 2 trials so that we can plot the average
-# aggregate dipole. As in :ref:`the MPIBackend example
-# <sphx_glr_auto_examples_plot_simulate_mpi_backend.py>`, we can use
-# ``MPIBackend`` to reduce the simulation time by parallizing across cells in
-# the network. However, no parallel backend is necessary. For a better
-# match to the empirical waveform, set ``n_trials`` to be >=25.
+# aggregate dipole. For a better match to the empirical waveform, set
+# ``n_trials`` to be >=25.
 n_trials = 2
 # n_trials = 25
 with JoblibBackend(n_jobs=2):

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -160,8 +160,8 @@ net.add_evoked_drive(
 ###############################################################################
 # Run simulation. Optional: for a better match to the empirical waveform, run
 # simulation with ``n_trials=50``.
-n_trials = 20
-# n_trials = 2
+n_trials = 2
+# n_trials = 50
 with MPIBackend(n_procs=6, mpi_cmd='mpiexec'):
     dpls = simulate_dipole(net, n_trials=n_trials)
 

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -15,10 +15,9 @@ simulate a biophysical model network that reproduces the observed dynamics.
 
 ###############################################################################
 # First, we will import the packages needed for computing the inverse solution
-# from the MNE somatosensory dataset. `MNE`_ along with one of its 3D rendering
-# dependencies, `pyvista`, can be installed with ``pip install mne pyvista``,
-# and the somatosensory dataset can be downloaded by importing ``somato`` from
-# ``mne.datasets``.
+# from the MNE somatosensory dataset. `MNE`_ can be installed with
+# ``pip install mne``, and the somatosensory dataset can be downloaded by
+# importing ``somato`` from ``mne.datasets``.
 import os.path as op
 import matplotlib.pyplot as plt
 
@@ -89,16 +88,20 @@ label_s1 = mne.read_labels_from_annot(subject, parc='aparc.a2009s', hemi=hemi,
 # figure out how to orient the dipole. Note that in the HNN framework,
 # positive and negative deflections of a current dipole source correspond to
 # upwards (from deep to superficial) and downwards (from superficial to deep)
-# current flow, respectively.
+# current flow, respectively. Uncomment the following code to open an
+# interactive 3D render of the brain and its surface activation (requires the
+# ``pyvista`` python library).
+'''
 stc_label = stc.in_label(label_s1)
 brain = stc_label.plot(subjects_dir=subjects_dir, hemi='rh', surface='white',
                        smoothing_steps='nearest', view_layout='horizontal',
                        initial_time=0.04, backend='pyvista')
 brain.add_label(label_s1, borders=True)
+'''
 
 ###############################################################################
 # Now we extract the representative time course of dipole activation in our
-# labeled brain region using ``mode='pca_flip'`` (see 'this MNE-python
+# labeled brain region using ``mode='pca_flip'`` (see `this MNE-python
 # example`_ for more details). Note that the most prominent component of the
 # median nerve response occurs in the posterior wall of the central sulcus at
 # ~0.040 sec. Since the dipolar activity here is negative, we orient the

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -90,7 +90,7 @@ plt.axhline(0, c='k', ls=':')
 plt.show()
 
 ###############################################################################
-# Now, let us try to simulate the same with hnn-core. We read in the network
+# Now, let us try to simulate the same with ``hnn-core``. We read in the network
 # parameters from ``N20.json`` and instantiate the network.
 
 import hnn_core
@@ -181,8 +181,7 @@ with MPIBackend(n_procs=2):
 # nerve evoked response waveforms, and output spike histogram.
 fig, axes = plt.subplots(3, 1, sharex=True, figsize=(6, 6))
 net.cell_response.plot_spikes_hist(ax=axes[0],
-                                   spike_types=['evprox1', 'evdist1',
-                                                'evdist2', 'evprox2'],
+                                   spike_types=['evprox', 'evdist']
                                    show=False)
 axes[1].axhline(0, c='k', ls=':', label='_nolegend_')
 axes[1].plot(1e3 * stc.times, stc.data[pick_vertex, :].T * 1e9, 'r--')

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -142,7 +142,8 @@ net = Network(params)
 # proximal drive. Note that setting ``sync_within_trial=True`` creates drives
 # with synchronous input (arriving to and transmitted by hypothetical granular
 # cells at the center of the network) to all pyramidal and basket cells that
-# receive distal drive. Note that granule cells are not explicitly modelled within HNN. 
+# receive distal drive. Note that granule cells are not explicitly modelled
+# within HNN.
 
 # Early proximal drive
 weights_ampa_p = {'L2_basket': 0.0036, 'L2_pyramidal': 0.0039,
@@ -226,4 +227,4 @@ net.cell_response.plot_spikes_raster(ax=axes[2])
 # .. LINKS
 #
 # .. _MNE: https://mne.tools/
-# .. _this MNE-python example: https://mne.tools/stable/auto_examples/inverse/plot_label_source_activations.html#sphx-glr-auto-examples-inverse-plot-label-source-activations-py
+# .. _this MNE-python example: https://mne.tools/stable/auto_examples/inverse/plot_label_source_activations.html#sphx-glr-auto-examples-inverse-plot-label-source-activations-py # noqa

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -248,6 +248,8 @@ class Network(object):
                         drive_name, mu=specs['dynamics']['mu'],
                         sigma=specs['dynamics']['sigma'],
                         numspikes=specs['dynamics']['numspikes'],
+                        sync_within_trial=specs['dynamics']
+                                               ['sync_within_trial'],
                         weights_ampa=specs['weights_ampa'],
                         weights_nmda=specs['weights_nmda'],
                         location=specs['location'], seedcore=specs['seedcore'],

--- a/hnn_core/param/N20.json
+++ b/hnn_core/param/N20.json
@@ -7,7 +7,7 @@
 	"save_figs": 0,
 	"save_spec_data": 0,
 	"f_max_spec": 40.0,
-	"dipole_scalefctr": 30,
+	"dipole_scalefctr": 12,
 	"dipole_smooth_win": 20,
 	"save_vsoma": 0,
 	"prng_seedcore_input_prox": 4,

--- a/hnn_core/param/N20.json
+++ b/hnn_core/param/N20.json
@@ -1,5 +1,5 @@
 {
-	"tstop": 120,
+	"tstop": 170,
 	"dt": 0.025,
 	"celsius": 37.0,
 	"N_trials": 100,
@@ -8,7 +8,7 @@
 	"save_spec_data": 0,
 	"f_max_spec": 40.0,
 	"dipole_scalefctr": 30,
-	"dipole_smooth_win": 5,
+	"dipole_smooth_win": 20,
 	"save_vsoma": 0,
 	"prng_seedcore_input_prox": 4,
 	"prng_seedcore_input_dist": 4,

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -212,7 +212,8 @@ def plot_spikes_hist(cell_response, ax=None, spike_types=None, show=True):
         color = spike_color[spike_label]
         ax.hist(spike_times[spike_types_mask[spike_type]], bins,
                 label=label, color=color)
-    plt.legend()
+    ax.set_ylabel("Counts")
+    ax.legend()
 
     plt_show(show)
     return ax.get_figure()


### PR DESCRIPTION
Goals:

- [x] improve narrative
- [ ] ~~update MNE vertex selection~~
- [x] update drive and local network connectivity parameters
- [x] consolidate plots so that the median nerve response inverse solution (i.e., MNE vertex) and hnn-core simulation are plotted together
- [x] provide option for multiple trials that, when averaged together, obviously resemble the empirical inverse solution
- [x] Extra fix: allow sync_within_trials to be set from within `Network` constructor if `add_drives_from_params is True`

closes #247