### PR TITLE
MRG: use Queue in MPIBackend for non-blocking read

### DIFF
--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -69,19 +69,22 @@ Verifies that MPI, NEURON, and Python are all working together.
 
     from hnn_core import MPIBackend
 
-    # set n_procs to the number of processors MPI can use (up to number of cores on system)
-    with MPIBackend(n_procs=2):
+    # Set n_procs to the number of processors MPI can use (up to number of cores on system)
+    # A different launch command can be specified for MPI distributions other than openmpi
+    with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
         dpls = simulate_dipole(net, n_trials=1)
 
 **Notes for contributors**::
 
 MPI parallelization with NEURON requires that the simulation be launched with the ``nrniv`` binary from the command-line. The ``mpiexec`` command is used to launch multiple ``nrniv`` processes which communicate via MPI. This is done using ``subprocess.Popen()`` in ``MPIBackend.simulate()`` to launch parallel child processes (``MPISimulation``) to carry out the simulation. The communication sequence between ``MPIBackend`` and ``MPISimulation`` is outlined below.
 
-#. In order to pass the parameters from ``MPIBackend`` the child ``MPISimulation`` processes' ``stdin`` is used. Parameters are pickled and base64 encoded before being written to the processes' ``stdin``. Closing ``stdin`` (from the ``MPIBackend`` side) signals to the child processes that it is done sending parameters and the parallel simulation should begin.
+#. In order to pass the network to simulate from ``MPIBackend``, the child ``MPISimulation`` processes' ``stdin`` is used. The ready-to-use `Network` object is pickled and base64 encoded before being written to the child processes' ``stdin`` by way of a Queue in a non-blocking way. See how it is `used in MNE-Python`_. The data is marked by start and end signals that are used to extra the pickled net object. After being unpicked, the parallel simulation begins.
 #. Output from the simulation (either to ``stdout`` or ``stderr``) is communicated back to ``MPIBackend``, where it will be printed to the console. Typical output at this point would be simulation progress messages as well as any MPI warnings/errors during the simulation.
-#. Once the simulation has completed, the child process with rank 0 (in ``MPISimulation.run()``) sends a signal to ``MPIBackend`` that the simulation has completed and simulation data will be written to ``stderr``.  The data is pickled and base64 encoded before it is written to ``stderr`` in ``MPISimulation._write_data_stderr()``. No other output (e.g. raised exceptions) can go to ``stderr`` during this step.
-#. At this point, the child process with rank 0 (the only rank with complete simulation results) will send another signal that includes the expected length of the pickled and encoded data (in bytes) to ``stderr`` following the data written in the previous step. ``MPIBackend`` will use this signal to know that data transfer has completed and it will verify the length of data it receives, printing a ``UserWarning`` if the lengths don't match.
+#. Once the simulation has completed, the child process with rank 0 adds markings to the data for the start and end of the encoded data, including the expected length of data (in bytes) in the end of data marking.
+#. ``MPIBackend`` will look for these markings to know that data is being sent (and will not print this) has completed. It will verify the length of data it receives, printing a ``UserWarning`` if the data length received doesn't match the length part of the marking. At this point, ``MPIBackend`` unpickles the simulation results and returns
 
-It is important that ``MPISimulation`` uses the ``flush()`` method after each signal to ensure that the signal will immediately be available for reading by ``MPIBackend`` and not buffered with other output.
+It is important that ``flush()`` is used whenever data is written to stdin or stderr to ensure that the signal will immediately be available for reading by the other side.
 
 Tests for parallel backends utilize a special ``@pytest.mark.incremental`` decorator (defined in ``conftest.py``) that causes a test failure to skip subsequent tests in the incremental block. For example, if a test running a simple MPI simulation fails, subsequent tests that compare simulation output between different backends will be skipped. These types of failures will be marked as a failure in CI.
+
+.. _used in MNE-Python: https://github.com/mne-tools/mne-python/blob/148de1661d5e43cc88d62e27731ce44e78892951/mne/utils/misc.py#L124-L132

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -97,7 +97,12 @@ The communication sequence between ``MPIBackend`` and ``MPISimulation`` is outli
 #. ``MPIBackend`` will look for these markings to know that data is being sent (and will not
    print this). It will verify the length of data it receives, printing a
    ``UserWarning`` if the data length received doesn't match the length part of the marking.
