### PR TITLE
[MRG, ENH] Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,17 +12,10 @@ coverage
 .venv
 
 # Sphinx documentation
-doc/_build/
-doc/generated/
-doc/auto_examples/
-doc/auto_tutorials/
-doc/modules/generated/
-doc/sphinxext/cachedir
+doc/**
 pip-log.txt
 .coverage
 tags
-doc/coverages
-doc/samples
 cover
 
 # Pycharm

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# HNN-core build
+
+
+# Distribution / packaging
+.Python
+dist/
+*.egg*
+build
+coverage
+*.xml
+.venv
+
+# Sphinx documentation
+doc/_build/
+doc/generated/
+doc/auto_examples/
+doc/auto_tutorials/
+doc/modules/generated/
+doc/sphinxext/cachedir
+pip-log.txt
+.coverage
+tags
+doc/coverages
+doc/samples
+cover
+
+# Pycharm
+.idea/
+
+*.pyc
+
+.cache
+.pytest_cache
+.ipynb_checkpoints
+.DS_Store
+.vscode/
+
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # HNN-core build
-
+dpl.txt
+hnn_core/mod/x86_64/
 
 # Distribution / packaging
 .Python


### PR DESCRIPTION
For developers' git convenience it seems like a good idea to have a .gitignore so as not to accidentally push the `__pycache__`s  etc. Is there a reason not to do this?

It seems like it's not so simple because the `build_mod` makes the dynamic libraries in a directory named after the architecture (e.g. `hnn_core/mod/x86_64/`) so that might have to be refactored or put somewhere else so that it can be properly ignored. I didn't do that part yet because that's a rather larger change and I wanted to make sure this was the way to go first.

Also this .gitignore is copied from `mne-bids` so there might be another one that would be better to copy too.