### PR TITLE
[MRG] Fix net.add_bursty_input() weight updating

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,8 @@ Bug
 
 - Remove rounding error caused by repositioning of NEURON cell sections, by `Mainak Jas`_ and `Ryan Thorpe`_ in `#314 <https://github.com/jonescompneurolab/hnn-core/pull/314>`_
 
+- Fix issue where common drives use the same parameters for all cell types, by `Nick Tolley`_ in `#350 <https://github.com/jonescompneurolab/hnn-core/pull/350>`_
+
 API
 ~~~
 - New API for defining cell-cell connections. Custom connections can be added with :func:`~hnn_core.Network.add_connection`, by `Nick Tolley`_ in `#276 <https://github.com/jonescompneurolab/hnn-core/pull/276>`_

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -883,9 +883,8 @@ class Network(object):
                     for this_cell_drive_conn in drive['conn'].values():
                         # Only create one set of event times
                         # Exit on fist target cell type with non-zero weight
-                        has_weight = np.logical_or(
-                            this_cell_drive_conn['ampa'],
-                            this_cell_drive_conn['nmda'])
+                        has_weight = (len(this_cell_drive_conn['ampa']) > 0
+                                      or len(this_cell_drive_conn['nmda']) > 0)
 
                         # cell_specific=False should only have one src_gid
                         if has_weight:

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -897,6 +897,11 @@ class Network(object):
                                 seedcore=drive['seedcore']))
                             break
 
+                    # Handles edge case where common gid exists,
+                    # but no events are created
+                    if not event_times:
+                        event_times.append([])
+
                 # 'events': list (trials) of list (cells) of list (events)
                 self.external_drives[
                     drive['name']]['events'].append(event_times)

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -881,15 +881,21 @@ class Network(object):
                             )
                 else:
                     for this_cell_drive_conn in drive['conn'].values():
-                        for drive_cell_gid in this_cell_drive_conn['src_gids']:
-                            event_ts = _drive_cell_event_times(
+                        has_weight = np.logical_or(
+                            this_cell_drive_conn['ampa'],
+                            this_cell_drive_conn['nmda'])
+
+                        # cell_specific=False should only have one src_gid
+                        if has_weight:
+                            assert len(this_cell_drive_conn['src_gids']) == 1
+                            drive_cell_gid = this_cell_drive_conn[
+                                'src_gids'][0]
+                            event_times.append(_drive_cell_event_times(
                                 drive['type'], this_cell_drive_conn,
                                 drive['dynamics'], trial_idx=trial_idx,
                                 drive_cell_gid=drive_cell_gid,
-                                seedcore=drive['seedcore'])
-                            if event_ts:
-                                event_times.append(event_ts)
-                                break
+                                seedcore=drive['seedcore']))
+                            break
 
                 # 'events': list (trials) of list (cells) of list (events)
                 self.external_drives[

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -881,6 +881,8 @@ class Network(object):
                             )
                 else:
                     for this_cell_drive_conn in drive['conn'].values():
+                        # Only create one set of event times
+                        # Exit on fist target cell type with non-zero weight
                         has_weight = np.logical_or(
                             this_cell_drive_conn['ampa'],
                             this_cell_drive_conn['nmda'])

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -823,7 +823,7 @@ class Network(object):
 
             drive_conn['target_gids'] = list()  # fill in below
             for cellname in target_populations:
-                drive_conn['target_gids'].extend(self.gid_ranges[cellname])
+                drive_conn['target_gids'] = self.gid_ranges[cellname]
                 drive_conn['target_type'] = cellname
                 drive_conn_by_cell[cellname] = drive_conn.copy()
 
@@ -870,17 +870,26 @@ class Network(object):
                 event_times = list()  # new list for each trial and drive
 
                 # loop over drive 'cells' and create event times for each