-   At this point, ``MPIBackend`` unpickles the simulation results and returns
+#. To signal that the child process should terminate, ``MPIBackend`` sends a signal to the child
+   proccesses' ``stdin``. After sending the simulation data, rank 0 waits for this completion signal
+   before continuing and letting all ranks of the MPI process exit successfully.
+#. At this point, ``MPIBackend.simulate()`` decodes and unpickles the data, populates the network's
+   CellResponse object, and returns the simulation dipoles to the caller.
+
 
 It is important that ``flush()`` is used whenever data is written to stdin or stderr to ensure that the signal will immediately be available for reading by the other side.
 

--- a/hnn_core/externals/mne.py
+++ b/hnn_core/externals/mne.py
@@ -765,3 +765,10 @@ def _check_tfr_param(freqs, sfreq, method, zero_mean, n_cycles,
     _check_option('method', method, ['multitaper', 'morlet'])
 
     return freqs, sfreq, zero_mean, n_cycles, time_bandwidth, decim
+
+
+####################################################
+# mne/utils/misc.py
+def _enqueue_output(out, queue):
+    for line in iter(out.readline, b''):
+        queue.put(line)

--- a/hnn_core/externals/mne.py
+++ b/hnn_core/externals/mne.py
@@ -765,10 +765,3 @@ def _check_tfr_param(freqs, sfreq, method, zero_mean, n_cycles,
     _check_option('method', method, ['multitaper', 'morlet'])
 
     return freqs, sfreq, zero_mean, n_cycles, time_bandwidth, decim
-
-
-####################################################
-# mne/utils/misc.py
-def _enqueue_output(out, queue):
-    for line in iter(out.readline, b''):
-        queue.put(line)

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -7,7 +7,6 @@ This script is called directly from MPIBackend.simulate()
 import sys
 import pickle
 import base64
-from warnings import warn
 from queue import Queue, Empty
 from threading import Thread
 

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -12,6 +12,14 @@ import re
 from hnn_core.parallel_backends import _extract_data, _extract_data_length
 
 
+def _pickle_data(sim_data):
+    # pickle the data and encode as base64 before sending to stderr
+    pickled_str = pickle.dumps(sim_data)
+    pickled_bytes = base64.b64encode(pickled_str)
+
+    return pickled_bytes
+
+
 class MPISimulation(object):
     """The MPISimulation class.
     Parameters
@@ -26,7 +34,6 @@ class MPISimulation(object):
     rank : int
         The rank for each processor part of the MPI communicator
     """
-
     def __init__(self, skip_mpi_import=False):
         self.skip_mpi_import = skip_mpi_import
         if skip_mpi_import:
@@ -74,7 +81,7 @@ class MPISimulation(object):
                 line = sys.stdin.readline()
                 line = line.rstrip('\n')
                 input_str += line
-                end_match = re.search(r'@end_of_net:\d+@', line)
+                end_match = re.search(r'@end_of_net:\d+@', input_str)
                 if end_match is not None:
                     break
 
@@ -85,12 +92,16 @@ class MPISimulation(object):
         net = self.comm.bcast(net, root=0)
         return net
 
-    def _pickle_data(self, sim_data):
-        # pickle the data and encode as base64 before sending to stderr
-        pickled_str = pickle.dumps(sim_data)
-        pickled_bytes = base64.b64encode(pickled_str)
-
-        return pickled_bytes
+    def _wait_for_exit_signal(self):
+        # read from stdin
+        if self.rank == 0:
+            input_str = ''
+            while True:
+                line = sys.stdin.readline()
+                line = line.rstrip('\n')
+                input_str += line
+                if '@data_received@' in input_str:
+                    break
 
     def _write_data_stderr(self, sim_data):
         """write base64 encoded data to stderr"""
@@ -100,13 +111,13 @@ class MPISimulation(object):
             return
 
         sys.stderr.write('@start_of_data@')
-        pickled_bytes = self._pickle_data(sim_data)
+        pickled_bytes = _pickle_data(sim_data)
         sys.stderr.write(pickled_bytes.decode())
 
         # the parent process is waiting for "@end_of_data:[#bytes]@" with the
         # length of data. The '@' is not found in base64 encoding, so we can
         # be certain it is the border of the signal
-        sys.stderr.write('@end_of_data:%d@' % len(pickled_bytes))
+        sys.stderr.write('@end_of_data:%d@\n' % len(pickled_bytes))
         sys.stderr.flush()  # flush to ensure signal is not buffered
 
     def run(self, net):
@@ -140,6 +151,7 @@ if __name__ == '__main__':
             net = mpi_sim._read_net()
             sim_data = mpi_sim.run(net)
             mpi_sim._write_data_stderr(sim_data)
+            mpi_sim._wait_for_exit_signal()
     except Exception:
         # This can be useful to indicate the problem to the
         # caller (in parallel_backends.py)

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -24,6 +24,8 @@ _BACKEND = None
 def _thread_handler(event, out, queue):
     while not event.isSet():
         line = out.readline()
+        if line == '':
+            break
         queue.put(line)
 
 

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -9,7 +9,7 @@ import hnn_core
 from hnn_core import read_params, read_dipole, average_dipoles, Network
 from hnn_core.viz import plot_dipole
 from hnn_core.dipole import Dipole, simulate_dipole
-from hnn_core.parallel_backends import requires_mpi4py
+from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
 
 matplotlib.use('agg')
 
@@ -112,6 +112,7 @@ def test_dipole_simulation():
 
 
 @requires_mpi4py
+@requires_psutil
 def test_cell_response_backends(run_hnn_core_fixture):
     """Test cell_response outputs across backends."""
 

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -7,7 +7,7 @@ import pytest
 
 import hnn_core
 from hnn_core import read_params, Network
-from hnn_core.mpi_child import MPISimulation
+from hnn_core.mpi_child import MPISimulation, _pickle_data
 from hnn_core.parallel_backends import (MPIBackend, _gather_trial_data,
                                         _extract_data, _extract_data_length)
 
@@ -84,7 +84,7 @@ def test_str_to_net():
     net = Network(params, add_drives_from_params=True)
 
     with MPISimulation(skip_mpi_import=True) as mpi_sim:
-        pickled_net = mpi_sim._pickle_data(net)
+        pickled_net = _pickle_data(net)
 
         input_str = '@start_of_net@' + pickled_net.decode() + \
             '@end_of_net:%d@\n' % (len(pickled_net))
@@ -164,8 +164,7 @@ def test_empty_data():
 def test_data_len_mismatch():
     """Test that padded data can be unpickled with warning for length """
 
-    with MPISimulation(skip_mpi_import=True) as mpi_sim:
-        pickled_bytes = mpi_sim._pickle_data({})
+    pickled_bytes = _pickle_data({})
 
     expected_len = len(pickled_bytes) + 1
 

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -75,7 +75,7 @@ def test_extract_data_length():
     assert output == 8
 
 
-def test_process_input():
+def test_str_to_net():
     """Test reading the network via a Queue"""
 
     hnn_core_root = op.dirname(hnn_core.__file__)
@@ -96,7 +96,7 @@ def test_process_input():
         in_q.put(data_str)
 
         # process input from queue
-        data_len = mpi_sim._process_input(in_q)
+        data_len = mpi_sim._str_to_net(in_q)
         assert isinstance(data_len, int)
 
         # unpickle net
@@ -118,7 +118,7 @@ def test_process_input():
 
         # process input from queue
         with pytest.raises(ValueError, match=expected_string):
-            mpi_sim._process_input(in_q)
+            mpi_sim._str_to_net(in_q)
 
 
 def test_child_run():

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -2,8 +2,6 @@ import os.path as op
 import io
 from contextlib import redirect_stdout, redirect_stderr
 from queue import Queue
-import pickle
-import base64
 
 import pytest
 

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -115,20 +115,13 @@ def test_process_input():
         in_q = Queue()
         in_q.put(data_str)
 
+        expected_string = "Got incorrect network size: %d bytes " % \
+            len(mpi_sim.input_bytes) + "expected length: %d" % \
+            (len(pickled_net) + 1)
+
         # process input from queue
-        with io.StringIO() as buf_err, redirect_stderr(buf_err):
-            with pytest.warns(UserWarning) as record:
-                mpi_sim._process_input(in_q)
-
-                expected_string = "Got incorrect network size: %d bytes " % \
-                    len(mpi_sim.input_bytes) + "expected length: %d" % \
-                    (len(pickled_net) + 1)
-
-            assert len(record) == 1
-            assert record[0].message.args[0] == expected_string
-
-            stderr_str = buf_err.getvalue()
-        assert "@net_receive_error@\n" in stderr_str
+        with pytest.raises(ValueError, match=expected_string):
+            mpi_sim._process_input(in_q)
 
 
 def test_child_run():

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -12,7 +12,7 @@ from mne.utils import _fetch_file
 import hnn_core
 from hnn_core import read_params
 from hnn_core import MPIBackend
-from hnn_core.parallel_backends import requires_mpi4py
+from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
 
 # The purpose of this incremental mark is to avoid running the full length
 # simulation when there are failures in previous (faster) tests. When a test
@@ -47,6 +47,7 @@ class TestParallelBackends():
                                dpls_reduced_joblib[trial_idx].data['agg'])
 
     @requires_mpi4py
+    @requires_psutil
     def test_mpi_nprocs(self):
         """Test that MPIBackend can use more than 1 processor"""
         # if only 1 processor is available, then MPIBackend tests will not
@@ -55,6 +56,7 @@ class TestParallelBackends():
         assert backend.n_procs > 1
 
     @requires_mpi4py
+    @requires_psutil
     def test_run_mpibackend(self, run_hnn_core_fixture):
         """Test running a MPIBackend on reduced model"""
         global dpls_reduced_default, dpls_reduced_mpi
@@ -66,6 +68,7 @@ class TestParallelBackends():
                             atol=1e-14)
 
     @requires_mpi4py
