### PR TITLE
[MRG] Add probability arguments to drives API

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,6 +65,9 @@ Changelog
 
 - Add method for setting in-plane cell distances and layer separation in the network :func:`~hnn_core.Network.set_cell_positions`, by `Christopher Bailey`_ in `#370 <https://github.com/jonescompneurolab/hnn-core/pull/370>`_
 
+- External drives API now accepts probability argument for targetting subsets of cells, 
+  by `Nick Tolley`_ in :gh:`416`
+
 Bug
 ~~~
 

--- a/examples/howto/plot_firing_pattern.py
+++ b/examples/howto/plot_firing_pattern.py
@@ -42,7 +42,7 @@ synaptic_delays_d1 = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evdist1', mu=63.53, sigma=3.85, numspikes=1, weights_ampa=weights_ampa_d1,
     weights_nmda=weights_nmda_d1, location='distal',
-    synaptic_delays=synaptic_delays_d1, seedcore=4)
+    synaptic_delays=synaptic_delays_d1, event_seed=4)
 
 ###############################################################################
 # The reason it is called an "evoked drive" is it can be used to simulate
@@ -58,7 +58,7 @@ synaptic_delays_prox = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evprox1', mu=26.61, sigma=2.47, numspikes=1, weights_ampa=weights_ampa_p1,
     weights_nmda=None, location='proximal',
-    synaptic_delays=synaptic_delays_prox, seedcore=4)
+    synaptic_delays=synaptic_delays_prox, event_seed=4)
 
 ###############################################################################
 # Now we add the second proximal evoked drive and simulate the network
@@ -70,7 +70,7 @@ weights_ampa_p2 = {'L2_basket': 0.000003, 'L2_pyramidal': 1.438840,
 net.add_evoked_drive(
     'evprox2', mu=137.12, sigma=8.33, numspikes=1,
     weights_ampa=weights_ampa_p2, location='proximal',
-    synaptic_delays=synaptic_delays_prox, seedcore=4)
+    synaptic_delays=synaptic_delays_prox, event_seed=4)
 
 dpls = simulate_dipole(net, tstop=170., record_vsoma=True)
 

--- a/examples/howto/plot_simulate_mpi_backend.py
+++ b/examples/howto/plot_simulate_mpi_backend.py
@@ -36,8 +36,8 @@ net = jones_2009_model()
 weights_ampa = {'L2_pyramidal': 5.4e-5, 'L5_pyramidal': 5.4e-5}
 net.add_bursty_drive(
     'bursty', tstart=50., burst_rate=10, burst_std=20., numspikes=2,
-    spike_isi=10, n_drive_cells=10, location='distal', weights_ampa=weights_ampa,
-    seedcore=8)
+    spike_isi=10, n_drive_cells=10, location='distal',
+    weights_ampa=weights_ampa, event_seed=8)
 
 ###############################################################################
 # Finally, to simulate we use the

--- a/examples/workflows/plot_simulate_alpha.py
+++ b/examples/workflows/plot_simulate_alpha.py
@@ -45,8 +45,8 @@ syn_delays_p = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.}
 
 net.add_bursty_drive(
     'alpha_prox', tstart=50., burst_rate=10, burst_std=burst_std, numspikes=2,
-    spike_isi=10, n_drive_cells=10, location=location, weights_ampa=weights_ampa_p,
-    synaptic_delays=syn_delays_p, seedcore=14)
+    spike_isi=10, n_drive_cells=10, location=location,
+    weights_ampa=weights_ampa_p, synaptic_delays=syn_delays_p, event_seed=14)
 
 # simulate the dipole, but do not automatically scale or smooth the result
 dpl = simulate_dipole(net, tstop=310., n_trials=1)
@@ -94,8 +94,8 @@ weights_ampa_d = {'L2_pyramidal': 5.4e-5, 'L5_pyramidal': 5.4e-5}
 syn_delays_d = {'L2_pyramidal': 5., 'L5_pyramidal': 5.}
 net.add_bursty_drive(
     'alpha_dist', tstart=50., burst_rate=10, burst_std=burst_std, numspikes=2,
-    spike_isi=10, n_drive_cells=10, location=location, weights_ampa=weights_ampa_d,
-    synaptic_delays=syn_delays_d, seedcore=16)
+    spike_isi=10, n_drive_cells=10, location=location,
+    weights_ampa=weights_ampa_d, synaptic_delays=syn_delays_d, event_seed=16)
 
 dpl = simulate_dipole(net, tstop=310., n_trials=1)
 

