### PR TITLE
MRG: add terminate method to MPIBackend

### DIFF
--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -193,8 +193,8 @@ def run_subprocess(command, obj, timeout, proc_queue=None, *args, **kwargs):
 
             if not child_terminated and \
                     count_since_last_output > timeout_cycles:
-                warn("No output from child process in approx 10s. "
-                     "Terminating...")
+                warn("Timeout exceeded while waiting for child process output"
+                     ". Terminating...")
                 kill_proc_name('nrniv')
                 break
     except KeyboardInterrupt:
@@ -692,6 +692,11 @@ class MPIBackend(object):
         return dpls
 
     def terminate(self):
+        """Terminate running simulation on this MPIBackend
+
+        Safe to call from another thread from the one `simulate_dipole`
+        was called from.
+        """
         proc = None
         try:
             proc = self.proc_queue.get(timeout=1)

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -701,7 +701,7 @@ class MPIBackend(object):
         if proc is not None:
             proc.terminate()
             try:
-                proc.wait(5)  # wait maximum of 1s
+                proc.wait(5)  # wait maximum of 5s
             except TimeoutExpired:
                 warn("Could not kill python subprocess: PID %d" %
                      proc.pid)

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -93,7 +93,7 @@ def _get_mpi_env():
     return my_env
 
 
-def run_subprocess(command, obj, timeout=10, proc_queue=None, *args, **kwargs):
+def run_subprocess(command, obj, timeout, proc_queue=None, *args, **kwargs):
     """Run process and communicate with it.
     Parameters
     ----------
@@ -102,9 +102,8 @@ def run_subprocess(command, obj, timeout=10, proc_queue=None, *args, **kwargs):
     obj : object
         The object to write to stdin after starting child process
         with MPI command.
-    timeout : float | None
-        The number of seconds to wait for a process without output. If None
-        specified, will default to 10s
+    timeout : float
+        The number of seconds to wait for a process without output.
     *args, **kwargs : arguments
         Additional arguments to pass to subprocess.Popen.
     Returns
@@ -685,7 +684,7 @@ class MPIBackend(object):
         env = _get_mpi_env()
 
         self.proc, sim_data = run_subprocess(
-            command=self.mpi_cmd, obj=net, timeout=10,
+            command=self.mpi_cmd, obj=net, timeout=30,
             proc_queue=self.proc_queue, env=env, cwd=os.getcwd(),
             universal_newlines=True)
 

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -682,7 +682,7 @@ class MPIBackend(object):
         env = _get_mpi_env()
 
         self.proc, sim_data = run_subprocess(
-            command=self.mpi_cmd, obj=net, timeout=4,
+            command=self.mpi_cmd, obj=net, timeout=10,
             env=env, cwd=os.getcwd(), universal_newlines=True)
 
         dpls = _gather_trial_data(sim_data, net, n_trials, postproc)

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -14,7 +14,7 @@ from warnings import warn
 from subprocess import Popen, PIPE, TimeoutExpired
 import binascii
 from queue import Queue, Empty
-from threading import Thread, Event, Lock
+from threading import Thread, Event
 
 from psutil import wait_procs, process_iter, NoSuchProcess
 

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -545,11 +545,19 @@ class MPIBackend(object):
         can be less than the user specified value if limited by the cores on
         the system, the number of cores allowed by the job scheduler, or
         if mpi4py could not be loaded.
-    mpi_cmd: list of str
+    mpi_cmd : list of str
         The mpi command with number of procs and options to be passed to Popen
     expected_data_length : int
         Used to check consistency between data that was sent and what
         MPIBackend received.
+    killed : bool
+        Whether MPIBackend has been signalled to terminate by an external
+        process. To prevent proceeding with a simulation after this has been
+        set, it is checked immediately before starting.
+    killed_lock : threading.Lock
+        A lock to prevent reads from self.killed while the other process is
+        currently writing. It means a read will reflect the consistent state
+        of self.killed
     """
     def __init__(self, n_procs=None, mpi_cmd='mpiexec'):
         self.expected_data_length = 0

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -163,6 +163,8 @@ def run_subprocess(command, obj, timeout, *args, **kwargs):
                     # child failed during _write_net(). get the
                     # output and break out of loop on the next
                     # iteration
+                    warn("Received BrokenPipeError exception. "
+                         "Child process failed unexpectedly")
                     continue
                 else:
                     sent_network = True

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -97,7 +97,7 @@ class TestParallelBackends():
                     simulate_dipole(net)
 
         expected_string = "Child process failed unexpectedly"
-        assert record[0].message.args[0] == expected_string
+        assert expected_string in record[0].message.args[0]
 
     @requires_mpi4py
     @requires_psutil

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -132,8 +132,7 @@ def test_mpi_failure(run_hnn_core_fixture):
 
     assert "MPI processes are unable to reach each other" in stdout
 
-    expected_string = "Child process failed unexpectedly. Output from " + \
-        "child below:"
+    expected_string = "Child process failed unexpectedly"
     assert len(record) == 1
     assert record[0].message.args[0] == expected_string
 


### PR DESCRIPTION
This method will be called asynchronously by HNN GUI. So we need to use a lock to protect the variable declaring whether the simulation should terminate.

Killing nrniv procs are done in two places, and only in hnn-core. First, when the context manager exits, as this is basically state is only valid within the manager. Second, when a terminate() call is made specifically. The user may desire to run multiple simulations within a single MPIBackend context manager.