### PR TITLE
[MRG] ptr_update_callback fixes segfaults

### DIFF
--- a/hnn_core/extracellular.py
+++ b/hnn_core/extracellular.py
@@ -513,7 +513,7 @@ class _ExtracellularArrayBuilder(object):
         # contributions of all segments on this rank to total calculated
         # potential at electrode (_PC.allreduce called in _simulate_dipole)
         self._nrn_voltages = h.Vector()
-        self._nrn_imem_vec = h.Vector(self.n_total_segments, 1.)
+        self._nrn_imem_vec = h.Vector(self.n_total_segments)
 
         # Attach a callback for calculating the potentials at each time step.
         # Enables fast calculation of transmembrane current (nA) at each


### PR DESCRIPTION
The gather-method of the PtrVector `_nrn_imem_ptrvec` causes
a segmentation fault when `simulate_dipole(net)` is called
multiple times within the same python/ipython process. This
happens naturally in loops. The Neuron documentation is vague
about the update-method, but other OSS (e.g. NetPyNE) tools
use it.

See discussion in #370 where this bug was identified. Note that I haven't been able to create a test that recreates the segmentation fault using the "reduced" parameter set!