--- a/examples/workflows/plot_simulate_beta.py
+++ b/examples/workflows/plot_simulate_beta.py
@@ -88,7 +88,7 @@ def add_erp_drives(net, stimulus_start):
     net.add_evoked_drive(
         'evdist1', mu=70.0 + stimulus_start, sigma=0.0, numspikes=1,
         weights_ampa=weights_ampa_d1, weights_nmda=weights_nmda_d1,
-        location='distal', synaptic_delays=syn_delays_d1, seedcore=4)
+        location='distal', synaptic_delays=syn_delays_d1, event_seed=4)
 
     # Two proximal drives
     weights_ampa_p1 = {'L2_basket': 0.002, 'L2_pyramidal': 0.0011,
@@ -100,7 +100,7 @@ def add_erp_drives(net, stimulus_start):
     net.add_evoked_drive(
         'evprox1', mu=25.0 + stimulus_start, sigma=0.0, numspikes=1,
         weights_ampa=weights_ampa_p1, weights_nmda=None,
-        location='proximal', synaptic_delays=syn_delays_prox, seedcore=4)
+        location='proximal', synaptic_delays=syn_delays_prox, event_seed=4)
 
     # Second proximal evoked drive. NB: only AMPA weights differ from first
     weights_ampa_p2 = {'L2_basket': 0.005, 'L2_pyramidal': 0.005,
@@ -109,7 +109,7 @@ def add_erp_drives(net, stimulus_start):
     net.add_evoked_drive(
         'evprox2', mu=135.0 + stimulus_start, sigma=0.0, numspikes=1,
         weights_ampa=weights_ampa_p2, location='proximal',
-        synaptic_delays=syn_delays_prox, seedcore=4)
+        synaptic_delays=syn_delays_prox, event_seed=4)
 
     return net
 
@@ -127,9 +127,9 @@ def add_beta_drives(net, beta_start):
                      'L5_pyramidal': 0.5}
     net.add_bursty_drive(
         'beta_dist', tstart=beta_start, tstart_std=0., tstop=beta_start + 50.,
-        burst_rate=1., burst_std=10., numspikes=2, spike_isi=10, n_drive_cells=10,
-        location='distal', weights_ampa=weights_ampa_d1,
-        synaptic_delays=syn_delays_d1, seedcore=20)
+        burst_rate=1., burst_std=10., numspikes=2, spike_isi=10,
+        n_drive_cells=10, location='distal', weights_ampa=weights_ampa_d1,
+        synaptic_delays=syn_delays_d1, event_seed=20)
 
     # Proximal Drive
     weights_ampa_p1 = {'L2_basket': 0.00004, 'L2_pyramidal': 0.00002,
@@ -139,9 +139,9 @@ def add_beta_drives(net, beta_start):
 
     net.add_bursty_drive(
         'beta_prox', tstart=beta_start, tstart_std=0., tstop=beta_start + 50.,
-        burst_rate=1., burst_std=20., numspikes=2, spike_isi=10, n_drive_cells=10,
-        location='proximal', weights_ampa=weights_ampa_p1,
-        synaptic_delays=syn_delays_p1, seedcore=20)
+        burst_rate=1., burst_std=20., numspikes=2, spike_isi=10,
+        n_drive_cells=10, location='proximal', weights_ampa=weights_ampa_p1,
+        synaptic_delays=syn_delays_p1, event_seed=20)
 
     return net
 

--- a/examples/workflows/plot_simulate_evoked.py
+++ b/examples/workflows/plot_simulate_evoked.py
@@ -61,7 +61,7 @@ synaptic_delays_d1 = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evdist1', mu=63.53, sigma=3.85, numspikes=1, weights_ampa=weights_ampa_d1,
     weights_nmda=weights_nmda_d1, location='distal',
-    synaptic_delays=synaptic_delays_d1, seedcore=4)
+    synaptic_delays=synaptic_delays_d1, event_seed=4)
 
 ###############################################################################
 # Then, we add two proximal drives
@@ -73,7 +73,7 @@ synaptic_delays_prox = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evprox1', mu=26.61, sigma=2.47, numspikes=1, weights_ampa=weights_ampa_p1,
     weights_nmda=None, location='proximal',
