### PR TITLE
[MRG] Add functions to modify and visualize connectivity

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -15,6 +15,7 @@ Simulation (:py:mod:`hnn_core`):
    :toctree: generated/
 
    simulate_dipole
+   default_network
    Network
    Cell
    CellResponse

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,8 @@ Changelog
 
 - Store :class:`~hnn_core.Cell` instances in :class:`~hnn_core.Network`'s :attr:`~/hnn_core.Network.cells` attribute by `Ryan Thorpe`_ in `#321 <https://github.com/jonescompneurolab/hnn-core/pull/321>`_
 
+- Add probability argument to :func:`~hnn_core.Network.add_connection`. Connectivity patterns can also be visualized with :func:`~hnn_core.viz.plot_connectivity_matrix`, by `Nick Tolley`_ in `#318 <https://github.com/jonescompneurolab/hnn-core/pull/318>`_
+
 Bug
 ~~~
 
@@ -36,6 +38,8 @@ API
 
 - New API for accessing and modifying :class:`~hnn_core.Cell` attributes (e.g., synapse and biophysics parameters) as cells are now instantiated from template cells specified
   in a :class:`~hnn_core.Network` instance's :attr:`~/hnn_core.Network.cell_types` attribute by `Ryan Thorpe`_ in `#321 <https://github.com/jonescompneurolab/hnn-core/pull/321>`_
+
+- New API for network creation. The default network is now created with ``net = default_network(params)``, by `Nick Tolley`_ in `#318 <https://github.com/jonescompneurolab/hnn-core/pull/318>`_
 
 .. _0.1:
 

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -114,6 +114,7 @@ for target in ['L5_pyramidal', 'L2_basket']:
 
 dpl_sparse = simulate_dipole(net_sparse, n_trials=1)
 net_sparse.cell_response.plot_spikes_raster()
+
 net_sparse.connectivity[-2].plot()
 net_sparse.connectivity[-1].plot()
 

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -45,8 +45,8 @@ print(net_erp.connectivity[0:2])
 
 ###############################################################################
 # Data recorded during simulations are stored under
-# :class:`~hnn_core.Cell_Response`. To test multiple network structures, we can
-# create a copy of the original network. The copied network is then simulated.
+# :class:`~hnn_core.Cell_Response`. Spiking activity can be visualized after
+# a simulation is using :meth:`~hnn_core.Cell_Response.plot_spikes_raster`
 dpl_erp = simulate_dipole(net_erp, n_trials=1)
 net_erp.cell_response.plot_spikes_raster()
 

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -52,8 +52,9 @@ net_erp.cell_response.plot_spikes_raster()
 # We can modify the connectivity list to test the effect of different
 # connectivity patterns. For example, we can remove 90% all layer 2 inhibitory
 # connections.
-# This can be achieved with :meth:`hnn_core._Connectivity.update_probability`,
-# a function that is available for each element of ``net.connectivity``.
+# This can be achieved with ``net.connectivity[idx].drop``, a function that is
+# available for each element of ``net.connectivity``. We can also visualize
+# any connection using ``net.connectivity.plot``.
 # Note that in the default network, the src_gids of each connection are
 # all the same cell type allowing for easy modifications.
 for conn in net.connectivity:
@@ -63,6 +64,7 @@ for conn in net.connectivity:
 net_remove = net.copy()
 dpl_remove = simulate_dipole(net_remove, n_trials=1)
 net_remove.cell_response.plot_spikes_raster()
+net.connectivity[10].plot()
 
 ###############################################################################
 # That's a lot of spiking! Since basket cells are inhibitory, removing these
