### PR TITLE
[MRG] Fix average_dipoles to allow for one trial

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,6 +41,8 @@ Bug
 
 - Fix bug where depth of L5 and L2 cells were swapped, by `Christopher Bailey`_ in `#352 <https://github.com/jonescompneurolab/hnn-core/pull/352>`_
 
+- Fix bug where :func:`~hnn_core.average_dipole` failed when there were less than two dipoles in the input dipole list, by `Kenneth Loi`_ in `#368 <https://github.com/jonescompneurolab/hnn-core/pull/368>`_
+
 API
 ~~~
 - New API for defining cell-cell connections. Custom connections can be added with :func:`~hnn_core.Network.add_connection`, by `Nick Tolley`_ in `#276 <https://github.com/jonescompneurolab/hnn-core/pull/276>`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,7 +41,7 @@ Bug
 
 - Fix bug where depth of L5 and L2 cells were swapped, by `Christopher Bailey`_ in `#352 <https://github.com/jonescompneurolab/hnn-core/pull/352>`_
 
-- Fix bug where :func:`~hnn_core.average_dipole` failed when there were less than two dipoles in the input dipole list, by `Kenneth Loi`_ in `#368 <https://github.com/jonescompneurolab/hnn-core/pull/368>`_
+- Fix bug where average_dipole() failed when there were less than two dipoles in the input dipole list, by `Kenneth Loi`_ in `#368 <https://github.com/jonescompneurolab/hnn-core/pull/368>`_
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,7 +41,7 @@ Bug
 
 - Fix bug where depth of L5 and L2 cells were swapped, by `Christopher Bailey`_ in `#352 <https://github.com/jonescompneurolab/hnn-core/pull/352>`_
 
-- Fix bug where average_dipole() failed when there were less than two dipoles in the input dipole list, by `Kenneth Loi`_ in `#368 <https://github.com/jonescompneurolab/hnn-core/pull/368>`_
+- Fix bug where :func:`~hnn_core.average_dipole` failed when there were less than two dipoles in the input dipole list, by `Kenneth Loi`_ in `#368 <https://github.com/jonescompneurolab/hnn-core/pull/368>`_
 
 API
 ~~~

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -113,7 +113,7 @@ def average_dipoles(dpls):
         average over the same components in the input list
     """
     for dpl_idx, dpl in enumerate(dpls):
-        if not dpls:
+        if not isinstance(dpl, Dipole):
             raise ValueError("Need at least one dipole object to return a"
                              " dipole")
         if dpl.nave > 1:

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -114,8 +114,9 @@ def average_dipoles(dpls):
     """
     for dpl_idx, dpl in enumerate(dpls):
         if not isinstance(dpl, Dipole):