-    synaptic_delays=synaptic_delays_prox, seedcore=4)
+    synaptic_delays=synaptic_delays_prox, event_seed=4)
 
 # Second proximal evoked drive. NB: only AMPA weights differ from first
 weights_ampa_p2 = {'L2_basket': 0.000003, 'L2_pyramidal': 1.438840,
@@ -82,7 +82,7 @@ weights_ampa_p2 = {'L2_basket': 0.000003, 'L2_pyramidal': 1.438840,
 net.add_evoked_drive(
     'evprox2', mu=137.12, sigma=8.33, numspikes=1,
     weights_ampa=weights_ampa_p2, location='proximal',
-    synaptic_delays=synaptic_delays_prox, seedcore=4)
+    synaptic_delays=synaptic_delays_prox, event_seed=4)
 
 ###############################################################################
 # Now let's simulate the dipole, running 2 trials with the

--- a/examples/workflows/plot_simulate_gamma.py
+++ b/examples/workflows/plot_simulate_gamma.py
@@ -51,7 +51,8 @@ synaptic_delays = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.0}
 rate_constant = {'L2_pyramidal': 140.0, 'L5_pyramidal': 40.0}
 net.add_poisson_drive(
     'poisson', rate_constant=rate_constant, weights_ampa=weights_ampa,
-    location='proximal', synaptic_delays=synaptic_delays, seedcore=1079)
+    location='proximal', synaptic_delays=synaptic_delays,
+    event_seed=1079)
 
 ###############################################################################
 dpls = simulate_dipole(net, tstop=250.)

--- a/examples/workflows/plot_simulate_somato.py
+++ b/examples/workflows/plot_simulate_somato.py
@@ -171,7 +171,8 @@ synaptic_delays_p = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evprox1', mu=21., sigma=4., numspikes=1, location='proximal',
     n_drive_cells=1, cell_specific=False, weights_ampa=weights_ampa_p,
