### PR TITLE
MRG: fix test_compare_hnn_core

### DIFF
--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -9,8 +9,6 @@ from numpy.testing import assert_array_equal, assert_allclose, assert_raises
 import pytest
 from mne.utils import _fetch_file
 
-import hnn_core
-from hnn_core import read_params
 from hnn_core import MPIBackend
 from hnn_core.parallel_backends import requires_mpi4py
 

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -84,13 +84,7 @@ class TestParallelBackends():
             _fetch_file(data_url, 'dpl.txt')
         dpl_master = loadtxt('dpl.txt')
 
-        hnn_core_root = op.dirname(hnn_core.__file__)
-
-        # default params
-        params_fname = op.join(hnn_core_root, 'param', 'default.json')
-        params = read_params(params_fname)
-
-        dpls, net = run_hnn_core_fixture(params, backend)
+        dpls, net = run_hnn_core_fixture(backend=backend)
         dpl = dpls[0]
 
         # write the dipole to a file and compare


### PR DESCRIPTION
A typo here kept MPI backend from running. Default Joblib backend was being compared to itself.