### PR TITLE
[MRG] ENH: Improve connectivity data structure

### DIFF
--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -58,7 +58,7 @@ net_erp.cell_response.plot_spikes_raster()
 # the first element corresponds to the src_gid, and the second corresponds to
 # all of its target cells.
 new_connectivity = [conn for conn in net.connectivity
-                    if net.gid_to_type(conn['gid_pairs'][0][0]) != 'L2_basket']
+                    if conn['src_type'] != 'L2_basket']
 net.connectivity = new_connectivity
 
 net_remove = net.copy()

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -38,8 +38,7 @@ net = Network(params, add_drives_from_params=True)
 # is a list of dictionaries which detail every cell-cell, and drive-cell
 # connection.
 print(len(net.connectivity))
-print(net.connectivity[0])
-print(net.connectivity[-1])
+print(net.connectivity[0].keys())
 
 ###############################################################################
 # Data recorded during simulations are stored under
@@ -53,9 +52,13 @@ net_erp.cell_response.plot_spikes_raster()
 # We can modify the connectivity list to test the effect of different
 # connectivity patterns. For example, we can remove all layer 2 inhibitory
 # connections. In the default network, the src_gids of each connection are
-# all of the same type so we'll just check the first element.
+# all of the same type so we'll just check the first element. Connections are
+# stored under ``conn['gid_pairs']`` as a list of lists of the form
+# ``[[src_gid, [target_gid1, target_gid1]], ...]``. For each inner list,
+# the first element corresponds to the src_gid, and the second corresponds to
+# all of its target cells.
 new_connectivity = [conn for conn in net.connectivity
-                    if net.gid_to_type(conn['src_gids'][0]) != 'L2_basket']
+                    if net.gid_to_type(conn['gid_pairs'][0][0]) != 'L2_basket']
 net.connectivity = new_connectivity
 
 net_remove = net.copy()
@@ -68,9 +71,11 @@ net_remove.cell_response.plot_spikes_raster()
 # new connections using ``net.add_connection()``. Let's try connecting a
 # single layer 2 basket cell, to every layer 2 pyramidal cell. We can utilize
 # ``net.gid_ranges`` to help find the gids of interest.
+# ``net.add_connection()`` allows connections to be specified with either cell
+# names, or the gids directly.
 print(net.gid_ranges)
 src_gid = net.gid_ranges['L2_basket'][0]
-target_gids = net.gid_ranges['L2_pyramidal']
+target_gids = 'L2_pyramidal'
 location, receptor = 'soma', 'gabaa'
 weight, delay, lamtha = 1.0, 1.0, 70
 net.add_connection(src_gid, target_gids, location, receptor,

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -38,7 +38,7 @@ net = Network(params, add_drives_from_params=True)
 # is a list of dictionaries which detail every cell-cell, and drive-cell
 # connection.
 print(len(net.connectivity))
-print(net.connectivity[0].keys())
+print(net.connectivity[0:2])
 
 ###############################################################################
 # Data recorded during simulations are stored under
@@ -52,11 +52,10 @@ net_erp.cell_response.plot_spikes_raster()
 # We can modify the connectivity list to test the effect of different
 # connectivity patterns. For example, we can remove all layer 2 inhibitory
 # connections. In the default network, the src_gids of each connection are
-# all of the same type so we'll just check the first element. Connections are
-# stored under ``conn['gid_pairs']`` as a list of lists of the form
-# ``[[src_gid, [target_gid1, target_gid1]], ...]``. For each inner list,
-# the first element corresponds to the src_gid, and the second corresponds to
-# all of its target cells.
+# all the same cell type.. Connections are stored under ``conn['gid_pairs']``
+# as a dictionary indexed by src_gid:
+# ``{src_gid1: [target_gid1, target_gid2], ...]``. Each src_gid indexes a
+# list with it's target gids
 new_connectivity = [conn for conn in net.connectivity
                     if conn['src_type'] != 'L2_basket']
 net.connectivity = new_connectivity
@@ -72,7 +71,8 @@ net_remove.cell_response.plot_spikes_raster()
 # single layer 2 basket cell, to every layer 2 pyramidal cell. We can utilize
 # ``net.gid_ranges`` to help find the gids of interest.
 # ``net.add_connection()`` allows connections to be specified with either cell
-# names, or the gids directly.
+# names, or the gids directly. If multiple gids are provided for either the
+# sources or the targets, they will be connected in an all-to-all pattern.
 print(net.gid_ranges)
 src_gid = net.gid_ranges['L2_basket'][0]
 target_gids = 'L2_pyramidal'

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -55,7 +55,7 @@ net_erp.cell_response.plot_spikes_raster()
 # connections. In the default network, the src_gids of each connection are
 # all of the same type so we'll just check the first element.
 new_connectivity = [conn for conn in net.connectivity
-                    if net.gid_to_type(conn['gid_pairs'][0][0]) != 'L2_basket']
+                    if net.gid_to_type(conn['src_gids'][0]) != 'L2_basket']
 net.connectivity = new_connectivity
 
 net_remove = net.copy()