-                for this_cell_drive_conn in drive['conn'].values():
-                    for drive_cell_gid in this_cell_drive_conn['src_gids']:
-                        event_times.append(_drive_cell_event_times(
-                            drive['type'], this_cell_drive_conn,
-                            drive['dynamics'], trial_idx=trial_idx,
-                            drive_cell_gid=drive_cell_gid,
-                            seedcore=drive['seedcore'])
-                        )
-                    # only create one event_times list for globals
-                    if not drive['cell_specific']:
-                        break  # loop over drive['conn'].values
+                if drive['cell_specific']:
+                    for this_cell_drive_conn in drive['conn'].values():
+                        for drive_cell_gid in this_cell_drive_conn['src_gids']:
+                            event_times.append(_drive_cell_event_times(
+                                drive['type'], this_cell_drive_conn,
+                                drive['dynamics'], trial_idx=trial_idx,
+                                drive_cell_gid=drive_cell_gid,
+                                seedcore=drive['seedcore'])
+                            )
+                else:
+                    for this_cell_drive_conn in drive['conn'].values():
+                        for drive_cell_gid in this_cell_drive_conn['src_gids']:
+                            event_ts = _drive_cell_event_times(
+                                drive['type'], this_cell_drive_conn,
+                                drive['dynamics'], trial_idx=trial_idx,
+                                drive_cell_gid=drive_cell_gid,
+                                seedcore=drive['seedcore'])
+                            if event_ts:
+                                event_times.append(event_ts)
+                                break
 
                 # 'events': list (trials) of list (cells) of list (events)
                 self.external_drives[

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -825,7 +825,7 @@ class Network(object):
             for cellname in target_populations:
                 drive_conn['target_gids'].extend(self.gid_ranges[cellname])
                 drive_conn['target_type'] = cellname
-                drive_conn_by_cell[cellname] = drive_conn
+                drive_conn_by_cell[cellname] = drive_conn.copy()
 
         for cellname in target_populations:
             for receptor, weights in weights_by_receptor.items():

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -884,25 +884,16 @@ class Network(object):
                         # cell_specific=False should only have one src_gid
                         assert len(this_cell_drive_conn['src_gids']) == 1
 
-                        # Only create one set of event times
-                        # Exit on first target cell type with non-zero weight
-                        has_weight = (len(this_cell_drive_conn['ampa']) > 0 or
-                                      len(this_cell_drive_conn['nmda']) > 0)
-
-                        if has_weight:
-                            drive_cell_gid = this_cell_drive_conn[
-                                'src_gids'][0]
-                            event_times.append(_drive_cell_event_times(
-                                drive['type'], this_cell_drive_conn,
-                                drive['dynamics'], trial_idx=trial_idx,
-                                drive_cell_gid=drive_cell_gid,
-                                seedcore=drive['seedcore']))
+                        drive_cell_gid = this_cell_drive_conn[
+                            'src_gids'][0]
+                        event_times = [_drive_cell_event_times(
+                            drive['type'], this_cell_drive_conn,
+                            drive['dynamics'], trial_idx=trial_idx,
+                            drive_cell_gid=drive_cell_gid,
+                            seedcore=drive['seedcore'])]
+                        # only one event_id list for one src_gid
+                        if len(event_times[0]) > 0:
                             break
-
-                # Handles edge case where common gid exists,
-                # but no events are created
-                if len(event_times) == 0:
-                    event_times.append([])
 
                 # 'events': nested list (n_trials x n_drive_cells x n_events)
                 self.external_drives[

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -884,6 +884,8 @@ class Network(object):
                         # cell_specific=False should only have one src_gid
                         assert len(this_cell_drive_conn['src_gids']) == 1
 
+                        # Only return empty event times if all cells have
+                        # no events
                         drive_cell_gid = this_cell_drive_conn[
                             'src_gids'][0]
                         event_times = [_drive_cell_event_times(
@@ -891,7 +893,7 @@ class Network(object):
                             drive['dynamics'], trial_idx=trial_idx,
                             drive_cell_gid=drive_cell_gid,
                             seedcore=drive['seedcore'])]
-                        # only one event_id list for one src_gid
+                        # only one event times list for one src_gid
                         if len(event_times[0]) > 0:
                             break
 

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -117,6 +117,19 @@ def test_add_drives():
     net.add_evoked_drive('early_distal', mu=10, sigma=1, numspikes=1,
                          location='distal')
 
+    # Ensure weights and delays are updated
+    weights_ampa = {'L2_basket': 1.0, 'L2_pyramidal': 3.0,
+                    'L5_basket': 2.0, 'L5_pyramidal': 4.0}
+    syn_delays = {'L2_basket': 1.0, 'L2_pyramidal': 2.0,
+                    'L5_basket': 3.0, 'L5_pyramidal': 4.0}
+    net.add_bursty_drive(
+        'ex_drive', location='distal', burst_rate=10,
+        weights_ampa=weights_ampa, synaptic_delays=syn_delays, seedcore=14)
+
+    for type_name, drive in net.external_drives['ex_drive']['conn'].items():
+        assert drive['ampa']['A_weight'] == weights_ampa[type_name]
+        assert drive['ampa']['A_delay'] == syn_delays[type_name]
+
     # evoked
     with pytest.raises(ValueError,
                        match='Standard deviation cannot be negative'):

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -121,7 +121,7 @@ def test_add_drives():
     weights_ampa = {'L2_basket': 1.0, 'L2_pyramidal': 3.0,
                     'L5_basket': 2.0, 'L5_pyramidal': 4.0}
     syn_delays = {'L2_basket': 1.0, 'L2_pyramidal': 2.0,
-                    'L5_basket': 3.0, 'L5_pyramidal': 4.0}
+                  'L5_basket': 3.0, 'L5_pyramidal': 4.0}
     net.add_bursty_drive(
         'ex_drive', location='distal', burst_rate=10,
         weights_ampa=weights_ampa, synaptic_delays=syn_delays, seedcore=14)

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -123,10 +123,26 @@ def test_add_drives():
     syn_delays = {'L2_basket': 1.0, 'L2_pyramidal': 2.0,
                   'L5_basket': 3.0, 'L5_pyramidal': 4.0}
     net.add_bursty_drive(
-        'ex_drive', location='distal', burst_rate=10,
-        weights_ampa=weights_ampa, synaptic_delays=syn_delays, seedcore=14)
+        'bursty', location='distal', burst_rate=10,
+        weights_ampa=weights_ampa, synaptic_delays=syn_delays)
 
