### PR TITLE
[MRG] Add function to visualize connectivity weights

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -46,6 +46,8 @@ Visualization (:py:mod:`hnn_core.viz`):
    plot_cell_morphology
    plot_psd
    plot_tfr_morlet
+   plot_cell_connectivity
+   plot_connectivity_matrix
 
 Parallel backends (:py:mod:`hnn_core.parallel_backends`):
 ---------------------------------------------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,6 +24,8 @@ Changelog
 
 - Add probability argument to :func:`~hnn_core.Network.add_connection`. Connectivity patterns can also be visualized with :func:`~hnn_core.viz.plot_connectivity_matrix`, by `Nick Tolley`_ in `#318 <https://github.com/jonescompneurolab/hnn-core/pull/318>`_
 
+- Add function to visualize connections originating from individual cells :func:`~hnn_core.viz.plot_cell_connectivity`, by `Nick Tolley`_ in `#339 <https://github.com/jonescompneurolab/hnn-core/pull/339>`_
+
 Bug
 ~~~
 
@@ -42,8 +44,6 @@ API
   in a :class:`~hnn_core.Network` instance's :attr:`~/hnn_core.Network.cell_types` attribute by `Ryan Thorpe`_ in `#321 <https://github.com/jonescompneurolab/hnn-core/pull/321>`_
 
 - New API for network creation. The default network is now created with ``net = default_network(params)``, by `Nick Tolley`_ in `#318 <https://github.com/jonescompneurolab/hnn-core/pull/318>`_
-
-- Add API for visualizing connections originating from individual cells :func:`~hnn_core.viz.plot_cell_connectivity`, by `Nick Tolley`_ in `#339 <https://github.com/jonescompneurolab/hnn-core/pull/339>`_
 
 .. _0.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,6 +24,8 @@ Changelog
 
 - Add probability argument to :func:`~hnn_core.Network.add_connection`. Connectivity patterns can also be visualized with :func:`~hnn_core.viz.plot_connectivity_matrix`, by `Nick Tolley`_ in `#318 <https://github.com/jonescompneurolab/hnn-core/pull/318>`_
 
+- Add function to visualize connections originating from individual cells :func:`~hnn_core.viz.plot_cell_connectivity`, by `Nick Tolley`_ in `#339 <https://github.com/jonescompneurolab/hnn-core/pull/339>`_
+
 Bug
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,8 +24,6 @@ Changelog
 
 - Add probability argument to :func:`~hnn_core.Network.add_connection`. Connectivity patterns can also be visualized with :func:`~hnn_core.viz.plot_connectivity_matrix`, by `Nick Tolley`_ in `#318 <https://github.com/jonescompneurolab/hnn-core/pull/318>`_
 
-- Add function to visualize connections originating from individual cells :func:`~hnn_core.viz.plot_cell_connectivity`, by `Nick Tolley`_ in `#339 <https://github.com/jonescompneurolab/hnn-core/pull/339>`_
-
 Bug
 ~~~
 
@@ -44,6 +42,8 @@ API
   in a :class:`~hnn_core.Network` instance's :attr:`~/hnn_core.Network.cell_types` attribute by `Ryan Thorpe`_ in `#321 <https://github.com/jonescompneurolab/hnn-core/pull/321>`_
 
 - New API for network creation. The default network is now created with ``net = default_network(params)``, by `Nick Tolley`_ in `#318 <https://github.com/jonescompneurolab/hnn-core/pull/318>`_
+
+- Add API for visualizing connections originating from individual cells :func:`~hnn_core.viz.plot_cell_connectivity`, by `Nick Tolley`_ in `#339 <https://github.com/jonescompneurolab/hnn-core/pull/339>`_
 
 .. _0.1:
 

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -39,15 +39,18 @@ net_erp = default_network(params, add_drives_from_params=True)
 # reflect the canonical neocortical microcircuit. ``net.connectivity``
 # is a list of dictionaries which detail every cell-cell, and drive-cell
 # connection. The weights of these connections can be visualized with
-# :func:`~hnn_core.viz.plot_connectivity_weights`
-from hnn_core.viz import plot_connectivity_weights
+# :func:`~hnn_core.viz.plot_connectivity_weights` as well as
+# :func:`~hnn_core.viz.plot_cell_connectivity`
+from hnn_core.viz import plot_connectivity_weights, plot_cell_connectivity
 print(len(net_erp.connectivity))
 
