### PR TITLE
[MRG] reset net.cell_response in simulate_dipole

### DIFF
--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -93,6 +93,7 @@ def simulate_dipole(net, n_trials=None, record_vsoma=False,
     # XXX needed in mpi_child.py:run()#L103; include fix in #211 or later PR
     net.params['N_trials'] = n_trials
     net._instantiate_drives(n_trials=n_trials)
+    net.cell_response.reset()  # see #290 for context; relevant for MPI
 
     if isinstance(record_vsoma, bool):
         net.params['record_vsoma'] = record_vsoma

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -886,6 +886,8 @@ class CellResponse(object):
 
     Methods
     -------
+    reset()
+        Reset all recorded attributes to empty lists.
     update_types(gid_ranges)
         Update spike types in the current instance of CellResponse.
     plot(ax=None, show=True)
@@ -1044,6 +1046,14 @@ class CellResponse(object):
     @property
     def times(self):
         return self._times
+
+    def reset(self):
+        """Reset all recorded attributes to empty lists."""
+        self._spike_times = list()
+        self._spike_gids = list()
+        self._spike_types = list()
+        self._vsoma = list()
+        self._isoma = list()
 
     def update_types(self, gid_ranges):
         """Update spike types in the current instance of CellResponse.

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -245,9 +245,14 @@ def test_cell_response(tmpdir):
     assert ("CellResponse | 0 simulation trials" in repr(cell_response))
     # reset clears all recorded variables, but leaves simulation time intact
     assert len(cell_response.times) == len(sim_times)
-    attributes = ['_spike_times', '_spike_gids', '_spike_types',
-                  '_vsoma', '_isoma']
-    for attr in attributes:
+    sim_attributes = ['_spike_times', '_spike_gids', '_spike_types',
+                      '_vsoma', '_isoma']
+    net_attributes = ['_times']  # `Network.__init__` creates these
+    # check that we always know which response attributes are simulated
+    # see #291 for discussion; objective is to keep cell_response size small
+    assert list(cell_response.__dict__.keys()) == \
+        sim_attributes + net_attributes
+    for attr in sim_attributes:  # populated by `simulate_dipole`
         assert len(getattr(cell_response, attr)) == 0  # all lists are empty
 
     # Test recovery of empty spike files


### PR DESCRIPTION
`net.cell_response` must be reset (lists emptied) in `simulate_dipole` to prevent cell response attributes being appended. The use case is pathological (see #290 and the gist therein), but may come up during optimisation?

Closes #290 