@@ -85,6 +87,7 @@ net.add_connection(src_gid, target_gids, location, receptor,
 net_add = net.copy()
 dpl_add = simulate_dipole(net_add, n_trials=1)
 net_add.cell_response.plot_spikes_raster()
+net.connectivity[-1].plot()
 
 ###############################################################################
 # Adding a single inhibitory connection didn't completely restored the normal

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -8,6 +8,9 @@ This example demonstrates how to modify the network connectivity.
 
 # Author: Nick Tolley <nicholas_tolley@brown.edu>
 
+# sphinx_gallery_thumbnail_number = 4
+
+from hnn_core.network import Network
 import os.path as op
 
 ###############################################################################
@@ -30,64 +33,85 @@ params = read_params(params_fname)
 # explore how it changes with new connections. We first instantiate the
 # network. (Note: Setting ``add_drives_from_params=True`` loads a set of
 # predefined drives without the drives API shown previously).
-net = default_network(params, add_drives_from_params=True)
+net_erp = default_network(params, add_drives_from_params=True)
 
 ###############################################################################
 # Instantiating the network comes with a predefined set of connections that
 # reflect the canonical neocortical microcircuit. ``net.connectivity``
 # is a list of dictionaries which detail every cell-cell, and drive-cell
 # connection.
-print(len(net.connectivity))
-print(net.connectivity[0:2])
+print(len(net_erp.connectivity))
+print(net_erp.connectivity[0:2])
 
 ###############################################################################
 # Data recorded during simulations are stored under
 # :class:`~hnn_core.Cell_Response`. To test multiple network structures, we can
 # create a copy of the original network. The copied network is then simulated.
-net_erp = net.copy()
 dpl_erp = simulate_dipole(net_erp, n_trials=1)
 net_erp.cell_response.plot_spikes_raster()
 
 ###############################################################################
-# We can modify the connectivity list to test the effect of different
-# connectivity patterns. For example, we can remove 90% all layer 2 inhibitory
-# connections.
-# This can be achieved with ``net.connectivity[idx].drop``, a function that is
-# available for each element of ``net.connectivity``. We can also visualize
-# any connection using ``net.connectivity.plot``.
-# Note that in the default network, the src_gids of each connection are
-# all the same cell type allowing for easy modifications.
-for conn in net.connectivity:
-    if conn['src_type'] == 'L2_basket':
-        conn.drop(0.1)
-
-net_remove = net.copy()
-dpl_remove = simulate_dipole(net_remove, n_trials=1)
-net_remove.cell_response.plot_spikes_raster()
-net.connectivity[10].plot()
-
-###############################################################################
-# That's a lot of spiking! Since basket cells are inhibitory, removing these
-# connections increases network wide excitability. We can additionally add
-# new connections using ``net.add_connection()``. Let's try connecting a
-# single layer 2 basket cell, to every layer 2 pyramidal cell. We can utilize
-# ``net.gid_ranges`` to help find the gids of interest.
+# We can also define our own connections to test the effect of different
+# connectivity patterns. To start, an empty network is instantiated.
+# ``add_drives_from_params`` can still be used with an empty Network, but
+# all cells will start disconnected. ``net.add_connection`` is then
+# used to create a custom network. Let us first create an all-to-all
+# connectivity pattern between the L5 pyramidal cells, and L2 basket cells.
 # :meth:`hnn_core.Network.add_connection` allows connections to be specified
 # with either cell names, or the gids directly. If multiple gids are provided
 # for either the sources or the targets, they will be connected in an
 # all-to-all pattern.
-print(net.gid_ranges)
-src_gid = net.gid_ranges['L2_basket'][0]
-target_gids = 'L2_pyramidal'
+
+net_all = Network(params, add_drives_from_params=True)
+
+# Pyramidal cell connections
+location, receptor = 'distal', 'ampa'
+weight, delay, lamtha = 1.0, 1.0, 70
+src = 'L5_pyramidal'
+for target in ['L5_pyramidal', 'L5_pyramidal']:
+    net_all.add_connection(src, target, location, receptor,
+                           delay, weight, lamtha)
+
+# Basket cell connections
 location, receptor = 'soma', 'gabaa'
 weight, delay, lamtha = 1.0, 1.0, 70
-net.add_connection(src_gid, target_gids, location, receptor,
-                   delay, weight, lamtha)
+src = 'L2_basket'
+for target in ['L2_basket', 'L5_pyramidal']:
+    net_all.add_connection(src, target, location, receptor,
+                           delay, weight, lamtha)
 
-net_add = net.copy()
-dpl_add = simulate_dipole(net_add, n_trials=1)
-net_add.cell_response.plot_spikes_raster()
-net.connectivity[-1].plot()
+dpl_all = simulate_dipole(net_all, n_trials=1)
+net_all.cell_response.plot_spikes_raster()
+
+###############################################################################
+# That's a lot of spiking! We can additionally use the ``probability``.
+# argument to create a sparse connectivity pattern instead of all-to-all. Let's
+# try creating the same network with a 10% change of cells connecting
+# to each other. The resulting connectivity pattern can also be visualized
+# with ``net.connectivity[idx].plot()``
+probability = 0.1
+net_sparse = Network(params, add_drives_from_params=True)
+
+# Pyramidal cell connections
+location, receptor = 'distal', 'ampa'
+weight, delay, lamtha = 1.0, 1.0, 70
+src = 'L5_pyramidal'
+for target in ['L5_pyramidal', 'L2_basket']:
+    net_sparse.add_connection(src, target, location, receptor,
+                              delay, weight, lamtha, probability)
+
+# Basket cell connections
+location, receptor = 'soma', 'gabaa'
+weight, delay, lamtha = 1.0, 1.0, 70
+src = 'L2_basket'
+for target in ['L2_basket', 'L5_pyramidal']:
+    net_sparse.add_connection(src, target, location, receptor,
+                              delay, weight, lamtha, probability)
+
+dpl_sparse = simulate_dipole(net_sparse, n_trials=1)
+net_sparse.cell_response.plot_spikes_raster()
+net_sparse.connectivity[-2].plot()
+net_sparse.connectivity[-1].plot()
 
 ###############################################################################
 # Adding a single inhibitory connection didn't completely restored the normal
@@ -98,8 +122,8 @@ import matplotlib.pyplot as plt
 from hnn_core.viz import plot_dipole
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6),
                          constrained_layout=True)
-dpls = [dpl_erp[0], dpl_remove[0], dpl_add[0]]
+dpls = [dpl_erp[0], dpl_all[0], dpl_sparse[0]]
 plot_dipole(dpls, ax=axes[0], layer='agg', show=False)
-axes[0].legend(['Normal', 'No L2 Basket', 'Single L2 Basket'])
+axes[0].legend(['Default', 'Custom All', 'Custom Sparse'])
 net_erp.cell_response.plot_spikes_hist(
     ax=axes[1], spike_types=['evprox', 'evdist'])

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -53,7 +53,7 @@ net_erp.cell_response.plot_spikes_raster()
 # connectivity patterns. For example, we can remove 90% all layer 2 inhibitory
 # connections.
 # This can be achieved with :meth:`hnn_core._Connectivity.update_probability`,
-# a function that is available for each element of `net.connectivity`.
+# a function that is available for each element of ``net.connectivity``.
 # Note that in the default network, the src_gids of each connection are
 # all the same cell type allowing for easy modifications.
 for conn in net.connectivity:
@@ -87,9 +87,10 @@ dpl_add = simulate_dipole(net_add, n_trials=1)
 net_add.cell_response.plot_spikes_raster()
 
 ###############################################################################
-# Adding a single inhibitory connection almost completely restored the normal
-# spiking. As a final step, we can see how this change in spiking
-# activity impacts the aggregate current dipole.
+# Adding a single inhibitory connection didn't completely restored the normal
+# spiking. However, layer 2 firing is interrupted at 70 and 120 ms.
+# As a final step, we can see how this change in spiking activity impacts
+# the aggregate current dipole.
 import matplotlib.pyplot as plt
 from hnn_core.viz import plot_dipole
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6),

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -50,15 +50,15 @@ net_erp.cell_response.plot_spikes_raster()
 
 ###############################################################################
 # We can modify the connectivity list to test the effect of different
-# connectivity patterns. For example, we can remove all layer 2 inhibitory
-# connections. In the default network, the src_gids of each connection are
-# all the same cell type.. Connections are stored under ``conn['gid_pairs']``
-# as a dictionary indexed by src_gid:
-# ``{src_gid1: [target_gid1, target_gid2], ...]``. Each src_gid indexes a
-# list with its target gids
-new_connectivity = [conn for conn in net.connectivity
-                    if conn['src_type'] != 'L2_basket']
-net.connectivity = new_connectivity
+# connectivity patterns. For example, we can remove 90% all layer 2 inhibitory
+# connections.
+# This can be achieved with :meth:`hnn_core._Connectivity.update_probability`,
+# a function that is available for each element of `net.connectivity`.
+# Note that in the default network, the src_gids of each connection are
+# all the same cell type allowing for easy modifications.
+for conn in net.connectivity:
+    if conn['src_type'] == 'L2_basket':
+        conn.update_probability(0.1)
 
 net_remove = net.copy()
 dpl_remove = simulate_dipole(net_remove, n_trials=1)