-print(net_erp.connectivity[15])
-plot_connectivity_weights(net_erp, conn_idx=15)
+conn_idx = 15
+print(net_erp.connectivity[conn_idx])
+plot_connectivity_weights(net_erp, conn_idx)
 
-print(net_erp.connectivity[20])
-plot_connectivity_weights(net_erp, conn_idx=20)
+conn_idx, gid_idx = 20, 11
+src_gid = net_erp.connectivity[conn_idx]['src_range'][gid_idx]
+fig, ax = plot_cell_connectivity(net_erp, conn_idx, src_gid)
 
 ###############################################################################
 # Data recorded during simulations are stored under

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -125,12 +125,12 @@ net_sparse.cell_response.plot_spikes_raster()
 
 # Get index of most recently added connection, and a src_gid in src_range.
 conn_idx, gid_idx = len(net_sparse.connectivity) - 1, 5
-src_gid = net_erp.connectivity[conn_idx]['src_range'][gid_idx]
+src_gid = net_sparse.connectivity[conn_idx]['src_range'][gid_idx]
 plot_connectivity_matrix(net_sparse, conn_idx)
 plot_cell_connectivity(net_sparse, conn_idx, src_gid)
 
 conn_idx, gid_idx = len(net_sparse.connectivity) - 2, 5
-src_gid = net_erp.connectivity[conn_idx]['src_range'][gid_idx]
+src_gid = net_sparse.connectivity[conn_idx]['src_range'][gid_idx]
 plot_connectivity_matrix(net_sparse, conn_idx)
 plot_cell_connectivity(net_sparse, conn_idx, src_gid)
 

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -8,7 +8,7 @@ This example demonstrates how to modify the network connectivity.
 
 # Author: Nick Tolley <nicholas_tolley@brown.edu>
 
-# sphinx_gallery_thumbnail_number = 1
+# sphinx_gallery_thumbnail_number = 2
 
 import os.path as op
 

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -38,9 +38,15 @@ net_erp = default_network(params, add_drives_from_params=True)
 # Instantiating the network comes with a predefined set of connections that
 # reflect the canonical neocortical microcircuit. ``net.connectivity``
 # is a list of dictionaries which detail every cell-cell, and drive-cell
-# connection.
-print(len(net_erp.connectivity))
+# connection. The weights of these connections can be visualized with
+# :func:`~hnn_core.viz.plot_connectivity_weights`
+from hnn_core.viz import plot_connectivity_weights
+n_connections = len(net_erp.connectivity)
+print(n_connections)
 print(net_erp.connectivity[0:2])
+
+# Plot the last connection added to the network
+plot_connectivity_weights(net_erp, conn_idx=n_connections)
 
 ###############################################################################
 # Data recorded during simulations are stored under
@@ -117,6 +123,7 @@ net_sparse.cell_response.plot_spikes_raster()
 
 net_sparse.connectivity[-2].plot()
 net_sparse.connectivity[-1].plot()
+
 
 ###############################################################################
 # Using the sparse connectivity pattern produced a lot more spiking in

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -41,14 +41,14 @@ net_erp = default_network(params, add_drives_from_params=True)
 # connection. The weights of these connections can be visualized with
 # :func:`~hnn_core.viz.plot_connectivity_weights` as well as
 # :func:`~hnn_core.viz.plot_cell_connectivity`
-from hnn_core.viz import plot_connectivity_weights, plot_cell_connectivity
+from hnn_core.viz import plot_connectivity_matrix, plot_cell_connectivity
 print(len(net_erp.connectivity))
 
-conn_idx = 15
+conn_idx = 20
 print(net_erp.connectivity[conn_idx])
-plot_connectivity_weights(net_erp, conn_idx)
+plot_connectivity_matrix(net_erp, conn_idx)
 
-conn_idx, gid_idx = 20, 11
+gid_idx = 11
 src_gid = net_erp.connectivity[conn_idx]['src_range'][gid_idx]
 fig, ax = plot_cell_connectivity(net_erp, conn_idx, src_gid)
 
@@ -99,9 +99,7 @@ net_all.cell_response.plot_spikes_raster()
 # activity is visible as vertical lines where several cells fire simultaneously
 # We can additionally use the ``probability``. argument to create a sparse
 # connectivity pattern instead of all-to-all. Let's try creating the same