-    weights_nmda=weights_nmda_p, synaptic_delays=synaptic_delays_p, seedcore=6)
+    weights_nmda=weights_nmda_p, synaptic_delays=synaptic_delays_p,
+    event_seed=6)
 
 # Late proximal drive
 weights_ampa_p = {'L2_basket': 0.003, 'L2_pyramidal': 0.0039,
@@ -184,7 +185,8 @@ synaptic_delays_p = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evprox2', mu=134., sigma=4.5, numspikes=1, location='proximal',
     n_drive_cells=1, cell_specific=False, weights_ampa=weights_ampa_p,
-    weights_nmda=weights_nmda_p, synaptic_delays=synaptic_delays_p, seedcore=5)
+    weights_nmda=weights_nmda_p, synaptic_delays=synaptic_delays_p,
+    event_seed=5)
 
 # Early distal drive
 weights_ampa_d = {'L2_basket': 0.0043, 'L2_pyramidal': 0.0032,
@@ -197,7 +199,8 @@ synaptic_delays_d = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evdist1', mu=32., sigma=2.5, numspikes=1, location='distal',
     n_drive_cells=1, cell_specific=False, weights_ampa=weights_ampa_d,
-    weights_nmda=weights_nmda_d, synaptic_delays=synaptic_delays_d, seedcore=5)
+    weights_nmda=weights_nmda_d, synaptic_delays=synaptic_delays_d,
+    event_seed=5)
 
 # Late distal drive
 weights_ampa_d = {'L2_basket': 0.0041, 'L2_pyramidal': 0.0019,
@@ -210,7 +213,8 @@ synaptic_delays_d = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evdist2', mu=84., sigma=4.5, numspikes=1, location='distal',
     n_drive_cells=1, cell_specific=False, weights_ampa=weights_ampa_d,
-    weights_nmda=weights_nmda_d, synaptic_delays=synaptic_delays_d, seedcore=2)
+    weights_nmda=weights_nmda_d, synaptic_delays=synaptic_delays_d,
+    event_seed=2)
 
 ###############################################################################
 # Now we run the simulation over 2 trials so that we can plot the average

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -56,7 +56,7 @@ def simulate_dipole(net, tstop, dt=0.025, n_trials=None, record_vsoma=False,
         raise ValueError("Invalid number of simulations: %d" % n_trials)
 
     if not net.connectivity:
-        raise Warning('No connections instantiated in network. Consider using'
+        raise Warning('No connections instantiated in network. Consider using '
                       'net = jones_2009_model() or net = law_2021_model() to '
                       'create a predefined network from published models.')
 

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -55,6 +55,11 @@ def simulate_dipole(net, tstop, dt=0.025, n_trials=None, record_vsoma=False,
     if n_trials < 1:
         raise ValueError("Invalid number of simulations: %d" % n_trials)
 
+    if not net.connectivity:
+        raise Warning('No connections instantiated in network. Consider using'
+                      'net = jones_2009_model() or net = law_2021_model() to '
+                      'create a predefined network from published models.')
+
     for drive_name, drive in net.external_drives.items():
         if 'tstop' in drive['dynamics']:
             if drive['dynamics']['tstop'] is None:

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -11,7 +11,7 @@ from .params import (_extract_bias_specs_from_hnn_params,
 
 
 def _get_target_properties(weights_ampa, weights_nmda, synaptic_delays,
-                           location):
+                           location, probability=1.0):
     """Retrieve drive properties associated with each target cell type
 
     Note that target cell types of a drive are inferred from the synaptic
@@ -54,7 +54,20 @@ def _get_target_properties(weights_ampa, weights_nmda, synaptic_delays,
                          'types defined in weights_ampa and weights_nmda '
                          f'({target_populations})')
 
-    return target_populations, weights_by_type, delays_by_type
+    if isinstance(probability, float):
+        probability_by_type = {cell_type: probability for cell_type in
+                               target_populations}
+    else:
+        probability_by_type = probability.copy()
+
+    if set(probability_by_type.keys()) != target_populations:
+        raise ValueError('probability is either a common float or needs '
+                         'to be specified as a dict for each of the cell '
+                         'types defined in weights_ampa and weights_nmda '
+                         f'({target_populations})')
+
+    return (target_populations, weights_by_type, delays_by_type,
+            probability_by_type)
 
 
 def _check_drive_parameter_values(drive_type, **kwargs):

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -128,7 +128,7 @@ def _add_drives_from_params(net):
                 cell_specific=specs['cell_specific'],
                 weights_ampa=specs['weights_ampa'],
                 weights_nmda=specs['weights_nmda'],
-                location=specs['location'], seedcore=specs['seedcore'],
+                location=specs['location'], event_seed=specs['event_seed'],
                 synaptic_delays=specs['synaptic_delays'],
                 space_constant=specs['space_constant'])
         elif specs['type'] == 'poisson':
@@ -138,7 +138,7 @@ def _add_drives_from_params(net):
                 rate_constant=specs['dynamics']['rate_constant'],
                 weights_ampa=specs['weights_ampa'],
                 weights_nmda=specs['weights_nmda'],
-                location=specs['location'], seedcore=specs['seedcore'],
+                location=specs['location'], event_seed=specs['event_seed'],
                 synaptic_delays=specs['synaptic_delays'],
                 space_constant=specs['space_constant'])
         elif specs['type'] == 'gaussian':
@@ -148,7 +148,7 @@ def _add_drives_from_params(net):
                 numspikes=specs['dynamics']['numspikes'],
                 weights_ampa=specs['weights_ampa'],
                 weights_nmda=specs['weights_nmda'],
-                location=specs['location'], seedcore=specs['seedcore'],
+                location=specs['location'], event_seed=specs['event_seed'],
                 synaptic_delays=specs['synaptic_delays'],
                 space_constant=specs['space_constant'])
         elif specs['type'] == 'bursty':
@@ -168,7 +168,7 @@ def _add_drives_from_params(net):
                 location=specs['location'],
                 space_constant=specs['space_constant'],
                 synaptic_delays=specs['synaptic_delays'],
-                seedcore=specs['seedcore'])
+                event_seed=specs['event_seed'])
 
     # add tonic biases if present in params
     for cellname in bias_specs['tonic']:
@@ -215,7 +215,7 @@ def _get_prng(seed, gid, sync_evinput=False):
 
 
 def _drive_cell_event_times(drive_type, dynamics, tstop, target_type='any',
-                            trial_idx=0, drive_cell_gid=0, seedcore=0):
+                            trial_idx=0, drive_cell_gid=0, event_seed=0):
     """Generate event times for one artificial drive cell based on dynamics.
 
     Parameters
@@ -238,7 +238,7 @@ def _drive_cell_event_times(drive_type, dynamics, tstop, target_type='any',
         The index number of the current trial of a simulation (default=1).
     drive_cell_gid : int
         Optional gid of current artificial cell (used for seeding)
-    seedcore : int
+    event_seed : int
         Optional initial seed for random number generator.
 
     Returns
@@ -246,7 +246,7 @@ def _drive_cell_event_times(drive_type, dynamics, tstop, target_type='any',
     event_times : list
         The event times at which spikes occur.
     """
-    prng, prng2 = _get_prng(seed=seedcore + trial_idx,
+    prng, prng2 = _get_prng(seed=event_seed + trial_idx,
                             gid=drive_cell_gid)
 
     # check drive name validity, allowing substring matches

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -525,8 +525,8 @@ class Network(object):
             plane (delays are modulated by the inverse of this factor).
         probability : dict or float (default: 1.0)
             Probability of connection between any src-target pair.
-            Use dict to create delay->cell mapping. If float, applies to all
-            target cell types
+            Use dict to create probability->cell mapping. If float, applies to
+            all target cell types
         event_seed : int
             Optional initial seed for random number generator (default: 2).
             Used to generate event times for drive cells.
@@ -612,8 +612,8 @@ class Network(object):
             plane.
         probability : dict or float (default: 1.0)
             Probability of connection between any src-target pair.
-            Use dict to create delay->cell mapping. If float, applies to all
-            target cell types.
+            Use dict to create probability->cell mapping. If float, applies to
+            all target cell types.
         event_seed : int
             Optional initial seed for random number generator (default: 2).
             Used to generate event times for drive cells.
@@ -719,8 +719,8 @@ class Network(object):
             plane.
         probability : dict or float (default: 1.0)
             Probability of connection between any src-target pair.
-            Use dict to create delay->cell mapping. If float, applies to all
-            target cell types.
+            Use dict to create probability->cell mapping. If float, applies to
+            all target cell types.
         event_seed : int
             Optional initial seed for random number generator (default: 2).
             Used to generate event times for drive cells.
@@ -799,8 +799,8 @@ class Network(object):
             target in the network.
         probability : dict or float (default: 1.0)
             Probability of connection between any src-target pair.
-            Use dict to create delay->cell mapping. If float, applies to all
-            target cell types
+            Use dict to create probability->cell mapping. If float, applies to
+            all target cell types
 
         Attached drive is stored in self.external_drives[name]
         self.pos_dict is updated, and self._update_gid_ranges() called

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -523,9 +523,10 @@ class Network(object):
             ``exp(-(x / (3 * inplane_distance)) ** 2)``, where x is the
             physical distance (in um) between the connected cells in the xy
             plane (delays are modulated by the inverse of this factor).
-        probability : float
+        probability : dict or float (default: 1.0)
             Probability of connection between any src-target pair.
-            Defaults to 1.0 producing an all-to-all pattern.
+            Use dict to create delay->cell mapping. If float, applies to all
+            target cell types
         event_seed : int
             Optional initial seed for random number generator (default: 2).
             Used to generate event times for drive cells.
@@ -609,9 +610,10 @@ class Network(object):
             ``exp(-(x / (3 * inplane_distance)) ** 2)``, where ``x`` is the
             physical distance (in um) between the connected cells in the xy
             plane.
-        probability : float
+        probability : dict or float (default: 1.0)
             Probability of connection between any src-target pair.
-            Defaults to 1.0 producing an all-to-all pattern.
+            Use dict to create delay->cell mapping. If float, applies to all
+            target cell types.
         event_seed : int
             Optional initial seed for random number generator (default: 2).
             Used to generate event times for drive cells.
@@ -715,9 +717,10 @@ class Network(object):
             ``exp(-(x / (3 * inplane_distance)) ** 2)``, where ``x`` is the
             physical distance (in um) between the connected cells in the xy
             plane.
-        probability : float
+        probability : dict or float (default: 1.0)
             Probability of connection between any src-target pair.
-            Defaults to 1.0 producing an all-to-all pattern.
+            Use dict to create delay->cell mapping. If float, applies to all
+            target cell types.
         event_seed : int
             Optional initial seed for random number generator (default: 2).
             Used to generate event times for drive cells.
@@ -794,9 +797,10 @@ class Network(object):
             connectivity requires that n_drive_cells='n_cells', where 'n_cells'
             denotes the number of all available cells that this drive can
             target in the network.
-        probability : float
+        probability : dict or float (default: 1.0)
             Probability of connection between any src-target pair.
-            Defaults to 1.0 producing an all-to-all pattern.
+            Use dict to create delay->cell mapping. If float, applies to all
+            target cell types
 
         Attached drive is stored in self.external_drives[name]
         self.pos_dict is updated, and self._update_gid_ranges() called

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -530,9 +530,23 @@ class Network(object):
         event_seed : int
             Optional initial seed for random number generator (default: 2).
             Used to generate event times for drive cells.
+            Not fixed across trials (see Notes)
         conn_seed : int
             Optional initial seed for random number generator (default: 3).
             Used to randomly remove connections when probablity < 1.0.
+            Fixed across trials (see Notes)
+
+        Notes
+        -----
+        Random seeding behavior across trials is different for event_seed
+        and conn_seed (n_trials > 1 in simulate_dipole(..., n_trials)
+        event_seed
+            Across trials, the random seed is incremented leading such that
+            the exact spike times are different
+        conn_seed
+            The random seed does not change across trials. This means for
+            probability < 1.0, the random subset of gids targeted is the same.
+
         """
         if not self._legacy_mode:
             _check_drive_parameter_values('evoked', sigma=sigma,

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -923,6 +923,7 @@ class Network(object):
                         lamtha=space_constant, probability=probability,
                         conn_seed=drive['conn_seed'] + seed_increment)
                     # Ensure that AMPA/NMDA connections target the same gids
+                    # when probability < 1
                     if receptor_idx > 0:
                         self.connectivity[-1]['src_gids'] = \
                             self.connectivity[-2]['src_gids']

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -806,10 +806,14 @@ class Network(object):
         if location not in ['distal', 'proximal']:
             raise ValueError("Allowed drive target locations are: 'distal', "
                              f"and 'proximal', got {location}")
+
+        _validate_type(
+            probability, (float, dict), 'probability', 'float or dict')
         # allow passing weights as None, convert to dict here
-        target_populations, weights_by_type, delays_by_type = \
+        (target_populations, weights_by_type, delays_by_type,
+         probability_by_type) = \
             _get_target_properties(weights_ampa, weights_nmda, synaptic_delays,
-                                   location)
+                                   location, probability)
 
         # weights passed must correspond to cells in the network
         if not target_populations.issubset(set(self.cell_types.keys())):
@@ -825,6 +829,8 @@ class Network(object):
                     weights_by_type.update({target_type: {'ampa': 0.}})
                 if target_type not in delays_by_type:
                     delays_by_type.update({target_type: 0.1})
+                if target_type not in probability_by_type:
+                    probability_by_type.update({target_type: 1.0})
         elif len(target_populations) == 0:
             raise ValueError('No target populations have been specified for '
                              'this drive.')
@@ -863,6 +869,7 @@ class Network(object):
         for target_cell_type in target_populations:
             target_gids = list(self.gid_ranges[target_cell_type])
             delays = delays_by_type[target_cell_type]
+            probability = probability_by_type[target_cell_type]
             if cell_specific:
                 target_gids_nested = [[target_gid] for
                                       target_gid in target_gids]

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -307,7 +307,7 @@ def add_erp_drives_to_jones_model(net, tstart=0.0):
     net.add_evoked_drive(
         'evdist1', mu=63.53 + tstart, sigma=3.85, numspikes=1,
         weights_ampa=weights_ampa_d1, weights_nmda=weights_nmda_d1,
-        location='distal', synaptic_delays=synaptic_delays_d1, seedcore=4)
+        location='distal', synaptic_delays=synaptic_delays_d1, event_seed=4)
 
     # Add proximal drives
     weights_ampa_p1 = {'L2_basket': 0.08831, 'L2_pyramidal': 0.01525,
@@ -317,11 +317,11 @@ def add_erp_drives_to_jones_model(net, tstart=0.0):
     net.add_evoked_drive(
         'evprox1', mu=26.61 + tstart, sigma=2.47, numspikes=1,
         weights_ampa=weights_ampa_p1, weights_nmda=None, location='proximal',
-        synaptic_delays=synaptic_delays_prox, seedcore=4)
+        synaptic_delays=synaptic_delays_prox, event_seed=4)
 
     weights_ampa_p2 = {'L2_basket': 0.000003, 'L2_pyramidal': 1.438840,
                        'L5_basket': 0.008958, 'L5_pyramidal': 0.684013}
     net.add_evoked_drive(
         'evprox2', mu=137.12 + tstart, sigma=8.33, numspikes=1,
         weights_ampa=weights_ampa_p2, location='proximal',
-        synaptic_delays=synaptic_delays_prox, seedcore=4)
+        synaptic_delays=synaptic_delays_prox, event_seed=4)

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -166,7 +166,7 @@ def _extract_drive_specs_from_hnn_params(params, cellname_list):
                              'spike_isi': 10}  # not exposed in params-files
         drive['location'] = par['loc']
         drive['space_constant'] = par['lamtha']
-        drive['seedcore'] = par['prng_seedcore']
+        drive['event_seed'] = par['prng_seedcore']
         drive['weights_ampa'] = dict()
         drive['weights_nmda'] = dict()
         drive['synaptic_delays'] = dict()
@@ -220,7 +220,7 @@ def _extract_drive_specs_from_hnn_params(params, cellname_list):
             # XXX Force random states to be the same as HNN-gui for the default
             # parameter set after increasing the number of bursty drive
             # gids from 2 to 20
-            drive['seedcore'] = par['prng_seedcore'] - 18
+            drive['event_seed'] = par['prng_seedcore'] - 18
             for cellname in cellname_list:
                 if cellname in par:
                     ampa_weight = par[cellname][0]
@@ -239,7 +239,7 @@ def _extract_drive_specs_from_hnn_params(params, cellname_list):
                                  'numspikes': 50,  # NB hard-coded in GUI!
                                  'sync_within_trial': False}
             drive['space_constant'] = par['lamtha']
