### PR TITLE
[MRG] FIX tests for NEURON v8

### DIFF
--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -7,6 +7,11 @@
 import numpy as np
 from neuron import h
 
+# This is due to: https://github.com/neuronsimulator/nrn/pull/746
+from neuron import __version__
+if int(__version__[0]) >= 8:
+    h.nrnunit_use_legacy(1)
+
 from .cell import _ArtificialCell
 from .pyramidal import L2Pyr, L5Pyr
 from .basket import L2Basket, L5Basket


### PR DESCRIPTION
NEURON 8.0.0 makes a change in something to do with "dynamic units". This leads to slight (floating point precision-level) differences in the output of our Dipole time courses. 

The issue was first noted in #322.

References:
https://github.com/neuronsimulator/nrn/pull/746
https://github.com/neuronsimulator/nrn/blob/c8cb9878b5b46c9a116315037b963d77828070a9/cmake/ConfigFileSetting.cmake#L105


