### PR TITLE
DOC: Fixes plot_cells() param doc string by replacing NetworkBuilder with Network

### DIFF
--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -447,7 +447,8 @@ def plot_cells(net, ax=None, show=True):
 
     Parameters
     ----------
-    net : instance of the Network object.
+    net : instance of Network
+        The Network object.
     ax : instance of matplotlib Axes3D | None
         An axis object from matplotlib. If None,
         a new figure is created.

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -447,8 +447,7 @@ def plot_cells(net, ax=None, show=True):
 
     Parameters
     ----------
-    net : instance of NetworkBuilder
-        The NetworkBuilder object.
+    net : instance of the Network object.
     ax : instance of matplotlib Axes3D | None
         An axis object from matplotlib. If None,
         a new figure is created.


### PR DESCRIPTION
Closes #396

https://github.com/jonescompneurolab/hnn-core/blob/40b07726a747c336debfe3a2683ee1607391a75d/hnn_core/viz.py#L450

`plot_cells()` takes the Network object as a param, not the NetworkBuilder. Fixed the docstring to reflect this.