-            drive['seedcore'] = par['prng_seedcore']
+            drive['event_seed'] = par['prng_seedcore']
 
             for cellname in cellname_list:
                 if cellname in par:
@@ -253,7 +253,7 @@ def _extract_drive_specs_from_hnn_params(params, cellname_list):
             drive['type'] = 'poisson'
             drive['location'] = par['loc']
             drive['space_constant'] = par['lamtha']
-            drive['seedcore'] = par['prng_seedcore']
+            drive['event_seed'] = par['prng_seedcore']
 
             rate_params = dict()
             for cellname in cellname_list:

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -124,17 +124,19 @@ def test_dipole_simulation():
                         record_isoma=0)
 
     # test Network.copy() returns 'bare' network after simulating
+    dpl = simulate_dipole(net, tstop=25., n_trials=1)[0]
+    net_copy = net.copy()
+    assert len(net_copy.external_drives['evprox1']['events']) == 0
+
+    # test that Dipole.copy() returns the expected exact copy
+    assert_allclose(dpl.data['agg'], dpl.copy().data['agg'])
+
     with pytest.raises(Warning, match='No connections'):
-        dpl = simulate_dipole(net, tstop=25., n_trials=1)[0]
-        net_copy = net.copy()
-        assert len(net_copy.external_drives['evprox1']['events']) == 0
-
-        # test that Dipole.copy() returns the expected exact copy
-        assert_allclose(dpl.data['agg'], dpl.copy().data['agg'])
-
-        # Test raster plot with no spikes
         net = Network(params)