@@ -87,9 +87,8 @@ dpl_add = simulate_dipole(net_add, n_trials=1)
 net_add.cell_response.plot_spikes_raster()
 
 ###############################################################################
-# Adding more inhibitory connections did not completely restore the normal
-# spiking. L2 basket and pyramidal cells rhythymically fire in the gamma
-# range (30-80 Hz). As a final step, we can see how this change in spiking
+# Adding a single inhibitory connection almost completely restored the normal
+# spiking. As a final step, we can see how this change in spiking
 # activity impacts the aggregate current dipole.
 import matplotlib.pyplot as plt
 from hnn_core.viz import plot_dipole

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -10,7 +10,6 @@ This example demonstrates how to modify the network connectivity.
 
 # sphinx_gallery_thumbnail_number = 5
 
-from hnn_core.network import Network
 import os.path as op
 
 ###############################################################################

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -14,7 +14,7 @@ import os.path as op
 # Let us import ``hnn_core``.
 
 import hnn_core
-from hnn_core import read_params, Network, simulate_dipole
+from hnn_core import read_params, default_network, simulate_dipole
 
 hnn_core_root = op.dirname(hnn_core.__file__)
 
@@ -30,7 +30,7 @@ params = read_params(params_fname)
 # explore how it changes with new connections. We first instantiate the
 # network. (Note: Setting ``add_drives_from_params=True`` loads a set of
 # predefined drives without the drives API shown previously).
-net = Network(params, add_drives_from_params=True)
+net = default_network(params, add_drives_from_params=True)
 
 ###############################################################################
 # Instantiating the network comes with a predefined set of connections that

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -114,8 +114,10 @@ net_sparse.connectivity[-2].plot()
 net_sparse.connectivity[-1].plot()
 
 ###############################################################################
-# Adding a single inhibitory connection didn't completely restored the normal
-# spiking. However, layer 2 firing is interrupted at 70 and 120 ms.
+# Using the sparse connectivity pattern led produced a lot more spiking in
+# the L5 pyramidal cells. While there are less excitatory connections overall,
+# there was also a decrease in the inhibtory connections. This shift in
+# activity is often referred to as the excitatory/inhibitory (E/I) balance. 
 # As a final step, we can see how this change in spiking activity impacts
 # the aggregate current dipole.
 import matplotlib.pyplot as plt

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -52,17 +52,18 @@ net_erp.cell_response.plot_spikes_raster()
 
 ###############################################################################
 # We can also define our own connections to test the effect of different
-# connectivity patterns. To start, an empty network is instantiated.
-# ``add_drives_from_params`` can still be used with an empty Network, but
-# all cells will start disconnected. ``net.add_connection`` is then
-# used to create a custom network. Let us first create an all-to-all
-# connectivity pattern between the L5 pyramidal cells, and L2 basket cells.
-# :meth:`hnn_core.Network.add_connection` allows connections to be specified
-# with either cell names, or the gids directly. If multiple gids are provided
-# for either the sources or the targets, they will be connected in an
-# all-to-all pattern.
+# connectivity patterns. To start, ``net.clear_connectivity()`` can be used
+# to clear all cell to cell connections. By default, previously defined drives
+# to the network are retained, but can be removed with ``net.clear_drives()``.
+# ``net.add_connection`` is then used to create a custom network. Let us first
+# create an all-to-all connectivity pattern between the L5 pyramidal cells,
+# and L2 basket cells. :meth:`hnn_core.Network.add_connection` allows
+# connections to be specified with either cell names, or the gids directly.
+# If multiple gids are provided for either the sources or the targets,
+# they will be connected in an all-to-all pattern.
 
-net_all = Network(params, add_drives_from_params=True)
+net_all = default_network(params, add_drives_from_params=True)
+net_all.clear_connectivity()
 
 # Pyramidal cell connections
 location, receptor = 'distal', 'ampa'
@@ -93,7 +94,8 @@ net_all.cell_response.plot_spikes_raster()
 # connectivity pattern can also be visualized with
 # ``net.connectivity[idx].plot()``
 probability = 0.1
-net_sparse = Network(params, add_drives_from_params=True)
+net_sparse = default_network(params, add_drives_from_params=True)
+net_sparse.clear_connectivity()
 
 # Pyramidal cell connections
 location, receptor = 'distal', 'ampa'

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -58,7 +58,7 @@ net_erp.cell_response.plot_spikes_raster()
 # all the same cell type allowing for easy modifications.
 for conn in net.connectivity:
     if conn['src_type'] == 'L2_basket':
-        conn.update_probability(0.1)
+        conn.drop(0.1)
 
 net_remove = net.copy()
 dpl_remove = simulate_dipole(net_remove, n_trials=1)

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -117,7 +117,7 @@ net_sparse.connectivity[-1].plot()
 # Using the sparse connectivity pattern led produced a lot more spiking in
 # the L5 pyramidal cells. While there are less excitatory connections overall,
 # there was also a decrease in the inhibtory connections. This shift in
