### PR TITLE
[MRG] BUG: read_spikes wasn't returning updated CellResponse instance

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,6 +43,8 @@ Bug
 
 - Fix bug where :func:`~hnn_core.average_dipole` failed when there were less than two dipoles in the input dipole list, by `Kenneth Loi`_ in `#368 <https://github.com/jonescompneurolab/hnn-core/pull/368>`_
 
+- Fix bug where :func:`~hnn_core.read_spikes` wasn't returning a :class:`~hnn_core.CellResponse` instance with updated spike types, by `Ryan Thorpe`_ in `#382 <https://github.com/jonescompneurolab/hnn-core/pull/382>`_
+
 API
 ~~~
 - New API for defining cell-cell connections. Custom connections can be added with :func:`~hnn_core.Network.add_connection`, by `Nick Tolley`_ in `#276 <https://github.com/jonescompneurolab/hnn-core/pull/276>`_

--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -456,5 +456,4 @@ def read_spikes(fname, gid_ranges=None):
     if gid_ranges is not None:
         cell_response.update_types(gid_ranges)
 
-    return CellResponse(spike_times=spike_times, spike_gids=spike_gids,
-                        spike_types=spike_types)
+    return cell_response

--- a/hnn_core/tests/test_cell_response.py
+++ b/hnn_core/tests/test_cell_response.py
@@ -146,11 +146,16 @@ def test_cell_response(tmpdir):
         'L2_basket': [[test_rate], [0.0]]}
 
     # Write spike file with no 'types' column
-    # Check for gid_ranges errors
-
     for fname in sorted(glob(str(tmpdir.join('spk_*.txt')))):
         times_gids_only = np.loadtxt(fname, dtype=str)[:, (0, 1)]
         np.savetxt(fname, times_gids_only, delimiter='\t', fmt='%s')
+
+    # Check that spike_types are updated according to gid_ranges
+    cell_response = read_spikes(tmpdir.join('spk_*.txt'),
+                                gid_ranges=gid_ranges)
+    assert cell_response.spike_types == spike_types
+
+    # Check for gid_ranges errors
     with pytest.raises(ValueError, match="gid_ranges must be provided if "
                        "spike types are unspecified in the file "):
         cell_response = read_spikes(tmpdir.join('spk_*.txt'))


### PR DESCRIPTION
Since this is an obvious 1-line fix that allows us to read legacy spk.txt files, unless there are any objections, I don't think we need to add a test here.