+        # warning triggered on simulate_dipole()
         simulate_dipole(net, tstop=0.1, n_trials=1)
+
+        # Smoke test for raster plot with no spikes
         net.cell_response.plot_spikes_raster()
 
 

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -124,17 +124,18 @@ def test_dipole_simulation():
                         record_isoma=0)
 
     # test Network.copy() returns 'bare' network after simulating
-    dpl = simulate_dipole(net, tstop=25., n_trials=1)[0]
-    net_copy = net.copy()
-    assert len(net_copy.external_drives['evprox1']['events']) == 0
+    with pytest.raises(Warning, match='No connections'):
+        dpl = simulate_dipole(net, tstop=25., n_trials=1)[0]
+        net_copy = net.copy()
+        assert len(net_copy.external_drives['evprox1']['events']) == 0
 
-    # test that Dipole.copy() returns the expected exact copy
-    assert_allclose(dpl.data['agg'], dpl.copy().data['agg'])
+        # test that Dipole.copy() returns the expected exact copy
+        assert_allclose(dpl.data['agg'], dpl.copy().data['agg'])
 
-    # Test raster plot with no spikes
-    net = Network(params)
-    simulate_dipole(net, tstop=0.1, n_trials=1)
-    net.cell_response.plot_spikes_raster()
+        # Test raster plot with no spikes
+        net = Network(params)
+        simulate_dipole(net, tstop=0.1, n_trials=1)
+        net.cell_response.plot_spikes_raster()
 
 
 @requires_mpi4py

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -359,33 +359,39 @@ def test_add_drives():
                               rate_constant=10.,
                               weights_ampa={'L2_pyramidal': 1.},
                               synaptic_delays={'L5_pyramidal': 1.})
