### PR TITLE
Add an `environment.yml` for `conda`-users

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,6 @@ dependencies:
 - matplotlib
 - openmpi
 - mpi4py
-pip:
+- pip:
   - NEURON
   - mne

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: hnn
+channels:
+- default
+dependencies:
+- python>=3.7,<3.9
+- pip
+- numpy
+- scipy
+- matplotlib
+- openmpi
+- mpi4py
+pip:
+  - NEURON
+  - mne

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ ignore = E722, W504
 ignore =
     .circleci/*
     doc
+
+[bdist_wheel]
+universal = 0


### PR DESCRIPTION
This works on macOS and Ubuntu 16.04. If included, it would reduce our installation instructions to

```bash
conda create --file environment.yml
```

The modification to `setup.cfg` doesn't influence the behaviour of `python setup.py bdist_wheel`, though: a universal wheel is still built.