-    for type_name, drive in net.external_drives['ex_drive']['conn'].items():
+    for type_name, drive in net.external_drives['bursty']['conn'].items():
+        assert drive['ampa']['A_weight'] == weights_ampa[type_name]
+        assert drive['ampa']['A_delay'] == syn_delays[type_name]
+
+    net.add_evoked_drive(
+        'evoked', mu=1.0, sigma=1.0, numspikes=1.0, weights_ampa=weights_ampa,
+        location='distal', synaptic_delays=syn_delays)
+
+    for type_name, drive in net.external_drives['evoked']['conn'].items():
+        assert drive['ampa']['A_weight'] == weights_ampa[type_name]
+        assert drive['ampa']['A_delay'] == syn_delays[type_name]
+
+    net.add_poisson_drive(
+        'poisson', rate_constant=1.0, weights_ampa=weights_ampa,
+        location='distal', synaptic_delays=syn_delays)
+
+    for type_name, drive in net.external_drives['poisson']['conn'].items():
         assert drive['ampa']['A_weight'] == weights_ampa[type_name]
         assert drive['ampa']['A_delay'] == syn_delays[type_name]
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -77,7 +77,7 @@ def test_network():
             for kw in ['tstart', 'tstart_std', 'tstop',
                        'burst_rate', 'burst_std', 'numspikes', 'repeats']:
                 assert kw in drive['dynamics'].keys()
-            assert len(drive['events'][0]) == 1
+            assert len(drive['events'][0]) == 2
             n_events = (
                 drive['dynamics']['numspikes'] *  # 2
                 drive['dynamics']['repeats'] *  # 10
@@ -249,7 +249,7 @@ def test_network():
     # Test removing connections from net.connectivity
     # Needs to be updated if number of drives change in preceeding tests
     net.clear_connectivity()
-    assert len(net.connectivity) == 22
+    assert len(net.connectivity) == 18
     net.clear_drives()
     assert len(net.connectivity) == 0
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -77,7 +77,7 @@ def test_network():
             for kw in ['tstart', 'tstart_std', 'tstop',
                        'burst_rate', 'burst_std', 'numspikes', 'repeats']:
                 assert kw in drive['dynamics'].keys()
-            assert len(drive['events'][0]) == 2
+            assert len(drive['events'][0]) == 1
             n_events = (
                 drive['dynamics']['numspikes'] *  # 2
                 drive['dynamics']['repeats'] *  # 10

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -17,11 +17,11 @@ def test_network():
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
     # add rhythmic inputs (i.e., a type of common input)
-    params.update({'input_dist_A_weight_L2Pyr_ampa': 5.4e-5,
-                   'input_dist_A_weight_L5Pyr_ampa': 5.4e-5,
+    params.update({'input_dist_A_weight_L2Pyr_ampa': 1.4e-5,
+                   'input_dist_A_weight_L5Pyr_ampa': 2.4e-5,
                    't0_input_dist': 50,
-                   'input_prox_A_weight_L2Pyr_ampa': 5.4e-5,
-                   'input_prox_A_weight_L5Pyr_ampa': 5.4e-5,
+                   'input_prox_A_weight_L2Pyr_ampa': 3.4e-5,
+                   'input_prox_A_weight_L5Pyr_ampa': 4.4e-5,
                    't0_input_prox': 50})
     net = default_network(deepcopy(params), add_drives_from_params=True)
     network_builder = NetworkBuilder(net)  # needed to populate net.cells
@@ -101,7 +101,12 @@ def test_network():
                       'evprox1': {'L2_basket': 0.08831,
                                   'L5_pyramidal': 0.00865},
                       'evprox2': {'L2_basket': 0.000003,
-                                  'L5_pyramidal': 0.684013}}
+                                  'L5_pyramidal': 0.684013},
+                      'bursty1': {'L2_pyramidal': 0.000034,
+                                  'L5_pyramidal': 0.000044},
+                      'bursty2': {'L2_pyramidal': 0.000014,
+                                  'L5_pyramidal': 0.000024}
+                      }
     for drive_name in target_weights:
         for cellname in target_weights[drive_name]:
             assert_allclose(


### PR DESCRIPTION
Closes #349. Turns out that it was a problem with setting `cell_specific=False` in `net._create_drive_conns`, Since the `drive_conn` dictionary is created prior to looping over cell types, all of the cell types share the same dictionary. Just added a `.copy()` to resolve the issue.