### PR TITLE
[MRG] add .coveragerc to exclude externals

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+omit = */externals/*,*/tests/*

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -6,10 +6,21 @@ import pytest
 
 import hnn_core
 from hnn_core import read_params, Network
-from hnn_core.viz import plot_dipole, plot_psd, plot_tfr_morlet
+from hnn_core.viz import plot_cells, plot_dipole, plot_psd, plot_tfr_morlet
 from hnn_core.dipole import simulate_dipole
 
 matplotlib.use('agg')
+
+
+def test_network_visualization():
+    """Test network visualisations."""
+    hnn_core_root = op.dirname(hnn_core.__file__)
+    params_fname = op.join(hnn_core_root, 'param', 'default.json')
+    params = read_params(params_fname)
+    params.update({'N_pyr_x': 3,
+                   'N_pyr_y': 3})
+    net = Network(params)
+    plot_cells(net)
 
 
 def test_dipole_visualization():
@@ -34,6 +45,13 @@ def test_dipole_visualization():
     axes = fig.get_axes()[0]
     dpls[0].copy().smooth(window_len=10).plot(ax=axes)  # add smoothed versions
     dpls[0].copy().savgol_filter(h_freq=30).plot(ax=axes)  # on top
+
+    # test decimation options
+    plot_dipole(dpls[0], decim=2)
+    for dec in [-1, [2, 2.]]:
+        with pytest.raises(ValueError,
+                           match='each decimation factor must be a positive'):
+            plot_dipole(dpls[0], decim=dec)
 
     # test plotting multiple dipoles as overlay
     fig = plot_dipole(dpls)

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -24,12 +24,13 @@ def _get_plot_data(dpl, layer, tmin, tmax):
 
 def _decimate_plot_data(decim, data, times, sfreq=None):
     from scipy.signal import decimate
-    if isinstance(decim, int):
-        decim = [decim]
     if not isinstance(decim, list):
-        raise ValueError('the decimation factor must be a int or list'
-                         f'of ints; got {type(decim)}')
+        decim = [decim]
+
     for dec in decim:
+        if not isinstance(dec, int) or dec < 1:
+            raise ValueError('each decimation factor must be a positive int, '
+                             f'but {dec} is a {type(dec)}')
         data = decimate(data, dec)
         times = times[::dec]
 


### PR DESCRIPTION
Follow-up to #281 : excluding `externals` (and `tests`) from coverage report illustrates where we should focus attention to (e.g. `viz.py` is trailing behind the rest...).