### PR TITLE
[MRG] check section lengths match L-parameter

### DIFF
--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -325,10 +325,12 @@ class Cell:
             self.sections[sec_name] = sec
 
             h.pt3dclear(sec=sec)
+            h.pt3dconst(0, sec=sec)  # be explicit, see documentation
             for pt in p_secs[sec_name]['sec_pts']:
                 h.pt3dadd(pt[0] + dx,
                           pt[1] + dy,
                           pt[2] + dz, 1, sec=sec)
+            # with pt3dconst==0, these will alter the 3d points defined above!
             sec.L = p_secs[sec_name]['L']
             sec.diam = p_secs[sec_name]['diam']
             sec.Ra = p_secs[sec_name]['Ra']
@@ -350,6 +352,11 @@ class Cell:
             parent_loc = connection[1]
             child_loc = connection[3]
             child_sec.connect(parent_sec, parent_loc, child_loc)
+
+        # be explicit about letting sec.L dominate over the 3d points used by
+        # h.pt3dadd(); see
+        # https://nrn.readthedocs.io/en/latest/python/modelspec/programmatic/topology/geometry.html?highlight=pt3dadd#pt3dadd  # noqa
+        h.define_shape()
 
     def build(self, sec_name_apical=None):
         """Build cell in Neuron and insert dipole if applicable.

--- a/hnn_core/tests/test_cells_default.py
+++ b/hnn_core/tests/test_cells_default.py
@@ -1,7 +1,7 @@
 import pytest
 
 from neuron import h
-from numpy import allclose, abs
+import numpy as np
 
 from hnn_core.cells_default import pyramidal, basket
 from hnn_core.network_builder import load_custom_mechanisms
@@ -27,8 +27,8 @@ def test_cells_default():
                      'apical_tuft']
     for sec_name in vertical_secs:
         sec = l5p.sections[sec_name]
-        vert_len = abs(sec.z3d(1) - sec.z3d(0))
-        assert allclose(vert_len, sec.L)
+        vert_len = np.abs(sec.z3d(1) - sec.z3d(0))
+        assert np.allclose(vert_len, sec.L)
 
     # smoke test to check if cell can be used in simulation
     h.load_file("stdrun.hoc")

--- a/hnn_core/tests/test_cells_default.py
+++ b/hnn_core/tests/test_cells_default.py
@@ -1,6 +1,7 @@
 import pytest
 
 from neuron import h
+from numpy import allclose, abs
 
 from hnn_core.cells_default import pyramidal, basket
 from hnn_core.network_builder import load_custom_mechanisms
@@ -17,6 +18,17 @@ def test_cells_default():
     l5p.build(sec_name_apical='apical_trunk')
     assert len(l5p.sections) == 9
     assert 'apical_2' in l5p.sections
+
+    # check that after building, the vertical sections have the length
+    # specified in get_L5Pyr_params_default (or overriden in a params file).
+    # Note that the lengths implied by _secs_L5Pyr are completely ignored:
+    # NEURON extends the sections as needed to match the sec.L 's
+    vertical_secs = ['basal_1', 'soma', 'apical_trunk', 'apical_1', 'apical_2',
+                     'apical_tuft']
+    for sec_name in vertical_secs:
+        sec = l5p.sections[sec_name]
+        vert_len = abs(sec.z3d(1) - sec.z3d(0))
+        assert allclose(vert_len, sec.L)
 
     # smoke test to check if cell can be used in simulation
     h.load_file("stdrun.hoc")


### PR DESCRIPTION
Closes #330 by adding a test to check `sec.L` matches the difference in `sec.z3d(1) - sec.z3d(0)`.

I added a few lines to `Cell` based on the [NEURON docs for `pt3dadd`](https://nrn.readthedocs.io/en/latest/python/modelspec/programmatic/topology/geometry.html?highlight=pt3dadd#pt3dad):

```python
h.pt3dconst(0, sec=sec)
...
h.define_shape()
```

