### PR TITLE
[MRG] DOC: improve connectivity example

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -24,6 +24,7 @@ help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html-noplot to make standalone HTML files, without plotting anything"
 	@echo "  html       to make standalone HTML files"
+	@echo "  html_dev-pattern to make standalone HTML files for one example dir (dev version)"
 
 .PHONY: clean
 
@@ -43,3 +44,8 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+html_dev-pattern:
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) _build/html
+	@echo
+	@echo "Build finished. The HTML pages are in _build/html"


### PR DESCRIPTION
Some tweaks to the connectivity example and a convenience option in the makefile to build individual files. Just do:

```sh
$ PATTERN=plot_connectivity make html_dev-pattern
```

@ntolley I see:

![image](https://user-images.githubusercontent.com/15852194/122337975-0af0a680-cf0d-11eb-8100-def658d4537d.png)

there is a grayscale colorbar and "Weight" written next to it. Isn't this incorrect? It should be probability? But I'd leave out the colorbar altogether for this kind of plot ...

also the filtering function we talked about would be really useful for a complete API. Then we can imagine doing:

```py
$ net.clear_connectivity(conn_idxs)
```

and then adding a modified connection. That would make this example less contrived I suppose?