@@ -67,15 +67,13 @@ net_remove.cell_response.plot_spikes_raster()
 # connections increases network wide excitability. We can additionally add
 # new connections using ``net.add_connection()``. Let's try connecting a
 # single layer 2 basket cell, to every layer 2 pyramidal cell. We can utilize
-# ``net.gid_ranges`` to help
-# find the gids of interest.
+# ``net.gid_ranges`` to help find the gids of interest.
 print(net.gid_ranges)
 src_gid = net.gid_ranges['L2_basket'][0]
 target_gids = net.gid_ranges['L2_pyramidal']
 location, receptor = 'soma', 'gabaa'
 weight, delay, lamtha = 1.0, 1.0, 70
-gid_pairs = [(src_gid, target_gid) for target_gid in target_gids]
-net.add_connection(gid_pairs, location, receptor,
+net.add_connection(src_gid, target_gids, location, receptor,
                    delay, weight, lamtha)
 
 net_add = net.copy()

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -70,9 +70,10 @@ net_remove.cell_response.plot_spikes_raster()
 # new connections using ``net.add_connection()``. Let's try connecting a
 # single layer 2 basket cell, to every layer 2 pyramidal cell. We can utilize
 # ``net.gid_ranges`` to help find the gids of interest.
-# ``net.add_connection()`` allows connections to be specified with either cell
-# names, or the gids directly. If multiple gids are provided for either the
-# sources or the targets, they will be connected in an all-to-all pattern.
+# :meth:`hnn_core.Network.add_connection` allows connections to be specified
+# with either cell names, or the gids directly. If multiple gids are provided
+# for either the sources or the targets, they will be connected in an
+# all-to-all pattern.
 print(net.gid_ranges)
 src_gid = net.gid_ranges['L2_basket'][0]
 target_gids = 'L2_pyramidal'

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -55,7 +55,7 @@ net_erp.cell_response.plot_spikes_raster()
 # all the same cell type.. Connections are stored under ``conn['gid_pairs']``
 # as a dictionary indexed by src_gid:
 # ``{src_gid1: [target_gid1, target_gid2], ...]``. Each src_gid indexes a
-# list with it's target gids
+# list with its target gids
 new_connectivity = [conn for conn in net.connectivity
                     if conn['src_type'] != 'L2_basket']
 net.connectivity = new_connectivity

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -52,9 +52,10 @@ net_erp.cell_response.plot_spikes_raster()
 ###############################################################################
 # We can modify the connectivity list to test the effect of different
 # connectivity patterns. For example, we can remove all layer 2 inhibitory
-# connections.
+# connections. In the default network, the src_gids of each connection are
+# all of the same type so we'll just check the first element.
 new_connectivity = [conn for conn in net.connectivity
-                    if conn['src_type'] != 'L2_basket']
+                    if net.gid_to_type(conn['gid_pairs'][0][0]) != 'L2_basket']
 net.connectivity = new_connectivity
 
 net_remove = net.copy()
@@ -73,7 +74,8 @@ src_gid = net.gid_ranges['L2_basket'][0]
 target_gids = net.gid_ranges['L2_pyramidal']
 location, receptor = 'soma', 'gabaa'
 weight, delay, lamtha = 1.0, 1.0, 70