-# network with a 10% chance of cells connecting to each other. The resulting
-# connectivity pattern can also be visualized with
-# ``net.connectivity[idx].plot()``
+# network with a 10% chance of cells connecting to each other.
 probability = 0.1
 net_sparse = default_network(params, add_drives_from_params=True)
 net_sparse.clear_connectivity()
@@ -125,9 +123,10 @@ for target in ['L5_pyramidal', 'L2_basket']:
 dpl_sparse = simulate_dipole(net_sparse, n_trials=1)
 net_sparse.cell_response.plot_spikes_raster()
 
-net_sparse.connectivity[-2].plot()
-net_sparse.connectivity[-1].plot()
-
+# Get index of most recently added connection
+conn_idx = len(net_sparse.connectivity)
+plot_connectivity_matrix(net_sparse, conn_idx, show_weight=False)
+plot_connectivity_matrix(net_sparse, conn_idx - 1, show_weight=False)
 
 ###############################################################################
 # Using the sparse connectivity pattern produced a lot more spiking in

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -123,10 +123,16 @@ for target in ['L5_pyramidal', 'L2_basket']:
 dpl_sparse = simulate_dipole(net_sparse, n_trials=1)
 net_sparse.cell_response.plot_spikes_raster()
 
-# Get index of most recently added connection
-conn_idx = len(net_sparse.connectivity)
-plot_connectivity_matrix(net_sparse, conn_idx, show_weight=False)
-plot_connectivity_matrix(net_sparse, conn_idx - 1, show_weight=False)
+# Get index of most recently added connection, and a src_gid in src_range.
+conn_idx, gid_idx = len(net_sparse.connectivity) - 1, 5
+src_gid = net_erp.connectivity[conn_idx]['src_range'][gid_idx]
+plot_connectivity_matrix(net_sparse, conn_idx)
+plot_cell_connectivity(net_sparse, conn_idx, src_gid)
+
+conn_idx, gid_idx = len(net_sparse.connectivity) - 2, 5
+src_gid = net_erp.connectivity[conn_idx]['src_range'][gid_idx]
+plot_connectivity_matrix(net_sparse, conn_idx)
+plot_cell_connectivity(net_sparse, conn_idx, src_gid)
 
 ###############################################################################
 # Using the sparse connectivity pattern produced a lot more spiking in

--- a/examples/plot_connectivity.py
+++ b/examples/plot_connectivity.py
@@ -8,7 +8,7 @@ This example demonstrates how to modify the network connectivity.
 
 # Author: Nick Tolley <nicholas_tolley@brown.edu>
 
-# sphinx_gallery_thumbnail_number = 5
+# sphinx_gallery_thumbnail_number = 1
 
 import os.path as op
 
@@ -41,12 +41,13 @@ net_erp = default_network(params, add_drives_from_params=True)
 # connection. The weights of these connections can be visualized with
 # :func:`~hnn_core.viz.plot_connectivity_weights`
 from hnn_core.viz import plot_connectivity_weights
-n_connections = len(net_erp.connectivity)
-print(n_connections)
-print(net_erp.connectivity[0:2])
+print(len(net_erp.connectivity))
 
-# Plot the last connection added to the network
-plot_connectivity_weights(net_erp, conn_idx=n_connections)
+print(net_erp.connectivity[15])
+plot_connectivity_weights(net_erp, conn_idx=15)
+
+print(net_erp.connectivity[20])
+plot_connectivity_weights(net_erp, conn_idx=20)
 
 ###############################################################################
 # Data recorded during simulations are stored under

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -52,16 +52,18 @@ def _calculate_gaussian(x_val, height, lamtha):
     return x_height
 
 
-def _get_gaussian_connection(nc_dict, target_pos):
+def _get_gaussian_connection(src_pos, target_pos, nc_dict):
     """Calculate distance dependent connection properties.
 
     Parameters
     ----------
+    src_pos : float
+        Position of source cell.
+    target_pos : float
+        Position of target cell.
     nc_dict : dict
         Dictionary with keys: pos_src, A_weight, A_delay, lamtha
         Defines the connection parameters
-    target_pos : float
-        Position of target cell.
 
     Returns
     -------
@@ -74,8 +76,8 @@ def _get_gaussian_connection(nc_dict, target_pos):
     -----
     Distance in xy plane is used for gaussian decay.
     """