-    with pytest.raises(ValueError, match='probability must be'):
+    with pytest.raises(ValueError,
+                       match=r'probability must be in the range \(0\,1\)'):
         net.add_bursty_drive(
             'cell_unknown', location='distal', burst_rate=10,
             weights_ampa={'L2_pyramidal': 1.},
             synaptic_delays={'L2_pyramidal': 1.}, probability=2.0)
 
-    with pytest.raises(TypeError, match='probability must be'):
+    with pytest.raises(TypeError, match="probability must be an instance of "
+                       r"float or dict, got \<class 'str'\> instead"):
         net.add_bursty_drive(
             'cell_unknown2', location='distal', burst_rate=10,
             weights_ampa={'L2_pyramidal': 1.},
             synaptic_delays={'L2_pyramidal': 1.}, probability='1.0')
 
-    with pytest.raises(ValueError, match='probability is either'):
+    with pytest.raises(ValueError, match='probability is either a common '
+                       'float or needs to be specified as a dict for '
+                       'each of the cell'):
         net.add_bursty_drive(
             'cell_unknown2', location='distal', burst_rate=10,
             weights_ampa={'L2_pyramidal': 1.},
             synaptic_delays={'L2_pyramidal': 1.},
             probability={'L5_pyramidal': 1.})
 