-# activity is often referred to as the excitatory/inhibitory (E/I) balance. 
+# activity is often referred to as the excitatory/inhibitory (E/I) balance.
 # As a final step, we can see how this change in spiking activity impacts
 # the aggregate current dipole.
 import matplotlib.pyplot as plt

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -1,6 +1,6 @@
 """
 =====================
-07. Plot Connectivity
+06. Plot Connectivity
 =====================
 
 This example demonstrates how to modify the network connectivity.
@@ -8,7 +8,7 @@ This example demonstrates how to modify the network connectivity.
 
 # Author: Nick Tolley <nicholas_tolley@brown.edu>
 
-# sphinx_gallery_thumbnail_number = 4
+# sphinx_gallery_thumbnail_number = 5
 
 from hnn_core.network import Network
 import os.path as op
@@ -68,7 +68,7 @@ net_all = Network(params, add_drives_from_params=True)
 location, receptor = 'distal', 'ampa'
 weight, delay, lamtha = 1.0, 1.0, 70
 src = 'L5_pyramidal'
-for target in ['L5_pyramidal', 'L5_pyramidal']:
+for target in ['L5_pyramidal', 'L2_basket']:
     net_all.add_connection(src, target, location, receptor,
                            delay, weight, lamtha)
 
@@ -76,7 +76,7 @@ for target in ['L5_pyramidal', 'L5_pyramidal']:
 location, receptor = 'soma', 'gabaa'
 weight, delay, lamtha = 1.0, 1.0, 70
 src = 'L2_basket'
-for target in ['L2_basket', 'L5_pyramidal']:
+for target in ['L5_pyramidal', 'L2_basket']:
     net_all.add_connection(src, target, location, receptor,
                            delay, weight, lamtha)
 
@@ -84,11 +84,14 @@ dpl_all = simulate_dipole(net_all, n_trials=1)
 net_all.cell_response.plot_spikes_raster()
 
 ###############################################################################
-# That's a lot of spiking! We can additionally use the ``probability``.
-# argument to create a sparse connectivity pattern instead of all-to-all. Let's
-# try creating the same network with a 10% change of cells connecting
-# to each other. The resulting connectivity pattern can also be visualized
-# with ``net.connectivity[idx].plot()``
+# With the previous connection pattern there appears to be synchronous rhythmic
+# firing of the L5 pyramidal cells with a period of 10 ms. The synchronous
+# activity is visible as vertical lines where several cells fire simultaneously
+# We can additionally use the ``probability``. argument to create a sparse
+# connectivity pattern instead of all-to-all. Let's try creating the same
+# network with a 10% chance of cells connecting to each other. The resulting
+# connectivity pattern can also be visualized with
+# ``net.connectivity[idx].plot()``
 probability = 0.1
 net_sparse = Network(params, add_drives_from_params=True)
 
@@ -104,7 +107,7 @@ for target in ['L5_pyramidal', 'L2_basket']:
 location, receptor = 'soma', 'gabaa'
 weight, delay, lamtha = 1.0, 1.0, 70
 src = 'L2_basket'
-for target in ['L2_basket', 'L5_pyramidal']:
+for target in ['L5_pyramidal', 'L2_basket']:
     net_sparse.add_connection(src, target, location, receptor,
                               delay, weight, lamtha, probability)
 
@@ -114,10 +117,9 @@ net_sparse.connectivity[-2].plot()
 net_sparse.connectivity[-1].plot()
 
 ###############################################################################
-# Using the sparse connectivity pattern led produced a lot more spiking in
-# the L5 pyramidal cells. While there are less excitatory connections overall,
-# there was also a decrease in the inhibtory connections. This shift in
-# activity is often referred to as the excitatory/inhibitory (E/I) balance.
+# Using the sparse connectivity pattern produced a lot more spiking in
+# the L5 pyramidal cells. Nevertheless there appears to be some rhythmicity
+# where the cells are firing synchronously with a smaller period of 4-5 ms.
 # As a final step, we can see how this change in spiking activity impacts
 # the aggregate current dipole.
 import matplotlib.pyplot as plt

--- a/examples/plot_firing_pattern.py
+++ b/examples/plot_firing_pattern.py
@@ -17,7 +17,7 @@ import tempfile
 # Let us import ``hnn_core``.
 
 import hnn_core
-from hnn_core import read_params, read_spikes, Network, simulate_dipole
+from hnn_core import read_params, read_spikes, default_network, simulate_dipole
 
 hnn_core_root = op.dirname(hnn_core.__file__)
 
@@ -31,7 +31,7 @@ params = read_params(params_fname)
 # :ref:`evoked example <sphx_glr_auto_examples_plot_simulate_evoked.py>`.
 import matplotlib.pyplot as plt
 
-net = Network(params)
+net = default_network(params)
 
 ###############################################################################
 # ``net`` does not have any driving inputs and only defines the local network

--- a/examples/plot_simulate_alpha.py
+++ b/examples/plot_simulate_alpha.py
@@ -21,7 +21,7 @@ import os.path as op
 # Let us import hnn_core
 
 import hnn_core
-from hnn_core import simulate_dipole, read_params, Network
+from hnn_core import simulate_dipole, read_params, default_network
 
 ###############################################################################
 # Then we setup the directories and read the default parameters file
@@ -38,7 +38,7 @@ params = read_params(params_fname)
 # time with unique randomization. The drive is only connected to the proximal
 # (dendritic) AMPA synapses on L2/3 and L5 pyramidal neurons.
 params['tstop'] = 310
-net = Network(params)
+net = default_network(params)
 
 location = 'proximal'
 burst_std = 20

--- a/examples/plot_simulate_evoked.py
+++ b/examples/plot_simulate_evoked.py
@@ -22,7 +22,7 @@ import tempfile
 # Let us import hnn_core
 
 import hnn_core
-from hnn_core import simulate_dipole, read_params, Network, read_spikes
+from hnn_core import simulate_dipole, read_params, default_network
 from hnn_core.viz import plot_dipole
 
 hnn_core_root = op.dirname(hnn_core.__file__)
@@ -42,7 +42,7 @@ print(params['L2Pyr_soma*'])
 ###############################################################################
 # Let us first create our network from the params file and visualize the cells
 # inside it.
-net = Network(params)
+net = default_network(params)
 net.plot_cells()
 net.plot_cell_morphology()
 

--- a/examples/plot_simulate_gamma.py
+++ b/examples/plot_simulate_gamma.py
@@ -24,7 +24,7 @@ import os.path as op
 # Let us import hnn_core
 
 import hnn_core
-from hnn_core import simulate_dipole, read_params, Network
+from hnn_core import simulate_dipole, read_params, default_network
 
 hnn_core_root = op.dirname(hnn_core.__file__)
 
@@ -41,7 +41,7 @@ print(params['gbar_L*'])
 # simulate the dipole moment in a single trial (the default value used by
 # ``simulate_dipole`` is ``n_trials=params['N_trials']``).
 
-net = Network(params)
+net = default_network(params)
 
 weights_ampa = {'L2_pyramidal': 0.0008, 'L5_pyramidal': 0.0075}
 synaptic_delays = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.0}

--- a/examples/plot_simulate_mpi_backend.py
+++ b/examples/plot_simulate_mpi_backend.py
@@ -1,6 +1,6 @@
 """
 =======================================