-net.add_connection(src_gid, target_gids, location, receptor,
+gid_pairs = [(src_gid, target_gid) for target_gid in target_gids]
+net.add_connection(gid_pairs, location, receptor,
                    delay, weight, lamtha)
 
 net_add = net.copy()

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1061,7 +1061,7 @@ class Network(object):
             raise AssertionError('target_gids must have a list for each src.')
 
         # Format gid_pairs and add to conn dictionary
-        gid_pairs = list()
+        gid_pairs = dict()
         src_type = self.gid_to_type(src_gids[0])
         for src_gid, target_src_pair in zip(src_gids, target_gids):
             _validate_type(src_gid, int, 'src_gid', 'int')
@@ -1071,7 +1071,7 @@ class Network(object):
                     f'src_gid {src_gid} not in net.gid_ranges')
             elif gid_type != src_type:
                 raise AssertionError('All src_gids must be of the same type')
-            gid_pairs.append([src_gid, target_src_pair])
+            gid_pairs[src_gid] = target_src_pair
         conn['src_type'] = src_type
 
         conn['gid_pairs'] = gid_pairs

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -979,15 +979,12 @@ class Network(object):
             Identifier for source cells. Passing str arguments
             ('L2_pyramidal', 'L2_basket', 'L5_pyramidal', 'L5_basket') is
             equivalent to passing a list of gids for the relvant cell type.
-            src-target connections depend on the input type of target_gids.
-        target_gids : str | int | range | list of int | list of list of int
+            source - target connections are made in an all-to-all pattern.
+        target_gids : str | int | range | list of int
             Identifer for targets of source cells. Passing str arguments
             ('L2_pyramidal', 'L2_basket', 'L5_pyramidal', 'L5_basket') is
             equivalent to passing a list of gids for the relvant cell type.
-            Inputs of type (str, int, range, and list of int) connect every
-            src_gid to an identical set of targets.
-            Targets can be uniquely specified for each src_gid by passing a
-            list of lists (must contain one element for each src_gid).
+            source - target connections are made in an all-to-all pattern.
         loc : str
             Location of synapse on target cell. Must be
             'proximal', 'distal', or 'soma'. Note that inhibitory synapses
@@ -1003,10 +1000,13 @@ class Network(object):
         lamtha : float
             Space constant.
 
-        N.B. Connections are stored in:
-        net.connectivity[idx]['gid_pairs'] : list of list
-            List of connected gids with the format:
-            [[src_gid, [target_gids, ...]], ...]
+        Notes
+        -----
+        Connections are stored in:
+        net.connectivity[idx]['gid_pairs'] : dict
+            dict indexed by src gids with the format:
+            {src_gid: [target_gids, ...], ...}
+        where each src_gid indexes a list of all its targets.
         """
         conn = _Connectivity()
         threshold = self.threshold

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -947,32 +947,27 @@ class Network(object):
             all target_type cells.
         """
         src_gids = self.gid_ranges[_long_name(src_cell)]
-        target_gids = self.gid_ranges[_long_name(target_cell)]
+        target_range = self.gid_ranges[_long_name(target_cell)]
 
         src_start = src_gids[0]  # Necessary for unique feeds
 
         if unique:
-            src_gids = np.array(target_gids) + src_start
+            src_gids = np.array(target_range) + src_start
             src_gids = src_gids.astype(int).tolist()
-            target_gids = [[target_gid] for target_gid in target_gids]
-            for src_gid, target_gid in zip(src_gids, target_gids):
-                self.add_connection(
-                    src_gid, target_gid, loc, receptor,
-                    nc_dict['A_weight'], nc_dict['A_delay'], nc_dict['lamtha'])
+            target_gids = [[target_gid] for target_gid in target_range]
         else:
-            if allow_autapses:
-                self.add_connection(
-                    src_gids, target_gids, loc, receptor,
-                    nc_dict['A_weight'], nc_dict['A_delay'], nc_dict['lamtha'])
-            else:
-                target_gids = np.array(target_gids)
-                for src_gid in src_gids:
-                    target_filtered = target_gids[
-                        np.where(target_gids != src_gid)[0]].tolist()
-                    self.add_connection(
-                        src_gid, target_filtered, loc, receptor,
-                        nc_dict['A_weight'], nc_dict['A_delay'],
-                        nc_dict['lamtha'])
+            target_gids = list()
+            for src_gid in src_gids:
+                target_src_pair = list()
+                for target_gid in target_range:
+                    if not allow_autapses and src_gid == target_gid:
+                        continue
+                    target_src_pair.append(target_gid)
+                target_gids.append(target_src_pair)
+
+        self.add_connection(
+            src_gids, target_gids, loc, receptor,
+            nc_dict['A_weight'], nc_dict['A_delay'], nc_dict['lamtha'])
 
     def add_connection(self, src_gids, target_gids, loc, receptor,
                        weight, delay, lamtha):