-    with pytest.raises(TypeError, match='probability must be'):
+    with pytest.raises(TypeError, match="probability must be an instance of "
+                       r"float, got \<class 'str'\> instead"):
         net.add_bursty_drive(
             'cell_unknown2', location='distal', burst_rate=10,
             weights_ampa={'L2_pyramidal': 1.},
             synaptic_delays={'L2_pyramidal': 1.},
             probability={'L2_pyramidal': '1.0'})
 
-    with pytest.raises(ValueError, match='probability must be'):
+    with pytest.raises(ValueError,
+                       match=r'probability must be in the range \(0\,1\)'):
         net.add_bursty_drive(
             'cell_unknown3', location='distal', burst_rate=10,
             weights_ampa={'L2_pyramidal': 1.},

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -190,6 +190,8 @@ def test_add_drives():
             conn = net.connectivity[conn_idx]
             num_connections = np.sum(
                 [len(gids) for gids in conn['gid_pairs'].values()])
+            # Ensures that AMPA and NMDA connections target the same gids.
+            # Necessary when weights of both are non-zero.
             assert gid_pairs_comparison == conn['gid_pairs']
             assert num_connections == \
                 np.around(len(net.gid_ranges[cell_type]) * n_drive_cells *

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -464,6 +464,9 @@ def test_network():
     net.clear_drives()
     assert len(net.connectivity) == 0
 
+    with pytest.raises(Warning, match='No connections'):
+        simulate_dipole(net, tstop=10)
+
 
 def test_add_cell_type():
     """Test adding a new cell type."""

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -335,7 +335,7 @@ def test_network():
         ('target_gids', 35.0), ('target_gids', [35.0]),
         ('target_gids', [[35], [36.0]]), ('loc', 1.0),
         ('receptor', 1.0), ('weight', '1.0'), ('delay', '1.0'),
-        ('lamtha', '1.0'), ('probability', '0.5')]
+        ('lamtha', '1.0'), ('probability', '0.5'), ('allow_autapses', 1.0)]
     for arg, item in kwargs_bad:
         match = ('must be an instance of')
         with pytest.raises(TypeError, match=match):

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -89,7 +89,8 @@ def test_dipole_visualization():
     net.add_bursty_drive(
         'beta_prox', tstart=0., burst_rate=25, burst_std=5,
         numspikes=1, spike_isi=0, n_drive_cells=11, location='proximal',
-        weights_ampa=weights_ampa_p, synaptic_delays=syn_delays_p, seedcore=14)
+        weights_ampa=weights_ampa_p, synaptic_delays=syn_delays_p,
+        event_seed=14)
 
     dpls = simulate_dipole(net, tstop=100., n_trials=2)
     fig = dpls[0].plot()  # plot the first dipole alone


### PR DESCRIPTION
Closes #410. Thanks to #369, this task is quite straightforward. The goal of this PR is to add a probability argument to the drives API, such that `net.add_evoked_drive(..., probability=0.5)` randomly removes half the drive connections, and only a subset are actually targeted by the drive. Additionally, the probability argument should also accept a dictionary which specifies probabilities for each individual connection (same was the weight and delay arguments).

After completing this, I think the final task for fully merging the drives and connection API's is enabling the manual targeting of `target_gids`, but let's leave that as a topic of discussion for the upcoming retreat ;).