### PR TITLE
[WIP] fix extracellular calculation after `ptr_update_callback`

### DIFF
--- a/hnn_core/extracellular.py
+++ b/hnn_core/extracellular.py
@@ -484,8 +484,6 @@ class _ExtracellularArrayBuilder(object):
         self._nrn_imem_vec = h.Vector(self.n_total_segments)
 
         self._set_imem_pointers_to_ref_i_membrane_()
-        self._nrn_imem_ptrvec.ptr_update_callback(
-            self._set_imem_pointers_to_ref_i_membrane_)
 
         # transfer resistances for each segment (keep in Neuron Matrix object)
         self._nrn_r_transfer = h.Matrix(self.n_contacts,

--- a/hnn_core/extracellular.py
+++ b/hnn_core/extracellular.py
@@ -467,6 +467,8 @@ class _ExtracellularArrayBuilder(object):
             ``'Pyr'``. For basket cells, use ``'Basket'``. NB This argument is
             currently not exposed in the API.
         """
+        from .network_builder import _CVODE
+
         self.secs_on_rank = h.allsec()  # get all h.Sections known to this rank
         _validate_type(include_celltypes, str)
         _check_option('include_celltypes', include_celltypes, ['all', 'Pyr',
@@ -519,7 +521,7 @@ class _ExtracellularArrayBuilder(object):
         # segment. Note that this will run on each rank, so it is safe to use
         # the extra_scatter_gather-method, which docs say doesn't support
         # "multiple threads".
-        cvode.extra_scatter_gather(0, self._calc_potentials_callback)
+        _CVODE.extra_scatter_gather(0, self._calc_potentials_callback)
 
     def _set_imem_pointers_to_ref_i_membrane_(self):
         """Let h.PtrVector.pset point to each segment's _ref_i_membrane_

--- a/hnn_core/extracellular.py
+++ b/hnn_core/extracellular.py
@@ -478,11 +478,10 @@ class _ExtracellularArrayBuilder(object):
         segment_counts = [sec.nseg for sec in self.secs_on_rank]
         self.n_total_segments = np.sum(segment_counts)
 
-        # pointers assigned to _ref_i_membrane_ at each EACH internal segment
-        self._nrn_imem_ptrvec = h.PtrVector(self.n_total_segments)
         # placeholder into which pointer values are read on each sim time step
         self._nrn_imem_vec = h.Vector(self.n_total_segments)
 
+        self._set_imem_pointers_to_ref_i_membrane_()
         self._nrn_imem_ptrvec.ptr_update_callback(
             self._set_imem_pointers_to_ref_i_membrane_)
 
@@ -530,6 +529,9 @@ class _ExtracellularArrayBuilder(object):
         Without it, repeated calls of simulate_dipole will cause segmentation
         faults.
         """
+        # pointers assigned to _ref_i_membrane_ at each EACH internal segment
+        self._nrn_imem_ptrvec = h.PtrVector(self.n_total_segments)
+
         ptr_idx = 0
         for sec in self.secs_on_rank:
             for seg in sec:  # section end points (0, 1) not included

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -16,7 +16,6 @@ if int(__version__[0]) >= 8:
 
 from .cell import _ArtificialCell
 from .params import _long_name, _short_name
-from .extracellular import _ExtracellularArrayBuilder
 
 # a few globals
 _PC = None
@@ -487,6 +486,15 @@ class NetworkBuilder(object):
                         self.ncs[connection_name].append(nc)
 
     def _record_extracellular(self):
+        from hnn_core.extracellular import _ExtracellularArrayBuilder
+
+        for nrn_arr in _LAST_NETWORK._nrn_rec_arrays.values():
+            del nrn_arr._nrn_imem_ptrvec
+            del nrn_arr._nrn_imem_vec
+            del nrn_arr._nrn_r_transfer
+            del nrn_arr._nrn_times
+            del nrn_arr._nrn_voltages
+
         for arr_name, arr in self.net.rec_arrays.items():
             nrn_arr = _ExtracellularArrayBuilder(arr)
             nrn_arr._build(cvode=_CVODE)

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -197,6 +197,9 @@ def test_rec_array_calculation():
     net.add_electrode_array('arr1', electrode_pos)
     _ = simulate_dipole(net, tstop=25, n_trials=1)
 
+    # make sure tests aren't passing just because everything is zero!
+    assert np.any(net.rec_arrays['arr1']._data[0][1])
+
     # test accessing simulated voltages
     assert (len(net.rec_arrays['arr1']) ==
             len(net.rec_arrays['arr1'].voltages) == 1)  # n_trials


### PR DESCRIPTION
The code that lead to segmentation faults is given below (originally by @jasmainak in #370). In this PR we need to figure out why no extracellular potential values are saved after the "fix" made in #401.

Closes #408