@@ -991,6 +986,8 @@ class Network(object):
             equivalent to passing a list of gids for the relvant cell type.
             Inputs of type (str, int, range, and list of int) connect every
             src_gid to an identical set of targets.
+            Targets can be uniquely specified for each src_gid by passing a
+            list of lists (must contain one element for each src_gid).
         loc : str
             Location of synapse on target cell. Must be
             'proximal', 'distal', or 'soma'. Note that inhibitory synapses
@@ -1038,9 +1035,6 @@ class Network(object):
         elif isinstance(target_gids, list) and all(isinstance(t_gid, int)
                                                    for t_gid in target_gids):
             target_gids = [target_gids for _ in range(len(src_gids))]
-        # else:
-        #     raise TypeError('target_gids must contain an int for every' 
-        #                     'element when specified as a list.')
 
         # Validate each target list - src pairs.
         # set() used to avoid redundant checks.

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1133,11 +1133,11 @@ class _Connectivity(dict):
     Attributes
     ----------
     src_type : str
-        Cell type of src gids.
+        Cell type of source gids.
     target_type : str
         Cell type of target gids.
     num_srcs : int
-        Number of unique src gids.
+        Number of unique source gids.
     num_targets : int
         Number of unique target gids.
     loc : str
@@ -1161,7 +1161,7 @@ class _Connectivity(dict):
 
     def __repr__(self):
         entr = f"{self['src_type']} -> {self['target_type']}"
-        entr += f"\nCell counts: {self['num_srcs']} srcs; "
+        entr += f"\ncell counts: {self['num_srcs']} srcs, "
         entr += f"{self['num_targets']} targets"
         entr += f"\nloc: '{self['loc']}'; receptor: '{self['receptor']}'"
         entr += f"\nweight: {self['nc_dict']['A_weight']}; "

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -976,12 +976,12 @@ class Network(object):
         Parameters
         ----------
         src_gids : str | int | range | list of int
-            Identifier for src cells. Passing str arguments
+            Identifier for source cells. Passing str arguments
             ('L2_pyramidal', 'L2_basket', 'L5_pyramidal', 'L5_basket') is
             equivalent to passing a list of gids for the relvant cell type.
             src-target connections depend on the input type of target_gids.
         target_gids : str | int | range | list of int | list of list of int
-            Identifer for targets of src cell. Passing str arguments
+            Identifer for targets of source cells. Passing str arguments
             ('L2_pyramidal', 'L2_basket', 'L5_pyramidal', 'L5_basket') is
             equivalent to passing a list of gids for the relvant cell type.
             Inputs of type (str, int, range, and list of int) connect every

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1008,7 +1008,7 @@ class Network(object):
             List of connected gids with the format:
             [[src_gid, [target_gids, ...]], ...]
         """
-        conn = dict()
+        conn = _Connectivity()
         threshold = self.threshold
         _validate_type(src_gids, (int, list, range, str), 'src_gids',
                        'int list, range, or str')
@@ -1056,6 +1056,7 @@ class Network(object):
                 raise AssertionError(
                     'All target_gids must be of the same type')
         conn['target_type'] = target_type
+        conn['num_targets'] = len(target_set)
 
         if len(target_gids) != len(src_gids):
             raise AssertionError('target_gids must have a list for each src.')
@@ -1073,6 +1074,7 @@ class Network(object):
                 raise AssertionError('All src_gids must be of the same type')
             gid_pairs[src_gid] = target_src_pair
         conn['src_type'] = src_type
+        conn['num_srcs'] = len(src_gids)
 
         conn['gid_pairs'] = gid_pairs
 
@@ -1120,6 +1122,54 @@ class Network(object):
             The matplotlib figure handle.
         """
         return plot_cells(net=self, ax=ax, show=show)
