### PR TITLE
[MRG]: Better argument names for add_tonic_bias()

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -137,7 +137,6 @@ People who contributed to this release (in alphabetical order):
 - `Blake Caldwell`_
 - `Christopher Bailey`_
 - `Carmen Kohl`_
-- `Kenneth Loi`_
 - `Mainak Jas`_
 - `Nick Tolley`_
 - `Ryan Thorpe`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,6 +45,8 @@ API
 
 - New API for network creation. The default network is now created with ``net = default_network(params)``, by `Nick Tolley`_ in `#318 <https://github.com/jonescompneurolab/hnn-core/pull/318>`_
 
+- Replace parameter `T` with `tstop` in :func:`~hnn_core.Network.add_tonic_bias` and :func:`~hnn_core.Cell.create_tonic_bias` to be more consistent with other functions and improve readability, by `Kenneth Loi`_ in `#354 <https://github.com/jonescompneurolab/hnn-core/pull/354>`_
+
 .. _0.1:
 
 0.1
@@ -135,6 +137,7 @@ People who contributed to this release (in alphabetical order):
 - `Blake Caldwell`_
 - `Christopher Bailey`_
 - `Carmen Kohl`_
+- `Kenneth Loi`_
 - `Mainak Jas`_
 - `Nick Tolley`_
 - `Ryan Thorpe`_
@@ -144,6 +147,7 @@ People who contributed to this release (in alphabetical order):
 .. _Blake Caldwell: https://github.com/blakecaldwell
 .. _Christopher Bailey: https://github.com/cjayb
 .. _Carmen Kohl: https://github.com/kohl-carmen
+.. _Kenneth Loi: https://github.com/kenloi
 .. _Mainak Jas: http://jasmainak.github.io/
 .. _Nick Tolley: https://github.com/ntolley
 .. _Ryan Thorpe: https://github.com/rythorpe

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,7 +45,7 @@ API
 
 - New API for network creation. The default network is now created with ``net = default_network(params)``, by `Nick Tolley`_ in `#318 <https://github.com/jonescompneurolab/hnn-core/pull/318>`_
 
-- Replace parameter `T` with `tstop` in :func:`~hnn_core.Network.add_tonic_bias` and :func:`~hnn_core.Cell.create_tonic_bias` to be more consistent with other functions and improve readability, by `Kenneth Loi`_ in `#354 <https://github.com/jonescompneurolab/hnn-core/pull/354>`_
+- Parameter `T` replaced with `tstop` in :func:`~hnn_core.Network.add_tonic_bias` and :func:`~hnn_core.Cell.create_tonic_bias` to be more consistent with other functions and improve readability, by `Kenneth Loi`_ in `#354 <https://github.com/jonescompneurolab/hnn-core/pull/354>`_
 
 .. _0.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,7 +45,7 @@ API
 
 - New API for network creation. The default network is now created with ``net = default_network(params)``, by `Nick Tolley`_ in `#318 <https://github.com/jonescompneurolab/hnn-core/pull/318>`_
 
-- Parameter `T` replaced with `tstop` in :func:`~hnn_core.Network.add_tonic_bias` and :func:`~hnn_core.Cell.create_tonic_bias` to be more consistent with other functions and improve readability, by `Kenneth Loi`_ in `#354 <https://github.com/jonescompneurolab/hnn-core/pull/354>`_
+- Replace parameter `T` with `tstop` in :func:`~hnn_core.Network.add_tonic_bias` and :func:`~hnn_core.Cell.create_tonic_bias` to be more consistent with other functions and improve readability, by `Kenneth Loi`_ in `#354 <https://github.com/jonescompneurolab/hnn-core/pull/354>`_
 
 .. _0.1:
 

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -430,7 +430,7 @@ class Cell:
             dpp.ztan = seg_lens_z[-1]
         self.dipole = h.Vector().record(self.dpl_ref)
 
-    def create_tonic_bias(self, amplitude, t0, T, loc=0.5):
+    def create_tonic_bias(self, amplitude, t0, tstop, loc=0.5):
         """Create tonic bias at the soma.
 
         Parameters
@@ -439,14 +439,14 @@ class Cell:
             The amplitude of the input.
         t0 : float
             The start time of tonic input (in ms).
-        T : float
+        tstop : float
             The end time of tonic input (in ms).
         loc : float (0 to 1)
             The location of the input in the soma section.
         """
         stim = h.IClamp(self.sections['soma'](loc))
         stim.delay = t0
-        stim.dur = T - t0
+        stim.dur = tstop - t0
         stim.amp = amplitude
         self.tonic_biases.append(stim)
 

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -141,7 +141,7 @@ def _add_drives_from_params(net):
             cell_type=cellname,
             amplitude=bias_specs['tonic'][cellname]['amplitude'],
             t0=bias_specs['tonic'][cellname]['t0'],
-            T=bias_specs['tonic'][cellname]['T'])
+            tstop=bias_specs['tonic'][cellname]['tstop'])
 
     net._instantiate_drives(n_trials=net._params['N_trials'])
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -887,7 +887,7 @@ class Network(object):
                     drive['name']]['events'].append(event_times)
 
     def add_tonic_bias(self, *, cell_type=None, amplitude=None,
-                       t0=None, T=None):
+                       t0=None, tstop=None):
         """Attach parameters of tonic biasing input for a given cell type.
 
         Parameters
@@ -900,7 +900,7 @@ class Network(object):
         t0 : float
             The start time of tonic input (in ms). Default: 0 (beginning of
             simulation).
-        T : float
+        tstop : float
             The end time of tonic input (in ms). Default: end of simulation.
         """
         if (cell_type is None or amplitude is None):