-    x_dist = target_pos[0] - nc_dict['pos_src'][0]
-    y_dist = target_pos[1] - nc_dict['pos_src'][1]
+    x_dist = target_pos[0] - src_pos[0]
+    y_dist = target_pos[1] - src_pos[1]
     cell_dist = np.sqrt(x_dist**2 + y_dist**2)
 
     weight = _calculate_gaussian(
@@ -540,7 +542,8 @@ class Cell:
 
         # set props here.
         nc.threshold = nc_dict['threshold']
-        nc.weight[0], nc.delay = _get_gaussian_connection(nc_dict, self.pos)
+        nc.weight[0], nc.delay = _get_gaussian_connection(
+            nc_dict['pos_src'], self.pos, nc_dict)
 
         return nc
 

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -82,8 +82,8 @@ def _get_gaussian_connection(src_pos, target_pos, nc_dict):
 
     weight = _calculate_gaussian(
         cell_dist, nc_dict['A_weight'], nc_dict['lamtha'])
-    delay = _calculate_gaussian(
-        cell_dist, nc_dict['A_delay'], nc_dict['lamtha'])
+    delay = nc_dict['A_delay'] / _calculate_gaussian(
+        cell_dist, 1, nc_dict['lamtha'])
     return weight, delay
 
 

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -26,7 +26,7 @@ def _get_cos_theta(p_secs, sec_name_apical):
 
 
 def _calculate_gaussian(x_val, height, lamtha):
-    """Return height of gaussian at x_val.and
+    """Return height of gaussian at x_val.
 
     Parameters
     ----------

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -17,7 +17,7 @@ from .drives import _check_drive_parameter_values, _check_poisson_rates
 from .cells_default import pyramidal, basket
 from .cell_response import CellResponse
 from .params import _long_name, _short_name
-from .viz import plot_cells, plot_connectivity_matrix
+from .viz import plot_cells
 from .externals.mne import _validate_type, _check_option
 
 
@@ -1267,25 +1267,6 @@ class _Connectivity(dict):
         entr += "\n "
 
         return entr
-
-    def plot(self, ax=None, show=True):
-        """Plot connectivity matrix for instance of _Connectivity object.
-
-        Parameters
-        ----------
-        ax : instance of matplotlib Axes3D | None
-            An axis object from matplotlib. If None,
-            a new figure is created.
-        show : bool
-            If True, show the figure.
-
-        Returns
-        -------
-        fig : instance of matplotlib Figure
-            The matplotlib figure handle.
-        """
-
-        return plot_connectivity_matrix(self, ax=ax, show=show)
 
 
 class _NetworkDrive(dict):

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -7,6 +7,7 @@ import pytest
 import hnn_core
 from hnn_core import read_params, default_network
 from hnn_core.viz import plot_cells, plot_dipole, plot_psd, plot_tfr_morlet
+from hnn_core.viz import plot_connectivity_matrix, plot_cell_connectivity
 from hnn_core.dipole import simulate_dipole
 
 matplotlib.use('agg')
@@ -23,6 +24,26 @@ def test_network_visualization():
     plot_cells(net)
     ax = net.cell_types['L2_pyramidal'].plot_morphology()
     assert len(ax.lines) == 8
+
+    conn_idx = 0
+    with pytest.raises(TypeError, match='net must be an instance of'):
+        plot_connectivity_matrix('blah', conn_idx, show_weight=False)
+
+    with pytest.raises(TypeError, match='conn_idx must be an instance of'):
+        plot_connectivity_matrix(net, 'blah', show_weight=False)
+
+    with pytest.raises(TypeError, match='show_weight must be an instance of'):
+        plot_connectivity_matrix(net, conn_idx, show_weight='blah')
+
+    src_gid = 5
+    with pytest.raises(TypeError, match='net must be an instance of'):
+        plot_cell_connectivity('blah', conn_idx, src_gid=src_gid)
+
+    with pytest.raises(TypeError, match='conn_idx must be an instance of'):
+        plot_cell_connectivity(net, 'blah', src_gid=src_gid)
+
+    with pytest.raises(TypeError, match='src_gid must be an instance of'):
+        plot_cell_connectivity(net, conn_idx, src_gid='blah')
 
 
 def test_dipole_visualization():

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -26,6 +26,7 @@ def test_network_visualization():
     assert len(ax.lines) == 8
 
     conn_idx = 0
+    plot_connectivity_matrix(net, conn_idx, show=False)
     with pytest.raises(TypeError, match='net must be an instance of'):
         plot_connectivity_matrix('blah', conn_idx, show_weight=False)
 
@@ -36,14 +37,18 @@ def test_network_visualization():
         plot_connectivity_matrix(net, conn_idx, show_weight='blah')
 
     src_gid = 5
+    plot_cell_connectivity(net, conn_idx, src_gid, show=False)
     with pytest.raises(TypeError, match='net must be an instance of'):
         plot_cell_connectivity('blah', conn_idx, src_gid=src_gid)
 
     with pytest.raises(TypeError, match='conn_idx must be an instance of'):
-        plot_cell_connectivity(net, 'blah', src_gid=src_gid)
+        plot_cell_connectivity(net, 'blah', src_gid)
 
     with pytest.raises(TypeError, match='src_gid must be an instance of'):
         plot_cell_connectivity(net, conn_idx, src_gid='blah')
+
+    with pytest.raises(ValueError, match='src_gid not in the'):
+        plot_cell_connectivity(net, conn_idx, src_gid=-1)
 
 
 def test_dipole_visualization():

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -746,16 +746,16 @@ def plot_cell_connectivity(net, conn_idx, src_gid, ax=None, colorbar=True,
         weight, _ = _get_gaussian_connection(src_pos, target_pos, nc_dict)
         weights.append(weight)
 
-    im = ax.scatter(target_x_pos, target_y_pos, c=weights, cmap=colormap)
+    im = ax.scatter(target_x_pos, target_y_pos, c=weights, s=50, cmap=colormap)
 
     # Gather positions of all gids in target_type.
     x_pos = [target_type_pos[idx][0] for idx in range(len(target_type_pos))]
     y_pos = [target_type_pos[idx][1] for idx in range(len(target_type_pos))]
-    ax.scatter(x_pos, y_pos, color='k', zorder=-1, s=4)
+    ax.scatter(x_pos, y_pos, color='k', marker='x', zorder=-1, s=20)
 
     # Only plot src_gid if proper cell type.
     if src_type in net.cell_types:
-        ax.scatter(src_pos[0], src_pos[1], color='red', s=100)
+        ax.scatter(src_pos[0], src_pos[1], marker='s', color='red', s=150)
     ax.set_ylabel('Y Position')
     ax.set_xlabel('X Position')
     ax.set_title(f"{conn['src_type']}-> {conn['target_type']}"

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -571,7 +571,7 @@ def plot_cell_morphology(cell, ax, show=True):
 
 
 def plot_connectivity_matrix(net, conn_idx, show_weight=True,
-                             ax=None, show=True):
+                             colorbar=True, ax=None, show=True):
     """Plot connectivity matrix with color bar for synaptic weights
 
     Parameters
@@ -595,6 +595,7 @@ def plot_connectivity_matrix(net, conn_idx, show_weight=True,
         The matplotlib figure handle.
     """
     import matplotlib.pyplot as plt
+    from matplotlib.ticker import ScalarFormatter
     from .network import Network
     from .cell import _get_gaussian_connection
 
@@ -632,7 +633,19 @@ def plot_connectivity_matrix(net, conn_idx, show_weight=True,
 
             connectivity_matrix[src_idx, target_idx] = weight
 
-    ax.imshow(connectivity_matrix, cmap='Greys', interpolation='none')
+    im = ax.imshow(connectivity_matrix, cmap='Greys', interpolation='none')
+
+    ax.set_xlabel('Time (ms)')
+    ax.set_ylabel('Frequency (Hz)')
+
+    if colorbar:
+        fig = ax.get_figure()
+        xfmt = ScalarFormatter()
+        xfmt.set_powerlimits((-2, 2))
+        cbar = fig.colorbar(im, ax=ax, format=xfmt)
+        cbar.ax.yaxis.set_ticks_position('right')
+        cbar.ax.set_ylabel('Weight', rotation=-90, va="bottom")
+
     ax.set_xlabel(f"{conn['target_type']} target gids "
                   f"({target_range[0]}-{target_range[-1]})")
     ax.set_xticklabels(list())
@@ -642,11 +655,13 @@ def plot_connectivity_matrix(net, conn_idx, show_weight=True,
     ax.set_title(f"{conn['src_type']} -> {conn['target_type']} "
                  f"({conn['loc']}, {conn['receptor']})")
 
+    plt.tight_layout()
     plt_show(show)
     return ax.get_figure()
 
 
-def plot_cell_connectivity(net, conn_idx, src_gid, ax=None, show=True):
+def plot_cell_connectivity(net, conn_idx, src_gid, colorbar=True,
+                           ax=None, show=True):
     """Plot synaptic weight of connections from a src_gid.
 
     Parameters
@@ -667,12 +682,12 @@ def plot_cell_connectivity(net, conn_idx, src_gid, ax=None, show=True):
     -------
     fig : instance of matplotlib Figure
         The matplotlib figure handle.
-    im : Instance of matplotlib AxesImage
-        The matplotlib AxesImage handle.
+
     """
     import matplotlib.pyplot as plt
     from .network import Network
     from .cell import _get_gaussian_connection
+    from matplotlib.ticker import ScalarFormatter
 
     _validate_type(net, Network, 'net', 'Network')
     _validate_type(conn_idx, int, 'conn_idx', 'int')
@@ -707,13 +722,22 @@ def plot_cell_connectivity(net, conn_idx, src_gid, ax=None, show=True):
         weight, _ = _get_gaussian_connection(src_pos, target_pos, nc_dict)
         weights.append(weight)
 
-    ax.scatter(x_pos, y_pos, c=weights)
+    im = ax.scatter(x_pos, y_pos, c=weights)
 
     ax.scatter(src_pos[0], src_pos[1], color='red', s=100)
     ax.set_ylabel('Y Position')
     ax.set_xlabel('X Position')
-    ax.set_title(f"{conn['src_type']} (gid={src_gid}) -> {conn['target_type']}"
+    ax.set_title(f"{conn['src_type']}-> {conn['target_type']}"
                  f" ({conn['loc']}, {conn['receptor']})")
 
+    if colorbar:
+        fig = ax.get_figure()
+        xfmt = ScalarFormatter()
+        xfmt.set_powerlimits((-2, 2))
+        cbar = fig.colorbar(im, ax=ax, format=xfmt)
+        cbar.ax.yaxis.set_ticks_position('right')
+        cbar.ax.set_ylabel('Weight', rotation=-90, va="bottom")
+
+    plt.tight_layout()
     plt_show(show)
     return ax.get_figure(), ax

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -635,6 +635,7 @@ def plot_connectivity_weights(net, conn_idx, ax=None, show=True):
     ax.set_title(f"{conn['src_type']} -> {conn['target_type']} "
                  f"({conn['loc']}, {conn['receptor']})")
 
+    plt_show(show)
     return ax.get_figure()
 
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 from itertools import cycle
+from .externals.mne import _validate_type
 
 
 def _get_plot_data(dpl, layer, tmin, tmax):
@@ -593,8 +594,8 @@ def plot_connectivity_weights(net, conn_idx, ax=None, show=True):
     from .network import Network
     from .cell import _get_gaussian_connection
 
-    if not isinstance(net, Network):
-        raise TypeError('conn must be instance of _Connectivity')
+    _validate_type(net, Network, 'net', 'Network')
+    _validate_type(conn_idx, int, 'conn_idx', 'int')
     if ax is None:
         _, ax = plt.subplots(1, 1)
 
@@ -657,8 +658,7 @@ def plot_connectivity_matrix(conn, ax=None, show=True):
     import matplotlib.pyplot as plt
     from.network import _Connectivity
 
-    if not isinstance(conn, _Connectivity):
-        raise TypeError('conn must be instance of _Connectivity')
+    _validate_type(conn, _Connectivity, 'conn', '_Connectivity')
     if ax is None:
         _, ax = plt.subplots(1, 1)
 
@@ -679,6 +679,58 @@ def plot_connectivity_matrix(conn, ax=None, show=True):
     ax.set_yticklabels(list())
     ax.set_title(f"{conn['src_type']} -> {conn['target_type']} "
                  f"({conn['loc']}, {conn['receptor']})")
+
+    plt_show(show)
+    return ax.get_figure()
+
+
+def plot_cell_connectivity(net, conn_idx, gid, ax=None, show=True):
+    """Plot synaptic weight
+
+    Parameters
+    ----------
+    net : Instance of Network object
+        The Network object
+    conn_idx : int
+        Index of connection to be visualized
+        from `net.connectivity`
+    gid : int
+        Each cell in a network is uniquely identified by it's "global ID": GID.
+    ax : instance of Axes3D
+        Matplotlib 3D axis
+    show : bool
+        If True, show the plot
+
+    Returns
+    -------
+    fig : instance of matplotlib Figure
+        The matplotlib figure handle.
+    """
+    import matplotlib.pyplot as plt
+    from .network import Network
+    from .cell import _get_gaussian_connection
+
+    _validate_type(net, Network, 'net', 'Network')
+    _validate_type(conn_idx, int, 'conn_idx', 'int')
+    _validate_type(gid, int, 'gid', 'int')
+    if ax is None:
+        _, ax = plt.subplots(1, 1)
+
+    # Load objects for distance calculation
+    conn = net.connectivity[conn_idx]
+    nc_dict = conn['nc_dict']
+    src_type = conn['src_type']
+    target_type = conn['target_type']
+    src_type_pos = net.pos_dict[src_type]
+    target_type_pos = net.pos_dict[target_type]
+
+    # Assumes min/max values occur in the first/last pos_dict items.
+
+    src_range = np.array(conn['src_range'])
+    target_range = np.array(conn['target_range'])
+    connectivity_matrix = np.zeros((len(src_range), len(target_range)))
+
+
 
     plt_show(show)
     return ax.get_figure()

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -570,7 +570,8 @@ def plot_cell_morphology(cell, ax, show=True):
     return ax
 
 
-def plot_connectivity_weights(net, conn_idx, ax=None, show=True):
+def plot_connectivity_matrix(net, conn_idx, show_weight=True,
+                             ax=None, show=True):
     """Plot connectivity matrix with color bar for synaptic weights
 
     Parameters
@@ -580,6 +581,9 @@ def plot_connectivity_weights(net, conn_idx, ax=None, show=True):
     conn_idx : int
         Index of connection to be visualized
         from `net.connectivity`
+    show_weight : bool
+        If True, visualize connectivity weights as gradient.
+        If False, each connection is visualized with a black square.
     ax : instance of Axes3D
         Matplotlib 3D axis
     show : bool
@@ -596,6 +600,7 @@ def plot_connectivity_weights(net, conn_idx, ax=None, show=True):
 
     _validate_type(net, Network, 'net', 'Network')
     _validate_type(conn_idx, int, 'conn_idx', 'int')
+    _validate_type(show_weight, bool, 'show_weight', 'bool')
     if ax is None:
         _, ax = plt.subplots(1, 1)
 
@@ -619,56 +624,13 @@ def plot_connectivity_weights(net, conn_idx, ax=None, show=True):
             target_pos = target_type_pos[target_idx]
 
             # Identical calculation used in Cell.par_connect_from_src()
-            weight, _ = _get_gaussian_connection(src_pos, target_pos, nc_dict)
+            if show_weight:
+                weight, _ = _get_gaussian_connection(
+                    src_pos, target_pos, nc_dict)
+            else:
+                weight = 1.0
 
             connectivity_matrix[src_idx, target_idx] = weight
-
-    ax.imshow(connectivity_matrix, cmap='Greys', interpolation='none')
-    ax.set_xlabel(f"{conn['target_type']} target gids "
-                  f"({target_range[0]}-{target_range[-1]})")
-    ax.set_xticklabels(list())
-    ax.set_ylabel(f"{conn['src_type']} source gids "
-                  f"({src_range[0]}-{src_range[-1]})")
-    ax.set_yticklabels(list())
-    ax.set_title(f"{conn['src_type']} -> {conn['target_type']} "
-                 f"({conn['loc']}, {conn['receptor']})")
-
-    plt_show(show)
-    return ax.get_figure()
-
-
-def plot_connectivity_matrix(conn, ax=None, show=True):
-    """Plot connectivity matrix for instance of _Connectivity object.
-
-    Parameters
-    ----------
-    conn : Instance of _Connectivity object
-        The _Connectivity object
-    ax : instance of Axes3D
-        Matplotlib 3D axis
-    show : bool
-        If True, show the plot
-
-    Returns
-    -------
-    fig : instance of matplotlib Figure
-        The matplotlib figure handle.
-
-    """
-    import matplotlib.pyplot as plt
-    from.network import _Connectivity
-
-    _validate_type(conn, _Connectivity, 'conn', '_Connectivity')
-    if ax is None:
-        _, ax = plt.subplots(1, 1)
-
-    src_range = np.array(conn['src_range'])
-    target_range = np.array(conn['target_range'])
-    connectivity_matrix = np.zeros((len(src_range), len(target_range)))
-    for src_gid, target_src_pair in conn['gid_pairs'].items():
-        src_idx = np.where(src_range == src_gid)[0][0]
-        target_indeces = np.in1d(target_range, target_src_pair)
-        connectivity_matrix[src_idx, :] = target_indeces
 
     ax.imshow(connectivity_matrix, cmap='Greys', interpolation='none')
     ax.set_xlabel(f"{conn['target_type']} target gids "

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -570,7 +570,8 @@ def plot_cell_morphology(cell, ax, show=True):
 
 
 def plot_connectivity_weights(net, conn_idx, ax=None, show=True):
-    """ Plot connectivity matrix with color bar for synaptic weights
+    """Plot connectivity matrix with color bar for synaptic weights
+
     Parameters
     ----------
     net : Instance of Network object

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -724,13 +724,15 @@ def plot_cell_connectivity(net, conn_idx, gid, ax=None, show=True):
     src_type_pos = net.pos_dict[src_type]
     target_type_pos = net.pos_dict[target_type]
 
-    # Assumes min/max values occur in the first/last pos_dict items.
-
+    # Assumes max value occurs in the last pos_dict items.
     src_range = np.array(conn['src_range'])
     target_range = np.array(conn['target_range'])
-    connectivity_matrix = np.zeros((len(src_range), len(target_range)))
+    connectivity_matrix = np.zeros((target_type_pos[-1][1],
+                                    (target_type_pos[-1][0])))
 
+    # src_idx = np.where()
 
+    # conn['gid_pairs']
 
-    plt_show(show)
-    return ax.get_figure()
+    # plt_show(show)
+    # return ax.get_figure()

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -750,8 +750,8 @@ def plot_cell_connectivity(net, conn_idx, src_gid, ax=None, show=True):
     ax.scatter(src_pos[0], src_pos[1], color='red', s=100)
     ax.set_ylabel('Y Position')
     ax.set_xlabel('X Position')
-    ax.set_title(f"{conn['src_type']} -> {conn['target_type']} "
-                 f"({conn['loc']}, {conn['receptor']})")
+    ax.set_title(f"{conn['src_type']} (gid={src_gid}) -> {conn['target_type']}"
+                 f" ({conn['loc']}, {conn['receptor']})")
 
     plt_show(show)
     return ax.get_figure(), ax

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -577,7 +577,7 @@ def plot_connectivity_weights(net, conn_idx, ax=None, show=True):
     net : Instance of Network object
         The Network object
     conn_idx : int
-        Index of _Connectivity object to be visualized
+        Index of connection to be visualized
         from `net.connectivity`
     ax : instance of Axes3D
         Matplotlib 3D axis
@@ -591,6 +591,7 @@ def plot_connectivity_weights(net, conn_idx, ax=None, show=True):
     """
     import matplotlib.pyplot as plt
     from .network import Network
+    from .cell import _get_gaussian_connection
 
     if not isinstance(net, Network):
         raise TypeError('conn must be instance of _Connectivity')
@@ -617,12 +618,7 @@ def plot_connectivity_weights(net, conn_idx, ax=None, show=True):
             target_pos = target_type_pos[target_idx]
 
             # Identical calculation used in Cell.par_connect_from_src()
-            dx = src_pos[0] - target_pos[0]
-            dy = src_pos[1] - target_pos[1]
-            d = np.sqrt(dx**2 + dy**2)
-
-            weight = nc_dict['A_weight'] * \
-                np.exp(-(d**2) / (nc_dict['lamtha']**2))
+            weight, _ = _get_gaussian_connection(src_pos, target_pos, nc_dict)
 
             connectivity_matrix[src_idx, target_idx] = weight
 


### PR DESCRIPTION
This has been on the to-do for awhile. I've added a function to visualize the connectivity weights so that the gaussian decay with distance is visible. Since gids are arranged in a grid, it produces some interesting repeating patterns: 

![image](https://user-images.githubusercontent.com/55253912/119590776-6f539680-bda3-11eb-96e8-8be9c95b290f.png)
![image](https://user-images.githubusercontent.com/55253912/119590797-79759500-bda3-11eb-9aa6-dd0a2968f6df.png)

I still need to add some quick smoke tests, but I am satisfied with the current implementation of the function and definitely ready for some reviews.