### PR TITLE
MRG: fix MPI oversubscribe test on travis

### DIFF
--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -551,10 +551,9 @@ class MPIBackend(object):
     ----------
 
     n_procs : int
-        The number of processes MPI will actually use (spread over cores). This
-        can be less than the user specified value if limited by the cores on
-        the system, the number of cores allowed by the job scheduler, or
-        if mpi4py could not be loaded.
+        The number of processes MPI will actually use (spread over cores). If 1
+        is specified or mpi4py could not be loaded, the simulation will be run
+        with the JoblibBackend
     mpi_cmd : list of str
         The mpi command with number of procs and options to be passed to Popen
     expected_data_length : int
@@ -575,11 +574,6 @@ class MPIBackend(object):
             self.n_procs = n_logical_cores
         else:
             self.n_procs = n_procs
-
-        # obey limits set by scheduler
-        if hasattr(os, 'sched_getaffinity'):
-            scheduler_cores = len(os.sched_getaffinity(0))
-            self.n_procs = min(self.n_procs, scheduler_cores)
 
         # did user try to force running on more cores than available?
         oversubscribe = False

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -130,6 +130,13 @@ class TestParallelBackends():
         hnn_core_root = op.dirname(hnn_core.__file__)
         params_fname = op.join(hnn_core_root, 'param', 'default.json')
         params = read_params(params_fname)
+        params.update({'N_pyr_x': 3,
+                       'N_pyr_y': 3,
+                       'tstop': 40,
+                       't_evprox_1': 5,
+                       't_evdist_1': 10,
+                       't_evprox_2': 20,
+                       'N_trials': 2})
         net = Network(params, add_drives_from_params=True)
 
         oversubscribed = round(cpu_count() * 1.5)

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -127,9 +127,15 @@ class TestParallelBackends():
     @requires_psutil
     def test_run_mpibackend_oversubscribed(self, run_hnn_core_fixture):
         """Test running MPIBackend with oversubscribed number of procs"""
+        hnn_core_root = op.dirname(hnn_core.__file__)
+        params_fname = op.join(hnn_core_root, 'param', 'default.json')
+        params = read_params(params_fname)
+        net = Network(params, add_drives_from_params=True)
+
         oversubscribed = round(cpu_count() * 1.5)
-        run_hnn_core_fixture(backend='mpi', n_procs=oversubscribed,
-                             reduced=True)
+        with MPIBackend(n_procs=oversubscribed) as backend:
+            assert backend.n_procs == oversubscribed
+            simulate_dipole(net)
 
     @pytest.mark.parametrize("backend", ['mpi', 'joblib'])
     def test_compare_hnn_core(self, run_hnn_core_fixture, backend, n_jobs=1):


### PR DESCRIPTION
The os.sched_getaffinity(0) call on Travis (Linux) would return 2, thus limiting n_procs to 2 for MPIBackend and not allowing the oversubscribe CI test to run with 3 processors.

Note some clusters set scheduler affinity to limit jobs on shared resources. This change means that the user will be responsible for setting n_procs appropriately and not exceeding resource reservations.