+    @requires_psutil
     def test_run_mpibackend_oversubscribed(self, run_hnn_core_fixture):
         """Test running MPIBackend with oversubscribed number of procs"""
         oversubscribed = round(cpu_count() * 1.5)
@@ -123,6 +126,7 @@ class TestParallelBackends():
 # there are no dependencies if this unit tests fails; no need to be in
 # class marked incremental
 @requires_mpi4py
+@requires_psutil
 def test_mpi_failure(run_hnn_core_fixture):
     """Test that an MPI failure is handled and messages are printed"""
     # this MPI paramter will cause a MPI job to fail

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -132,17 +132,11 @@ def test_mpi_failure(run_hnn_core_fixture):
     # this MPI paramter will cause a MPI job to fail
     environ["OMPI_MCA_btl"] = "self"
 
-    with pytest.warns(UserWarning) as record:
-        with io.StringIO() as buf, redirect_stdout(buf):
-            with pytest.raises(RuntimeError, match="MPI simulation failed"):
-                run_hnn_core_fixture(backend='mpi', reduced=True)
-            stdout = buf.getvalue()
+    with io.StringIO() as buf, redirect_stdout(buf):
+        with pytest.raises(RuntimeError, match="MPI simulation failed"):
+            run_hnn_core_fixture(backend='mpi', reduced=True)
+        stdout = buf.getvalue()
 
     assert "MPI processes are unable to reach each other" in stdout
-
-    expected_string = "Timed out (5s) waiting for end of data " + \
-        "after child process stopped"
-    assert len(record) == 1
-    assert record[0].message.args[0] == expected_string
 
     del environ["OMPI_MCA_btl"]

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -52,8 +52,8 @@ class TestParallelBackends():
         """Test that MPIBackend can use more than 1 processor"""
         # if only 1 processor is available, then MPIBackend tests will not
         # be valid
-        backend = MPIBackend()
-        assert backend.n_procs > 1
+        with MPIBackend() as backend:
+            assert backend.n_procs > 1
 
     @requires_mpi4py
     @requires_psutil


### PR DESCRIPTION
Select is not compatible with windows (see #215), so we can
follow the same scheme MNE uses with a thread that reads from
stdin/stdout/stderr and appeands line-by-line to a queue. The
main process can then read from the queue. Implements non-
blocking read and is a bit faster than the old _read_all_bytes
function, even with #287.

Also add cleanup processes on KeyboardInterrupt that kill any
running nrniv processes.

Closes #285 and #215