### PR TITLE
More specific windows instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,11 @@ and then install the dependencies separately::
 and install Neuron using the traditional package installer available here
 `https://neuron.yale.edu/neuron/ <https://neuron.yale.edu/neuron/>`_.
 
+As a final step, .mod files must be compiled with Neuron by running:
+
+   $ python -c 'import site; print(site.getsitepackages()[1] + \hnn_core\)' | cd
+   $ nrnivmodl
+
 Documentation and examples
 ==========================
 

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ install ``hnn_core`` without the dependencies::
 
 and then install the dependencies separately::
 
-   $ pip install scipy numpy matplotlib
+   $ pip install scipy numpy matplotlib psutil
 
 and install Neuron using the traditional package installer available here
 `https://neuron.yale.edu/neuron/ <https://neuron.yale.edu/neuron/>`_.

--- a/README.rst
+++ b/README.rst
@@ -81,9 +81,10 @@ and then install the dependencies separately::
 and install Neuron using the traditional package installer available here
 `https://neuron.yale.edu/neuron/ <https://neuron.yale.edu/neuron/>`_.
 
-As a final step, .mod files must be compiled with Neuron by running:
+As a final step, .mod files must be compiled with Neuron by running::
 
-   $ python -c 'import site; print(site.getsitepackages()[1] + \hnn_core\)' | cd
+   $ python -c 'import site; print(site.getsitepackages()[1] + "\hnn_core\")' | cd
+   
    $ nrnivmodl
 
 Documentation and examples

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ than one CPU core, refer to `parallel_backends`_
 The pip installer for Neuron does not yet work for Windows. In this case, it is better to
 install ``hnn_core`` without the dependencies::
 
-   $ pip install hnn_core --no-deps
+   $ pip install --no-build-isolation --no-deps hnn_core
 
 and then install the dependencies separately::
 

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -1,7 +1,7 @@
 """
-=====================================
-01. Simulate dipole for evoked inputs
-=====================================
+================================
+01. Simulate an evoked potential
+================================
 
 This example demonstrates how to simulate a dipole for evoked-like
 waveforms using HNN-core.

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class BuildMod(Command):
         print("=> Building mod files ...")
 
         if platform.system() == 'Windows':
-            mod_path = op.join(op.dirname(__file__), 'mod')
+            mod_path = op.join(op.dirname(op.abspath(__file__)), 'hnn_core', 'mod')
             shell = True
         else:
             mod_path = op.join(op.dirname(__file__), 'hnn_core', 'mod')


### PR DESCRIPTION
@jasmainak while trying to reproduce the windows install, it seems the the `--no-deps` flag is being ignored (traceback at the bottom). Going to look at setup.py to see why this is happening... 

![image](https://user-images.githubusercontent.com/55253912/113060084-32419e00-917e-11eb-9654-cceb97d007d6.png)

closes #302 