-            raise ValueError("Need at least one dipole object to return a"
-                             " dipole")
+            raise ValueError(
+                f"All elements in the list should be instances of "
+                f"Dipole. Got {type(dpl)}")
         if dpl.nave > 1:
             raise ValueError("Dipole at index %d was already an average of %d"
                              " trials. Cannot reaverage" %

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -112,16 +112,10 @@ def average_dipoles(dpls):
         A new dipole object with each component of `dpl.data` representing the
         average over the same components in the input list
     """
-    # need at least one Dipole to get times
-    if len(dpls) == 1:
-        print('Only one dipole passed in. '
-              'Consider at least two dipole objects to compute an average.')
-        return dpls[0]
-    elif not dpls:
-        raise ValueError("Need at least one dipole object to return a"
-                         " dipole")
-
     for dpl_idx, dpl in enumerate(dpls):
+        if not dpls:
+            raise ValueError("Need at least one dipole object to return a"
+                             " dipole")
         if dpl.nave > 1:
             raise ValueError("Dipole at index %d was already an average of %d"
                              " trials. Cannot reaverage" %

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -113,9 +113,13 @@ def average_dipoles(dpls):
         average over the same components in the input list
     """
     # need at least one Dipole to get times
-    if len(dpls) < 2:
-        raise ValueError("Need at least two dipole object to compute an"
-                         " average")
+    if len(dpls) == 1:
+        print('Only one dipole passed in. '
+              'Consider at least two dipole objects to compute an average.')
+        return dpls[0]
+    elif not dpls:
+        raise ValueError("Need at least one dipole object to return a"
+                         " dipole")
 
     for dpl_idx, dpl in enumerate(dpls):
         if dpl.nave > 1:

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -76,7 +76,6 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     # test postproc
 
     # XXX all below to be deprecated in 0.3
-
     dpls_raw, net = run_hnn_core_fixture(backend='joblib', n_jobs=1,
                                          reduced=True, record_isoma=True,
                                          record_vsoma=True)

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -73,8 +73,6 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     for dpl_key in dpl_avg.data.keys():
         assert_allclose(dpl_1[0].data[dpl_key] / 2., dpl_avg.data[dpl_key])
 
-    # test postproc
-
     # XXX all below to be deprecated in 0.3
     dpls_raw, net = run_hnn_core_fixture(backend='joblib', n_jobs=1,
                                          reduced=True, record_isoma=True,

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -64,6 +64,8 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
             single_dpl_avg.data[dpl_key],
             rtol=0,
             atol=0.000051)
+        np.testing.assert_allclose(dipole_read.data[dpl_key],
+                    single_dpl_avg.data[dpl_key], rtol=0, atol=0.000051)
 
     # average dipole list with one dipole object and a zero dipole object
     n_times = len(dipole_read.data['agg'])
@@ -71,7 +73,8 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     dpl_1 = [dipole, dpl_null]
     dpl_avg = average_dipoles(dpl_1)
     for dpl_key in dpl_avg.data.keys():
-        assert_allclose(dpl_1[0].data[dpl_key] / 2., dpl_avg.data[dpl_key])
+        np.allclose(dpl_1[0].data[dpl_key],
+                    dpl_avg.data[dpl_key])
 
     # test postproc
 

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -59,13 +59,11 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     # average an n_of_1 dipole list
     single_dpl_avg = average_dipoles([dipole])
     for dpl_key in single_dpl_avg.data.keys():
-        assert_allclose((
+        np.testing.assert_allclose(
             dipole_read.data[dpl_key],
             single_dpl_avg.data[dpl_key],
             rtol=0,
             atol=0.000051)
-        np.testing.assert_allclose(dipole_read.data[dpl_key],
-                    single_dpl_avg.data[dpl_key], rtol=0, atol=0.000051)
 
     # average dipole list with one dipole object and a zero dipole object
     n_times = len(dipole_read.data['agg'])

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -71,8 +71,8 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     dpl_1 = [dipole, dpl_null]
     dpl_avg = average_dipoles(dpl_1)
     for dpl_key in dpl_avg.data.keys():
-        np.allclose(dpl_1[0].data[dpl_key],
-                    dpl_avg.data[dpl_key])
+        assert np.allclose([data / 2 for data in dpl_1[0].data[dpl_key]],
+                           dpl_avg.data[dpl_key])
 
     # test postproc
 

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -56,7 +56,27 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
                        "average of 2 trials"):
         dipole_avg = average_dipoles([dipole_avg, dipole_read])
 
+    # average an n_of_1 dipole list
+    single_dpl_avg = average_dipoles([dipole])
+    for dpl_key in single_dpl_avg.data.keys():
+        assert_allclose((
+            dipole_read.data[dpl_key],
+            single_dpl_avg.data[dpl_key],
+            rtol=0,
+            atol=0.000051)
+
+    # average dipole list with one dipole object and a zero dipole object
+    n_times = len(dipole_read.data['agg'])
+    dpl_null = Dipole(np.zeros(n_times, ), np.zeros((n_times, 3)))
+    dpl_1 = [dipole, dpl_null]
+    dpl_avg = average_dipoles(dpl_1)
+    for dpl_key in dpl_avg.data.keys():
+        assert_allclose(dpl_1[0].data[dpl_key] / 2., dpl_avg.data[dpl_key])
+
+    # test postproc
+
     # XXX all below to be deprecated in 0.3
+
     dpls_raw, net = run_hnn_core_fixture(backend='joblib', n_jobs=1,
                                          reduced=True, record_isoma=True,
                                          record_vsoma=True)

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -59,7 +59,7 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     # average an n_of_1 dipole list
     single_dpl_avg = average_dipoles([dipole])
     for dpl_key in single_dpl_avg.data.keys():
-        np.testing.assert_allclose(
+        assert_allclose(
             dipole_read.data[dpl_key],
             single_dpl_avg.data[dpl_key],
             rtol=0,
@@ -71,8 +71,7 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     dpl_1 = [dipole, dpl_null]
     dpl_avg = average_dipoles(dpl_1)
     for dpl_key in dpl_avg.data.keys():
-        assert np.allclose([data / 2 for data in dpl_1[0].data[dpl_key]],
-                           dpl_avg.data[dpl_key])
+        assert_allclose(dpl_1[0].data[dpl_key] / 2., dpl_avg.data[dpl_key])
 
     # test postproc
 


### PR DESCRIPTION
Closes #306
Fixed bug in average_dipoles() function in dipole.py, now allowing for computation of an average even for n_of_1 simulation. I essentially had the function just return the first and only dipole instance in the input parameter dipoles list.

For n_of_1 trials, I decided to also include a message to let users know that when calling an average on a sample size of 1, they should consider simulating at least two trials to properly produce an average.