+
+
+class _Connectivity(dict):
+    """A class for containing the connectivity details of the network
+
+    Class instances are essentially dictionaries, with the keys described below
+    as 'attributes'.
+
+    Attributes
+    ----------
+    src_type : str
+        Cell type of src gids.
+    target_type : str
+        Cell type of target gids.
+    num_srcs : int
+        Number of unique src gids.
+    num_targets : int
+        Number of unique target gids.
+    loc : str
+        Location of synapse on target cell. Must be
+        'proximal', 'distal', or 'soma'. Note that inhibitory synapses
+        (receptor='gabaa' or 'gabab') of L2 pyramidal neurons are only
+        valid loc='soma'.
+    receptor : str
+        Synaptic receptor of connection. Must be one of:
+        'ampa', 'nmda', 'gabaa', or 'gabab'.
+    nc_dict : dict
+        Dictionary containing details of synaptic connection.
+        Elements include:
+        A_weight : float
+            Synaptic weight on target cell.
+        A_delay : float
+            Synaptic delay in ms.
+        lamtha : float
+            Space constant.
+    """
+
+    def __repr__(self):
+        entr = f"{self['src_type']} -> {self['target_type']}"
+        entr += f"\nCell counts: {self['num_srcs']} srcs; "
+        entr += f"{self['num_targets']} targets"
+        entr += f"\nloc: '{self['loc']}'; receptor: '{self['receptor']}'"
+        entr += f"\nweight: {self['nc_dict']['A_weight']}; "
+        entr += f"delay: {self['nc_dict']['A_delay']}; "
+        entr += f"lamtha: {self['nc_dict']['lamtha']}"
+        entr += "\n "
+
+        return entr
 
 
 class _NetworkDrive(dict):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1044,22 +1044,35 @@ class Network(object):
                            'list or range')
             for target_gid in target_src_pair:
                 target_set.add(target_gid)
+        target_type = self.gid_to_type(target_gids[0][0])
         for target_gid in target_set:
             _validate_type(target_gid, int, 'target_gid', 'int')
             # Ensure gids in range of Network.gid_ranges
-            assert np.sum([target_gid in gid_range for
-                           gid_range in self.gid_ranges.values()]) == 1
+            gid_type = self.gid_to_type(target_gid)
+            if gid_type is None:
+                raise AssertionError(
+                    f'target_gid {target_gid}''not in net.gid_ranges')
+            elif gid_type != target_type:
+                raise AssertionError(
+                    'All target_gids must be of the same type')
+        conn['target_type'] = target_type
 
         if len(target_gids) != len(src_gids):
             raise AssertionError('target_gids must have a list for each src.')
 
         # Format gid_pairs and add to conn dictionary
         gid_pairs = list()
+        src_type = self.gid_to_type(src_gids[0])
         for src_gid, target_src_pair in zip(src_gids, target_gids):
             _validate_type(src_gid, int, 'src_gid', 'int')
-            assert np.sum([src_gid in gid_range for
-                           gid_range in self.gid_ranges.values()]) == 1
+            gid_type = self.gid_to_type(src_gid)
+            if gid_type is None:
+                raise AssertionError(
+                    f'src_gid {src_gid} not in net.gid_ranges')
+            elif gid_type != src_type:
+                raise AssertionError('All src_gids must be of the same type')
             gid_pairs.append([src_gid, target_src_pair])
+        conn['src_type'] = src_type
 
         conn['gid_pairs'] = gid_pairs
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -950,26 +950,26 @@ class Network(object):
         target_gids = self.gid_ranges[_long_name(target_cell)]
 
         src_start = src_gids[0]  # Necessary for unique feeds
-        connections = []
+        gid_pairs = []
         for target_gid in target_gids:
             if unique:
                 src_gids = [target_gid + src_start]
             for src_gid in src_gids:
                 if not allow_autapses and src_gid == target_gid:
                     continue
-                connections.append((src_gid, target_gid))
+                gid_pairs.append((src_gid, target_gid))
 
         self.add_connection(
-            connections, loc, receptor,
+            gid_pairs, loc, receptor,
             nc_dict['A_weight'], nc_dict['A_delay'], nc_dict['lamtha'])
 