@@ -913,26 +913,25 @@ class Network(object):
 
         if t0 is None:
             t0 = 0
-        tstop = self.cell_response.times[-1]
-        if T is None:
-            T = tstop
-        if T < 0.:
+        if tstop is None:
+            tstop = self.cell_response.times[-1]
+        if tstop < 0.:
             raise ValueError('End time of tonic input cannot be negative')
-        if T > tstop:
+        if tstop > self.cell_response.times[-1]:
             raise ValueError(f'End time of tonic input cannot exceed '
-                             f'simulation end time {tstop}. Got {T}.')
+                             f'simulation end time {self.cell_response.times[-1]}. Got {tstop}.')
         if cell_type not in self.cell_types:
             raise ValueError(f'cell_type must be one of '
                              f'{list(self.cell_types.keys())}. '
                              f'Got {cell_type}')
-        duration = T - t0
+        duration = tstop - t0
         if duration < 0.:
             raise ValueError('Duration of tonic input cannot be negative')
 
         self.external_biases['tonic'][cell_type] = {
             'amplitude': amplitude,
             't0': t0,
-            'T': T
+            'tstop': tstop
         }
 
     def _update_gid_ranges(self):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -910,7 +910,6 @@ class Network(object):
             self.external_biases['tonic'] = dict()
         if cell_type in self.external_biases['tonic']:
             raise ValueError(f'Tonic bias already defined for {cell_type}')
-
         if t0 is None:
             t0 = 0
         if tstop is None:

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -919,7 +919,8 @@ class Network(object):
         if tstop > self.cell_response.times[-1]:
             raise ValueError(
                 f'End time of tonic input cannot exceed '
-                f'simulation end time {self.cell_response.times[-1]}. Got {tstop}.')
+                f'simulation end time {self.cell_response.times[-1]}. '
+                f'Got {tstop}.')
         if cell_type not in self.cell_types:
             raise ValueError(f'cell_type must be one of '
                              f'{list(self.cell_types.keys())}. '

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -917,8 +917,9 @@ class Network(object):
         if tstop < 0.:
             raise ValueError('End time of tonic input cannot be negative')
         if tstop > self.cell_response.times[-1]:
-            raise ValueError(f'End time of tonic input cannot exceed '
-                             f'simulation end time {self.cell_response.times[-1]}. Got {tstop}.')
+            raise ValueError(
+                f'End time of tonic input cannot exceed '
+                f'simulation end time {self.cell_response.times[-1]}. Got {tstop}.')
         if cell_type not in self.cell_types:
             raise ValueError(f'cell_type must be one of '
                              f'{list(self.cell_types.keys())}. '
@@ -1318,6 +1319,7 @@ class _NetworkDrive(dict):
                     'lamtha': float
                         Space constant
     """
+
     def __repr__(self):
         entr = f"<External drive '{self['name']}'"
         if 'type' in self.keys():

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -139,7 +139,7 @@ def _extract_bias_specs_from_hnn_params(params, cellname_list):
             bias_specs['tonic'][cellname] = {
                 'amplitude': params[f'Itonic_A_{short_name}_soma'],
                 't0': params[f'Itonic_t0_{short_name}_soma'],
-                'T': params[f'Itonic_T_{short_name}_soma']
+                'tstop': params[f'Itonic_T_{short_name}_soma']
             }
     return bias_specs
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -265,17 +265,17 @@ def test_tonic_biases():
     net = hnn_core.Network(params, add_drives_from_params=True)
     with pytest.raises(ValueError, match=r'cell_type must be one of .*$'):
         net.add_tonic_bias(cell_type='name_nonexistent', amplitude=1.0,
-                           t0=0.0, T=4.0)
+                           t0=0.0, tstop=4.0)
 
     with pytest.raises(ValueError, match='Duration of tonic input cannot be'
                        ' negative'):
         net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
-                           t0=5.0, T=4.0)
+                           t0=5.0, tstop=4.0)
 
     with pytest.raises(ValueError, match='End time of tonic input cannot be'
                        ' negative'):
         net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
-                           t0=5.0, T=-1.)
+                           t0=5.0, tstop=-1.)
 
     with pytest.raises(ValueError, match='parameter may be missing'):
         params['Itonic_T_L2Pyr_soma'] = 5.0
@@ -305,6 +305,6 @@ def test_tonic_biases():
     assert 'L5_pyramidal' not in net.external_biases['tonic']
     assert net.external_biases['tonic']['L2_pyramidal']['t0'] == 0
     assert net.external_biases[
-        'tonic']['L2_pyramidal']['T'] == net._params['tstop']
+        'tonic']['L2_pyramidal']['tstop'] == net._params['tstop']
     with pytest.raises(ValueError, match=r'Tonic bias already defined for.*$'):
         net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0)


### PR DESCRIPTION
Closes #347 
For the add_tonic_bias() method in the network class in network.py, I changed the T arg to tstop. In the method, I replaced all the T instances with the new tstop arg.
The _add_drives_from_params(net) function in drives.py calls the add_tonic_bias() method; thus I changed the args to match my changes to add_tonic_bias().
I didn't find any other instances where the add_tonic_bias() method was used so it should be fixed.