-06. Use MPI backend for parallelization
+07. Use MPI backend for parallelization
 =======================================
 
 This example demonstrates how to use the MPI backend for

--- a/examples/plot_simulate_mpi_backend.py
+++ b/examples/plot_simulate_mpi_backend.py
@@ -21,7 +21,7 @@ without the need to install and configure MPI.
 import os.path as op
 
 import hnn_core
-from hnn_core import simulate_dipole, read_params, Network
+from hnn_core import simulate_dipole, read_params, default_network
 
 ###############################################################################
 # Then we setup the directories and Neuron
@@ -47,7 +47,7 @@ params.update({
 # The occurrence of each burst is jittered by a random, normally distributed
 # amount (20 ms standard deviation). We repeat the burst train 10 times, each
 # time with unique randomization.
-net = Network(params)
+net = default_network(params)
 
 weights_ampa = {'L2_pyramidal': 5.4e-5, 'L5_pyramidal': 5.4e-5}
 net.add_bursty_drive(

--- a/examples/plot_simulate_somato.py
+++ b/examples/plot_simulate_somato.py
@@ -143,15 +143,15 @@ plt.show()
 # network parameters from ``N20.json`` and instantiate the network.
 
 import hnn_core
-from hnn_core import simulate_dipole, read_params, Network, JoblibBackend
-from hnn_core import average_dipoles
+from hnn_core import simulate_dipole, read_params, default_network
+from hnn_core import average_dipoles, JoblibBackend
 
 hnn_core_root = op.dirname(hnn_core.__file__)
 
 params_fname = op.join(hnn_core_root, 'param', 'N20.json')
 params = read_params(params_fname)
 
-net = Network(params)
+net = default_network(params)
 
 ###############################################################################
 # To simulate the source of the median nerve evoked response, we add a

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -1,7 +1,7 @@
 from .dipole import simulate_dipole, read_dipole, average_dipoles
 from .drives import drive_event_times
 from .params import Params, read_params
-from .network import Network
+from .network import Network, default_network
 from .cell import Cell
 from .cell_response import CellResponse, read_spikes
 from .cells_default import pyramidal, basket

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1122,6 +1122,7 @@ class Network(object):
             Defaults to 1.0 producing an all-to-all pattern.
         seed : int
             Seed for the numpy random number generator.
+
         Notes
         -----
         num_srcs and num_targets are not updated after pruning connections.
@@ -1245,7 +1246,7 @@ class _Connectivity(dict):
         Number of unique target gids.
     src_range : range
         Range of gids identified by src_type.
-    target_range : target_range
+    target_range : range
         Range of gids identified by target_type.
     loc : str
         Location of synapse on target cell. Must be
@@ -1270,7 +1271,7 @@ class _Connectivity(dict):
 
     Notes
     -----
-    The len() of src_range or target_range may not match
+    The len() of src_range or target_range will not match
     num_srcs and num_targets for probability < 1.0.
     """
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1166,8 +1166,22 @@ class Network(object):
             conn['gid_pairs'].pop(src_gid)
 
     def clear_connectivity(self):
-        """Remove all connections defined in Network.connectivity_list"""
-        self.connectivity = list()
+        """Remove all connections defined in Network.connectivity
+        """
+        connectivity = list()
+        for conn in self.connectivity:
+            if conn['src_type'] in self.external_drives.keys():
+                connectivity.append(conn)
+        self.connectivity = connectivity
+
+    def clear_drives(self):
+        """Remove all drives defined in Network.connectivity"""
+        connectivity = list()
+        for conn in self.connectivity:
+            if conn['src_type'] not in self.external_drives.keys():
+                connectivity.append(conn)
+        self.external_drives = dict()
+        self.connectivity = connectivity
 
     def plot_cell_morphology(self, axes=None, cell_types=None, show=True):
         """Plot the cell morphology.

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -279,6 +279,13 @@ class Network(object):
         Firing threshold of all cells.
     delay : float
         Synaptic delay in ms.
+
+    Notes
+    ----
+    `net = default_network(params)` is the reccomended path for creating a
+    network. Instantiating the network as `net = Network(params)` will
+    produce a network with no cell to cell connections. As such,
+    connectivity information contained in `params` will be ignored.
     """
 
     def __init__(self, params, add_drives_from_params=False,

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -958,7 +958,7 @@ class Network(object):
             nc_dict['A_weight'], nc_dict['A_delay'], nc_dict['lamtha'])
 
     def add_connection(self, src_gids, target_gids, loc, receptor,
-                       weight, delay, lamtha, probability=1.0):
+                       weight, delay, lamtha, probability=1.0, seed=0):
         """Appends connections to connectivity list
 
         Parameters
@@ -1094,13 +1094,13 @@ class Network(object):
 
         # Probabilistically define connections
         if probability != 1.0:
-            self._connection_probability(conn, probability)
+            self._connection_probability(conn, probability, seed)
 
         conn['probability'] = probability
 
         self.connectivity.append(deepcopy(conn))
 
-    def _connection_probability(self, conn, probability):
+    def _connection_probability(self, conn, probability, seed=0):
         """Remove/keep a random subset of connections.
 
         Parameters
@@ -1111,7 +1111,8 @@ class Network(object):
         probability : float
             Probability of connection between any src-target pair.
             Defaults to 1.0 producing an all-to-all pattern.
-
+        seed : int
+            Seed for the numpy random number generator.
         Notes
         -----
         num_srcs and num_targets are not updated after pruning connections.
@@ -1122,6 +1123,8 @@ class Network(object):
         this function. As such, this number does not accurately describe the
         connections probability of the original set after successive calls.
         """
+        # Random number generator for random connection selection
+        rng = np.random.default_rng(seed)
         _validate_type(probability, float, 'probability')
         if probability <= 0.0 or probability >= 1.0:
             raise ValueError('probability must be in the range (0,1)')
@@ -1133,7 +1136,7 @@ class Network(object):
             len(all_connections) * probability).astype(int)
 
         # Select a random subset of connections to retain.
-        new_connections = np.random.choice(
+        new_connections = rng.choice(
             range(len(all_connections)), n_connections, replace=False)
         remove_srcs = list()
         connection_idx = 0

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1074,7 +1074,7 @@ class Network(object):
             conn['nc_dict'][key] = item
 
         if probability != 1.0:
-            conn.update_probability(probability)
+            conn.drop(probability)
         conn['probability'] = probability
 
         self.connectivity.append(deepcopy(conn))
@@ -1178,7 +1178,7 @@ class _Connectivity(dict):
 
         return entr
 
-    def update_probability(self, probability):
+    def drop(self, probability):
         """Remove/keep a random subset of connections.
 
         Parameters
@@ -1206,7 +1206,7 @@ class _Connectivity(dict):
              target_src_pair in self['gid_pairs'].values()])
         n_connections = np.round(
             len(all_connections) * probability).astype(int)
-        print(len(all_connections), n_connections)
+
         # Select a random subset of connections to retain.
         new_connections = np.random.choice(
             range(len(all_connections)), n_connections, replace=False)

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -92,12 +92,6 @@ def _create_cell_coords(n_pyr_x, n_pyr_y, zdiff=1307.4):
     return pos_dict
 
 
-# connections:
-# this NODE is aware of its cells as targets
-# for each syn, return list of source GIDs.
-# for each item in the list, do a:
-# nc = pc.gid_connect(source_gid, target_syn), weight,delay
-# Both for synapses AND for external inputs
 def default_network(params, add_drives_from_params=False):
     """Instantiate the default all-to-all connected network.
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1210,7 +1210,7 @@ class _Connectivity(dict):
         """
         _validate_type(probability, float, 'probability')
         if probability <= 0.0 or probability >= 1.0:
-            raise ValueError('probability must be in the range [0,1]')
+            raise ValueError('probability must be in the range (0,1)')
         # Flatten connections into a list of targets.
         all_connections = np.concatenate(
             [target_src_pair for

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -16,7 +16,7 @@ from .drives import _check_drive_parameter_values, _check_poisson_rates
 from .cells_default import pyramidal, basket
 from .cell_response import CellResponse
 from .params import _long_name, _short_name
-from .viz import plot_cells, plot_cell_morphology
+from .viz import plot_cells, plot_cell_morphology, plot_connectivity_matrix
 from .externals.mne import _validate_type, _check_option
 
 
@@ -1030,6 +1030,7 @@ class Network(object):
                 raise AssertionError(
                     'All target_gids must be of the same type')
         conn['target_type'] = target_type
+        conn['target_range'] = self.gid_ranges[_long_name(target_type)]
         conn['num_targets'] = len(target_set)
 
         if len(target_gids) != len(src_gids):
@@ -1048,6 +1049,7 @@ class Network(object):
                 raise AssertionError('All src_gids must be of the same type')
             gid_pairs[src_gid] = target_src_pair
         conn['src_type'] = src_type
+        conn['src_range'] = self.gid_ranges[_long_name(src_type)]
         conn['num_srcs'] = len(src_gids)
 
         conn['gid_pairs'] = gid_pairs
@@ -1143,6 +1145,10 @@ class _Connectivity(dict):
         Number of unique source gids.
     num_targets : int
         Number of unique target gids.
+    src_range : range
+        Range of gids identified by src_type.
+    target_range : target_range
+        Range of gids identified by target_type.
     loc : str
         Location of synapse on target cell. Must be
         'proximal', 'distal', or 'soma'. Note that inhibitory synapses
@@ -1163,6 +1169,11 @@ class _Connectivity(dict):
     probability : float
         Probability of connection between any src-target pair.
         Defaults to 1.0 producing an all-to-all pattern.
+
+    Notes
+    -----
+    The len() of src_range or target_range may not match
+    num_srcs and num_targets for probability < 1.0.
     """
 
     def __repr__(self):
@@ -1229,6 +1240,22 @@ class _Connectivity(dict):
             self['gid_pairs'].pop(src_gid)
 
         self['probability'] = probability
+
+    def plot(self, ax=None, show=True):
+        """Plot connectivity matrix for instance of _Connectivity object.
+
+        Parameters
+        ----------
+        conn : Instance of _Connectivity object
+            The _Connectivity object
+
+        Returns
+        -------
+        fig : instance of matplotlib Figure
+            The matplotlib figure handle.
+        """
+
+        return plot_connectivity_matrix(self, ax=ax, show=show)
 
 
 class _NetworkDrive(dict):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1100,11 +1100,13 @@ class Network(object):
 
         # Probabilistically define connections
         if probability != 1.0:
-            self.connection_probability(conn, probability)
+            self._connection_probability(conn, probability)
+
+        conn['probability'] = probability
 
         self.connectivity.append(deepcopy(conn))
 
-    def connection_probability(self, conn, probability):
+    def _connection_probability(self, conn, probability):
         """Remove/keep a random subset of connections.
 
         Parameters
@@ -1153,8 +1155,6 @@ class Network(object):
         # Remove src_gids with no targets
         for src_gid in remove_srcs:
             conn['gid_pairs'].pop(src_gid)
-
-        conn['probability'] = probability
 
     def clear_connectivity(self):
         """Remove all connections defined in Network.connectivity_list"""

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -990,6 +990,8 @@ class Network(object):
         probability : float
             Probability of connection between any src-target pair.
             Defaults to 1.0 producing an all-to-all pattern.
+        seed : int
+            Seed for the numpy random number generator.
 
         Notes
         -----

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1111,6 +1111,9 @@ class Network(object):
 
         Parameters
         ----------
+        conn : Instance of _Connectivity object
+            Object specifying the biophysical parameters and src target pairs
+            of a specific connection class. Function modifies conn in place.
         probability : float
             Probability of connection between any src-target pair.
             Defaults to 1.0 producing an all-to-all pattern.

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -411,6 +411,12 @@ class NetworkBuilder(object):
                 _PC.cell(drive_cell.gid, drive_cell.nrn_netcon)
                 self._drive_cells.append(drive_cell)
 
+    # connections:
+    # this NODE is aware of its cells as targets
+    # for each syn, return list of source GIDs.
+    # for each item in the list, do a:
+    # nc = pc.gid_connect(source_gid, target_syn), weight,delay
+    # Both for synapses AND for external inputs
     def _connect_celltypes(self):
         """Connect two cell types for a particular receptor."""
         net = self.net

--- a/hnn_core/tests/conftest.py
+++ b/hnn_core/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 import os.path as op
 import hnn_core
-from hnn_core import read_params, Network, simulate_dipole
+from hnn_core import read_params, default_network, simulate_dipole
 from hnn_core import MPIBackend, JoblibBackend
 
 # store history of failures per test class name and per index in parametrize
@@ -89,7 +89,7 @@ def run_hnn_core_fixture():
                            't_evdist_1': 10,
                            't_evprox_2': 20,
                            'N_trials': 2})
-        net = Network(params, add_drives_from_params=True)
+        net = default_network(params, add_drives_from_params=True)
 
         # number of trials simulated
         for drive in net.external_drives.values():

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -6,7 +6,8 @@ from numpy.testing import assert_allclose
 import pytest
 
 import hnn_core
-from hnn_core import read_params, read_dipole, average_dipoles, Network
+from hnn_core import read_params, read_dipole, average_dipoles
+from hnn_core import Network, default_network
 from hnn_core.viz import plot_dipole
 from hnn_core.dipole import Dipole, simulate_dipole
 from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
@@ -87,7 +88,7 @@ def test_dipole_simulation():
                    't_evprox_1': 5,
                    't_evdist_1': 10,
                    't_evprox_2': 20})
-    net = Network(params, add_drives_from_params=True)
+    net = default_network(params, add_drives_from_params=True)
     with pytest.raises(ValueError, match="Invalid number of simulations: 0"):
         simulate_dipole(net, n_trials=0)
     with pytest.raises(TypeError, match="record_vsoma must be bool, got int"):

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -6,7 +6,7 @@ from queue import Queue
 import pytest
 
 import hnn_core
-from hnn_core import read_params, Network
+from hnn_core import read_params, Network, default_network
 from hnn_core.mpi_child import (MPISimulation, _str_to_net, _pickle_data)
 from hnn_core.parallel_backends import (_gather_trial_data,
                                         _process_child_data,
@@ -81,7 +81,7 @@ def test_str_to_net():
     # prepare network
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
-    net = Network(params, add_drives_from_params=True)
+    net = default_network(params, add_drives_from_params=True)
 
     pickled_net = _pickle_data(net)
 
@@ -120,7 +120,7 @@ def test_child_run():
                            't_evdist_1': 10,
                            't_evprox_2': 20,
                            'N_trials': 2})
-    net_reduced = Network(params_reduced, add_drives_from_params=True)
+    net_reduced = default_network(params_reduced, add_drives_from_params=True)
 
     with MPISimulation(skip_mpi_import=True) as mpi_sim:
         with io.StringIO() as buf, redirect_stdout(buf):

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 import hnn_core
-from hnn_core import read_params, Network, CellResponse
+from hnn_core import read_params, default_network, CellResponse
 from hnn_core.network_builder import NetworkBuilder
 
 
@@ -23,7 +23,7 @@ def test_network():
                    'input_prox_A_weight_L2Pyr_ampa': 5.4e-5,
                    'input_prox_A_weight_L5Pyr_ampa': 5.4e-5,
                    't0_input_prox': 50})
-    net = Network(deepcopy(params), add_drives_from_params=True)
+    net = default_network(deepcopy(params), add_drives_from_params=True)
     network_builder = NetworkBuilder(net)  # needed to populate net.cells
 
     # Assert that params are conserved across Network initialization
@@ -155,7 +155,7 @@ def test_network():
     assert nc.threshold == params['threshold']
 
     # create a new connection between cell types
-    net = Network(deepcopy(params), add_drives_from_params=True)
+    net = default_network(deepcopy(params), add_drives_from_params=True)
     nc_dict = {'A_delay': 1, 'A_weight': 1e-5, 'lamtha': 20,
                'threshold': 0.5}
     net._all_to_all_connect('bursty1', 'L5_basket',
@@ -166,7 +166,7 @@ def test_network():
     assert len(network_builder.ncs['bursty1_L5Basket_gabaa']) == n_conn
 
     # try unique=True
-    net = Network(deepcopy(params), add_drives_from_params=True)
+    net = default_network(deepcopy(params), add_drives_from_params=True)
     net._all_to_all_connect('extgauss', 'L5_basket',
                             'soma', 'gabaa', nc_dict, unique=True)
     network_builder = NetworkBuilder(net)
@@ -174,7 +174,7 @@ def test_network():
     assert len(network_builder.ncs['extgauss_L5Basket_gabaa']) == n_conn
 
     # Test inputs for connectivity API
-    net = Network(deepcopy(params), add_drives_from_params=True)
+    net = default_network(deepcopy(params), add_drives_from_params=True)
     n_conn = len(network_builder.ncs['L2Basket_L2Pyr_gabaa'])
     kwargs_default = dict(src_gids=[0, 1], target_gids=[35, 36],
                           loc='soma', receptor='gabaa',

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -231,7 +231,7 @@ def test_network():
     n_connections = np.sum(
         [len(t_gids) for
          t_gids in net.connectivity[0]['gid_pairs'].values()])
-    net.connectivity[0].update_probability(0.5)
+    net.connectivity[0].drop(0.5)
     n_connections_new = np.sum(
         [len(t_gids) for
          t_gids in net.connectivity[0]['gid_pairs'].values()])

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -246,7 +246,11 @@ def test_network():
         kwargs['probability'] = -1.0
         net.add_connection(**kwargs)
 
+    # Test removing connections from net.connectivity
+    # Needs to be updated if number of drives change in preceeding tests
     net.clear_connectivity()
+    assert len(net.connectivity) == 22
+    net.clear_drives()
     assert len(net.connectivity) == 0
 
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -228,15 +228,19 @@ def test_network():
             kwargs[arg] = string_arg
             net.add_connection(**kwargs)
 
+    # Check probability=0.5 produces half as many connections as default
+    net.add_connection(**kwargs_default)
+    kwargs = kwargs_default.copy()
+    kwargs['probability'] = 0.5
+    net.add_connection(**kwargs)
     n_connections = np.sum(
         [len(t_gids) for
-         t_gids in net.connectivity[0]['gid_pairs'].values()])
-    net.connectivity[0].drop(0.5)
+         t_gids in net.connectivity[-2]['gid_pairs'].values()])
     n_connections_new = np.sum(
         [len(t_gids) for
-         t_gids in net.connectivity[0]['gid_pairs'].values()])
+         t_gids in net.connectivity[-1]['gid_pairs'].values()])
     assert n_connections_new == np.round(n_connections * 0.5).astype(int)
-    assert net.connectivity[0]['probability'] == 0.5
+    assert net.connectivity[-1]['probability'] == 0.5
     with pytest.raises(ValueError, match='probability must be'):
         kwargs = kwargs_default.copy()
         kwargs['probability'] = -1.0

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -12,7 +12,7 @@ import pytest
 from mne.utils import _fetch_file
 
 import hnn_core
-from hnn_core import MPIBackend, Network, read_params
+from hnn_core import MPIBackend, default_network, read_params
 from hnn_core.dipole import simulate_dipole
 from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
 
@@ -99,7 +99,7 @@ class TestParallelBackends():
                        't_evdist_1': 10,
                        't_evprox_2': 20,
                        'N_trials': 2})
-        net = Network(params, add_drives_from_params=True)
+        net = default_network(params, add_drives_from_params=True)
 
         with MPIBackend() as backend:
             event = Event()
@@ -137,7 +137,7 @@ class TestParallelBackends():
                        't_evdist_1': 10,
                        't_evprox_2': 20,
                        'N_trials': 2})
-        net = Network(params, add_drives_from_params=True)
+        net = default_network(params, add_drives_from_params=True)
 
         oversubscribed = round(cpu_count() * 1.5)
         with MPIBackend(n_procs=oversubscribed) as backend:

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 import hnn_core
-from hnn_core import read_params, Network
+from hnn_core import read_params, default_network
 from hnn_core.viz import (plot_cells, plot_dipole, plot_psd, plot_tfr_morlet,
                           plot_cell_morphology)
 from hnn_core.dipole import simulate_dipole
@@ -20,7 +20,7 @@ def test_network_visualization():
     params = read_params(params_fname)
     params.update({'N_pyr_x': 3,
                    'N_pyr_y': 3})
-    net = Network(params)
+    net = default_network(params)
     plot_cells(net)
     with pytest.raises(ValueError, match='Unrecognized cell type'):
         plot_cell_morphology(cell_types='blah')
@@ -37,7 +37,7 @@ def test_dipole_visualization():
     params.update({'N_pyr_x': 3,
                    'N_pyr_y': 3,
                    'tstop': 100.})
-    net = Network(params)
+    net = default_network(params)
     weights_ampa_p = {'L2_pyramidal': 5.4e-5, 'L5_pyramidal': 5.4e-5}
     syn_delays_p = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.}
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -593,6 +593,8 @@ def plot_cell_morphology(axes=None, cell_types=None, show=True):
     plt.tight_layout()
     plt_show(show)
     return axes
+
+
 def plot_connectivity_matrix(conn, ax=None, show=True):
     """Plot connectivity matrix for instance of _Connectivity object.
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -626,9 +626,11 @@ def plot_connectivity_matrix(conn, ax=None, show=True):
         connectivity_matrix[src_idx, :] = target_indeces
 
     ax.imshow(connectivity_matrix, cmap='Greys', interpolation='none')
-    ax.set_xlabel(f'target gids ({target_range[0]}-{target_range[-1]})')
+    ax.set_xlabel(f"{conn['target_type']} target gids "
+                  f"({target_range[0]}-{target_range[-1]})")
     ax.set_xticklabels(list())
-    ax.set_ylabel(f'source gids ({src_range[0]}-{src_range[-1]})')
+    ax.set_ylabel(f"{conn['src_type']} source gids "
+                  f"({src_range[0]}-{src_range[-1]})")
     ax.set_yticklabels(list())
     ax.set_title(f"{conn['src_type']} -> {conn['target_type']} "
                  f"({conn['loc']}, {conn['receptor']})")

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -593,3 +593,43 @@ def plot_cell_morphology(axes=None, cell_types=None, show=True):
     plt.tight_layout()
     plt_show(show)
     return axes
+def plot_connectivity_matrix(conn, ax=None, show=True):
+    """Plot connectivity matrix for instance of _Connectivity object.
+
+    Parameters
+    ----------
+    conn : Instance of _Connectivity object
+        The _Connectivity object
+
+    Returns
+    -------
+    fig : instance of matplotlib Figure
+        The matplotlib figure handle.
+
+    """
+    import matplotlib.pyplot as plt
+    from.network import _Connectivity
+
+    if not isinstance(conn, _Connectivity):
+        raise TypeError('conn must be instance of _Connectivity')
+    if ax is None:
+        _, ax = plt.subplots(1, 1)
+
+    src_range = np.array(conn['src_range'])
+    target_range = np.array(conn['target_range'])
+    connectivity_matrix = np.zeros((len(src_range), len(target_range)))
+    for src_gid, target_src_pair in conn['gid_pairs'].items():
+        src_idx = np.where(src_range == src_gid)[0][0]
+        target_indeces = np.in1d(target_range, target_src_pair)
+        connectivity_matrix[src_idx, :] = target_indeces
+
+    ax.imshow(connectivity_matrix, cmap='Greys', interpolation='none')
+    ax.set_xlabel(f'target gids ({target_range[0]}-{target_range[-1]})')
+    ax.set_xticklabels(list())
+    ax.set_ylabel(f'source gids ({src_range[0]}-{src_range[-1]})')
+    ax.set_yticklabels(list())
+    ax.set_title(f"{conn['src_type']} -> {conn['target_type']} "
+                 f"({conn['loc']}, {conn['receptor']})")
+
+    plt_show(show)
+    return ax.get_figure()


### PR DESCRIPTION
At long last we're here! This PR is meant to flush out the API for modifying and visualizing the connectivity now that it has been decoupled from `network_builder.py` (#276), and the data structure is lightweight and interpretable (#313). 

Thanks to @jasmainak's suggestion to store separate connection types as objects, there is now a very clean path towards modifying existing connections. To demonstrate, this PR enables modification of existing connections with `net.connectivity[idx].update_probability(0.5)`. I have additionally added a `probability` argument to `net.add_connection`.

Here are my currently planned functions to add:
- `net.connectivity[idx].plot` which will produce a "checkerboard" to visualize connections
- `net.connectivity[idx].update_srcs` and `net.connectivity[idx].update_targets` to filter connections to a subset of srcs and targets. This will be really useful for modifying drives to the network that target different sub populations of cells. 

Let me know if you guys have any other suggestions! 

P.S. I think this mode of modifying connections will be quite amenable to the GUI since it modifies everything in place.