-    def add_connection(self, connections, loc, receptor,
+    def add_connection(self, gid_pairs, loc, receptor,
                        weight, delay, lamtha):
         """Appends connections to connectivity list
 
         Parameters
         ----------
-        connections : list of tuple | list of list
+        gid_pairs : list of tuple | list of list
             List of connected gids with the format:
             [(src_gid, target_gid), ...]
         loc : str
@@ -988,18 +988,24 @@ class Network(object):
             Space constant.
         """
         conn = dict()
+        # gid_types = list()
         threshold = self.threshold
-        for src_gid, target_gid in connections:
+        for src_gid, target_gid in gid_pairs:
             _validate_type(src_gid, int, 'src_gid', 'int')
             _validate_type(target_gid, (list, range, int), 'target_gid',
                            'list, range or int')
-     
+
             # Ensure gids in range of Network.gid_ranges
             assert np.sum([src_gid in gid_range for
                            gid_range in self.gid_ranges.values()]) == 1
             assert np.sum([target_gid in gid_range for
                            gid_range in self.gid_ranges.values()]) == 1
-        conn['connections'] = connections
+
+            # gid_types.append((self.gid_to_type(src_gid),
+            #                 self.gid_to_type(target_gid))
+
+        conn['gid_pairs'] = gid_pairs
+        # conn['gid_types'] = gid_types
 
         # Ensure string inputs
         _validate_type(loc, str, 'loc')
@@ -1022,7 +1028,7 @@ class Network(object):
             _validate_type(item, (int, float), arg_name, 'int or float')
             conn['nc_dict'][key] = item
 
-            self.connectivity.append(deepcopy(conn))
+        self.connectivity.append(deepcopy(conn))
 
     def clear_connectivity(self):
         """Remove all connections defined in Network.connectivity_list"""

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -952,8 +952,7 @@ class Network(object):
         src_start = src_gids[0]  # Necessary for unique feeds
 
         if unique:
-            src_gids = np.array(target_range) + src_start
-            src_gids = src_gids.astype(int).tolist()
+            src_gids = [src_gid + src_start for src_gid in target_range]
             target_gids = [[target_gid] for target_gid in target_range]
         else:
             target_gids = list()

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -988,12 +988,15 @@ class Network(object):
             Space constant.
         """
         conn = dict()
-        # gid_types = list()
         threshold = self.threshold
-        for src_gid, target_gid in gid_pairs:
+        _validate_type(gid_pairs, list, 'gid_pairs', 'list')
+        for gid_pair in gid_pairs:
+            _validate_type(gid_pair, (list, tuple), 'gid_pairs',
+                           'list or tuple')
+            assert len(gid_pair) == 2
+            src_gid, target_gid = gid_pair
             _validate_type(src_gid, int, 'src_gid', 'int')
-            _validate_type(target_gid, (list, range, int), 'target_gid',
-                           'list, range or int')
+            _validate_type(target_gid, int, 'target_gid', 'int')
 
             # Ensure gids in range of Network.gid_ranges
             assert np.sum([src_gid in gid_range for
@@ -1001,11 +1004,7 @@ class Network(object):
             assert np.sum([target_gid in gid_range for
                            gid_range in self.gid_ranges.values()]) == 1
 
-            # gid_types.append((self.gid_to_type(src_gid),
-            #                 self.gid_to_type(target_gid))
-
         conn['gid_pairs'] = gid_pairs
-        # conn['gid_types'] = gid_types
 
         # Ensure string inputs
         _validate_type(loc, str, 'loc')

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -421,19 +421,10 @@ class NetworkBuilder(object):
         connectivity = self.net.connectivity
 
         assert len(self.cells) == len(self._gid_list) - len(self._drive_cells)
-        # Gather indeces of targets on current node
-        # connectivity = [conn for conn in connectivity if
-        #                 _PC.gid_exists(conn['target_gid'])]
-        # target_gids = [conn['target_gid'] for conn in connectivity]
-        # target_filter = {}
-        # for idx in range(len(self.cells)):
-        #     gid = self._gid_list[idx]
-        #     if gid in target_gids:
-        #         target_filter[gid] = idx
 
         for conn in connectivity:
             # Gather indeces of targets on current node
-            connections = [gid_pair for gid_pair in conn if
+            connections = [gid_pair for gid_pair in conn['gid_pairs'] if
                            _PC.gid_exists(gid_pair[1])]
             target_gids = [gid_pair[1] for gid_pair in connections]
             target_filter = dict()

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -428,13 +428,13 @@ class NetworkBuilder(object):
             nc_dict = deepcopy(conn['nc_dict'])
             # Gather indeces of targets on current node
             valid_targets = set()
-            for idx, (src_gid, target_gids) in enumerate(conn['gid_pairs']):
+            for src_gid, target_gids in conn['gid_pairs'].items():
                 filtered_targets = list()
                 for target_gid in target_gids:
                     if _PC.gid_exists(target_gid):
                         filtered_targets.append(target_gid)
                         valid_targets.add(target_gid)
-                conn['gid_pairs'][idx] = [src_gid, filtered_targets]
+                conn['gid_pairs'][src_gid] = filtered_targets
 
             target_filter = dict()
             for idx in range(len(self.cells)):
@@ -443,7 +443,7 @@ class NetworkBuilder(object):
                     target_filter[gid] = idx
 
             # Iterate over src/target pairs and connect cells
-            for src_gid, target_gids in conn['gid_pairs']:
+            for src_gid, target_gids in conn['gid_pairs'].items():
                 for target_gid in target_gids:
                     src_type = self.net.gid_to_type(src_gid)
                     target_type = self.net.gid_to_type(target_gid)

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -425,7 +425,7 @@ class NetworkBuilder(object):
 
         for conn in connectivity:
             loc, receptor = conn['loc'], conn['receptor']
-            nc_dict = conn['nc_dict']
+            nc_dict = deepcopy(conn['nc_dict'])
             # Gather indeces of targets on current node
             valid_targets = set()
             for idx, (src_gid, target_gids) in enumerate(conn['gid_pairs']):

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -467,7 +467,7 @@ class NetworkBuilder(object):
 
                     for syn_key in syn_keys:
                         nc = target_cell.parconnect_from_src(
-                            src_gid, deepcopy(nc_dict), 
+                            src_gid, deepcopy(nc_dict),
                             target_cell.synapses[syn_key])
                         self.ncs[connection_name].append(nc)
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -3,7 +3,6 @@
 from copy import deepcopy
 import os.path as op
 from numpy.testing import assert_allclose
-import numpy as np
 import pytest
 
 import hnn_core

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -165,7 +165,7 @@ def test_network():
     # Test inputs for connectivity API
     net = Network(deepcopy(params), add_drives_from_params=True)
     n_conn = len(network_builder.ncs['L2Basket_L2Pyr_gabaa'])
-    kwargs_default = dict(src_gid=0, target_gid=35,
+    kwargs_default = dict(gid_pairs=[(0, 35)],
                           loc='soma', receptor='gabaa',
                           weight=5e-4, delay=1.0, lamtha=3.0)
     net.add_connection(**kwargs_default)  # smoke test
@@ -175,28 +175,28 @@ def test_network():
     assert nc.weight[0] == kwargs_default['weight']
 
     kwargs = kwargs_default.copy()
-    kwargs['target_gid'] = [35, 36]
+    kwargs['gid_pairs'] = [(35, 36)]
     net.add_connection(**kwargs)
 
-    kwargs_bad = dict(src_gid=1.0, target_gid=1.0, loc=1.0, receptor=1.0,
-                      weight='1.0', delay='1.0', lamtha='1.0')
-    for arg in kwargs_bad.keys():
-        match = (f'{arg} must be an instance of')
+    kwargs_bad = [
+        ('gid_pairs', 0), ('gid_pairs', [(0.0, 35)]),
+        ('gid_pairs', [(0, 35.0)]), ('gid_pairs', [0, 35]), ('loc', 1.0),
+        ('receptor', 1.0), ('weight', '1.0'), ('delay', '1.0'),
+        ('lamtha', '1.0')]
+    for arg, item in kwargs_bad:
+        match = ('must be an instance of')
         with pytest.raises(TypeError, match=match):
             kwargs = kwargs_default.copy()
-            kwargs[arg] = kwargs_bad[arg]
+            kwargs[arg] = item
             net.add_connection(**kwargs)
 
-    match = 'target_gid must be an instance of'
-    with pytest.raises(TypeError, match=match):
-        kwargs = kwargs_default.copy()
-        kwargs['target_gid'] = [35, '36']
-        net.add_connection(**kwargs)
-
-    for arg in ['src_gid', 'target_gid']:
+    kwargs_bad = [
+        ('gid_pairs', [(-1, 0)]), ('gid_pairs', [(0, -1)]),
+        ('gid_pairs', [(0, 35, 36)])]
+    for arg, item in kwargs_bad:
         with pytest.raises(AssertionError):
             kwargs = kwargs_default.copy()
-            kwargs[arg] = -1
+            kwargs[arg] = item
             net.add_connection(**kwargs)
 
     for arg in ['loc', 'receptor']:

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -195,7 +195,6 @@ def test_network():
         with pytest.raises(TypeError, match=match):
             kwargs = kwargs_default.copy()
             kwargs[arg] = item
-            print(item)
             net.add_connection(**kwargs)
 
     kwargs_bad = [

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -165,7 +165,7 @@ def test_network():
     # Test inputs for connectivity API
     net = Network(deepcopy(params), add_drives_from_params=True)
     n_conn = len(network_builder.ncs['L2Basket_L2Pyr_gabaa'])
-    kwargs_default = dict(gid_pairs=[(0, 35)],
+    kwargs_default = dict(gid_pairs=[[0, [35]]],
                           loc='soma', receptor='gabaa',
                           weight=5e-4, delay=1.0, lamtha=3.0)
     net.add_connection(**kwargs_default)  # smoke test
@@ -175,12 +175,12 @@ def test_network():
     assert nc.weight[0] == kwargs_default['weight']
 
     kwargs = kwargs_default.copy()
-    kwargs['gid_pairs'] = [(35, 36)]
+    kwargs['gid_pairs'] = [[35, [36]]]
     net.add_connection(**kwargs)
 
     kwargs_bad = [
-        ('gid_pairs', 0), ('gid_pairs', [(0.0, 35)]),
-        ('gid_pairs', [(0, 35.0)]), ('gid_pairs', [0, 35]), ('loc', 1.0),
+        ('gid_pairs', 0), ('gid_pairs', [[0.0, [35]]]),
+        ('gid_pairs', [[0, [35.0]]]), ('gid_pairs', [0, 35]), ('loc', 1.0),
         ('receptor', 1.0), ('weight', '1.0'), ('delay', '1.0'),
         ('lamtha', '1.0')]
     for arg, item in kwargs_bad:
@@ -191,8 +191,8 @@ def test_network():
             net.add_connection(**kwargs)
 
     kwargs_bad = [
-        ('gid_pairs', [(-1, 0)]), ('gid_pairs', [(0, -1)]),
-        ('gid_pairs', [(0, 35, 36)])]
+        ('gid_pairs', [[-1, [0]]]), ('gid_pairs', [[0, [-1]]]),
+        ('gid_pairs', [[0, 35, 36]])]
     for arg, item in kwargs_bad:
         with pytest.raises(AssertionError):
             kwargs = kwargs_default.copy()

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -201,7 +201,8 @@ def test_network():
     kwargs_bad = [
         ('src_gids', -1), ('src_gids', [-1]),
         ('target_gids', -1), ('target_gids', [-1]),
-        ('target_gids', [[35], [-1]]), ('target_gids', [[35]])]
+        ('target_gids', [[35], [-1]]), ('target_gids', [[35]]),
+        ('src_gids', [0, 100]), ('target_gids', [0, 100])]
     for arg, item in kwargs_bad:
         with pytest.raises(AssertionError):
             kwargs = kwargs_default.copy()


### PR DESCRIPTION
Closes #298. The current change reduces the size of `net.connectivity` (default network) from 55 MB to 10 MB. I think this could be further reduced by changing how src-target pairs are enumerated. Specifically:
```py
{'gid_pairs': (src_gid1, [target_gid1, target_gid2, ...]), (src_gid2, [target_gid1, target_gid2, ...]), ...}
```
Also I think this will be a good opportunity to discuss better high level API's. For sparse connectivity, I think the simplest implementation would be adding a probability argument to `net.add_connection()` that defaults to 1.0, and randomly removes connections passed via `gid_pairs`. 

The previous API allowed for passing a single `src_gid`, and a list of `target_gids`. I can certainly restore that ability with helper function, but my feeling is it won't be that useful in the grander scheme of high level functions. 