### PR TITLE
WIP: Replace simulation time with progress bar

### DIFF
--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -16,6 +16,7 @@ from .cell import _ArtificialCell
 from .params import _long_name, _short_name
 from copy import deepcopy
 from .extracellular import ExtracellularArrayBuilder
+from tqdm import tqdm
 
 # a few globals
 _PC = None
@@ -62,8 +63,10 @@ def _simulate_single_trial(neuron_net, trial_idx):
     h.finitialize()
 
     def simulation_time():
-        print('Simulation time: {0} ms...'.format(round(h.t, 2)))
+        pbar.update(10)
 
+    pbar = tqdm(total=neuron_net.net._params['tstop'], unit='ms',
+                dynamic_ncols=True, desc='Simulation Times')
     if rank == 0:
         for tt in range(0, int(h.tstop), 10):
             _CVODE.event(tt, simulation_time)


### PR DESCRIPTION
After messing with #77, I think it'd be great to rethink how simulation time is updated on screen. It gets pretty unwieldy with all the print statements and is particular rough for jupyter notebooks. I've drafted a pretty quick solution using [tqdm](https://github.com/tqdm/tqdm)
![image](https://user-images.githubusercontent.com/55253912/124538237-48986f00-dde9-11eb-9481-35d3217387fc.png)

This works well for single core simulations, but will require some more thought with MPI/joblib (new progress bars get printed on every update which defeats the purpose).

Let me know what you guys think! If you're ok with this solution (and adding a dependency or new code in `externals`) then I'll keep at this.
