### PR TITLE
[MRG] Add warnings for invalid connections

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,10 @@ Changelog
   by `Mattan Pelah`_ in :gh:`492`.
 
 - Add interface to modify attributes of sections in
- :func:`~hnn_core.Cell.modify_section`, by `Nick Tolley`_ in :gh:`481`
+  :func:`~hnn_core.Cell.modify_section`, by `Nick Tolley`_ in :gh:`481`
+
+ - Add ability to target specific sections when adding drives or connections,
+   by `Nick Tolley`_ in :gh:`419`
 
 Bug
 ~~~

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -11,7 +11,6 @@ import itertools as it
 from copy import deepcopy
 
 import numpy as np
-from numpy.testing._private.utils import raises
 
 from .drives import _drive_cell_event_times
 from .drives import _get_target_properties, _add_drives_from_params
@@ -1175,34 +1174,12 @@ class Network(object):
         _validate_type(loc, str, 'loc')
         _validate_type(receptor, str, 'receptor')
 
-        valid_loc = list(self.cell_types[target_type].p_secs.keys())
-        for item in self.cell_types[target_type].sect_loc.values():
-            valid_loc.extend(item)
-
-        valid_loc = list(set(valid_loc))
-        # Separation ecessary to identify valid receptors
-        if loc in self.cell_types[target_type].sect_loc and \
-                self.cell_types[target_type].sect_loc[loc]:
-            sect_list = self.cell_types[target_type].sect_loc[loc]
-        elif loc in self.cell_types[target_type].p_secs:
-            sect_list = [loc]
-        else:
-            raise ValueError(
-                f"The loc '{loc}' is not defined for '{target_type}' "
-                f"cells. Valid locations include {valid_loc}")
-
+        valid_loc = ['proximal', 'distal', 'soma']
+        _check_option('loc', loc, valid_loc)
         conn['loc'] = loc
 
-        valid_receptors = set(np.concatenate([
-            self.cell_types[target_type].p_secs[sect_name]['syns'] for
-            sect_name in sect_list]))
-
-        if receptor not in valid_receptors:
-            raise ValueError(
-                f"The receptor'{receptor}' is not defined for the loc '{loc}'"
-                f" on '{target_type}' cells. Valid receptors include"
-                f"{valid_receptors}")
-
+        valid_receptor = ['ampa', 'nmda', 'gabaa', 'gabab']
+        _check_option('receptor', receptor, valid_receptor)
         conn['receptor'] = receptor
 
         # Create and validate nc_dict

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -493,7 +493,9 @@ class Network(object):
             Target location of synapses. Must be an element of
             `Cell.sect_loc` such as 'proximal' or 'distal', which defines a
             group of sections, or an existing section such as 'soma' or
-            'apical_tuft' (defined in `Cell.sections` for all targeted cells)
+            'apical_tuft' (defined in `Cell.sections` for all targeted cells).
+            The parameter `legacy_mode` of the `Network` must be set to `False`
+            to target specific sections.
         n_drive_cells : int | 'n_cells'
             The number of drive cells that each contribute an independently
             sampled synaptic spike to the network according to the Gaussian
@@ -599,7 +601,9 @@ class Network(object):
             Target location of synapses. Must be an element of
             `Cell.sect_loc` such as 'proximal' or 'distal', which defines a
             group of sections, or an existing section such as 'soma' or
-            'apical_tuft' (defined in `Cell.sections` for all targeted cells)
+            'apical_tuft' (defined in `Cell.sections` for all targeted cells).
+            The parameter `legacy_mode` of the `Network` must be set to `False`
+            to target specific sections.
         n_drive_cells : int | 'n_cells'
             The number of drive cells that each contribute an independently
             sampled synaptic spike to the network according to a Poisson
@@ -704,7 +708,9 @@ class Network(object):
             Target location of synapses. Must be an element of
             `Cell.sect_loc` such as 'proximal' or 'distal', which defines a
             group of sections, or an existing section such as 'soma' or
-            'apical_tuft' (defined in `Cell.sections` for all targeted cells)
+            'apical_tuft' (defined in `Cell.sections` for all targeted cells).
+            The parameter `legacy_mode` of the `Network` must be set to `False`
+            to target specific sections.
         burst_rate : float
             The mean rate at which cyclic bursts occur (unit: Hz)
         burst_std : float
@@ -801,7 +807,12 @@ class Network(object):
             Synaptic weights (in uS) of NMDA receptors on each targeted cell
             type (dict keys). Cell types omitted from the dict are set to zero.
         location : str
-            Target location of synapses ('distal' or 'proximal')
+            Target location of synapses. Must be an element of
+            `Cell.sect_loc` such as 'proximal' or 'distal', which defines a
+            group of sections, or an existing section such as 'soma' or
+            'apical_tuft' (defined in `Cell.sections` for all targeted cells).
+            The parameter `legacy_mode` of the `Network` must be set to `False`
+            to target specific sections.
         space_constant : float
             Describes lateral dispersion (from the column origin) of synaptic
             weights and delays within the simulated column. The constant is
@@ -1095,10 +1106,12 @@ class Network(object):
             equivalent to passing a list of gids for the relevant cell type.
             source - target connections are made in an all-to-all pattern.
         loc : str
-            Location of synapse on target cell. Must be an element of
+            Target location of synapses. Must be an element of
             `Cell.sect_loc` such as 'proximal' or 'distal', which defines a
             group of sections, or an existing section such as 'soma' or
-            'apical_tuft' (defined in `Cell.sections`)
+            'apical_tuft' (defined in `Cell.sections` for all targeted cells).
+            The parameter `legacy_mode` of the `Network` must be set to `False`
+            to target specific sections.
         receptor : str
             Synaptic receptor of connection. Must be one of:
             'ampa', 'nmda', 'gabaa', or 'gabab'.

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -840,19 +840,6 @@ class Network(object):
         if name in self.external_drives:
             raise ValueError(f"Drive {name} already defined")
 
-        # cell_sections = [set(self.cell_types[cell_type].sections.keys()) for
-        #                  cell_type in drive['target_types']]
-        # sect_locs = [set(self.cell_types[cell_type].sect_loc.keys()) for
-        #              cell_type in drive['target_types']]
-
-        # valid_cell_sections = set.intersection(*cell_sections)
-        # valid_sect_locs = set.intersection(*sect_locs)
-        # valid_loc = list(valid_cell_sections) + list(valid_sect_locs)
-
-        # _check_option('location', location, valid_loc,
-        #               extra=(f" (the location '{location}' is not defined "
-        #                      "for one of the targeted cells)"))
-
         _validate_type(
             probability, (float, dict), 'probability', 'float or dict')
         # allow passing weights as None, convert to dict here

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -495,9 +495,11 @@ class NetworkBuilder(object):
 
                     # get synapse locations
                     syn_keys = list()
-                    if loc in ['proximal', 'distal']:
+                    # Targeting group of sections like proximal or distal
+                    if loc in target_cell.sect_loc:
                         for sect in target_cell.sect_loc[loc]:
                             syn_keys.append(f'{sect}_{receptor}')
+                    # Targeting individual section like soma or apical_tuft
                     else:
                         syn_keys = [f'{loc}_{receptor}']
 

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -11,7 +11,8 @@ from .cells_default import pyramidal_ca
 from .externals.mne import _validate_type
 
 
-def jones_2009_model(params=None, add_drives_from_params=False):
+def jones_2009_model(params=None, add_drives_from_params=False,
+                     legacy_mode=True):
     """Instantiate the Jones et al. 2009 model.
 
     Parameters
@@ -24,6 +25,9 @@ def jones_2009_model(params=None, add_drives_from_params=False):
         If True, add drives as defined in the params-dict. NB this is mainly
         for backward-compatibility with HNN GUI, and will be deprecated in a
         future release. Default: False
+    legacy_mode : bool
+        Set to True by default to enable matching HNN GUI output when drives
+        are added suitably. Will be deprecated in a future release.
 
     Returns
     -------
@@ -45,7 +49,8 @@ def jones_2009_model(params=None, add_drives_from_params=False):
     if isinstance(params, str):
         params = read_params(params)
 
-    net = Network(params, add_drives_from_params=add_drives_from_params)
+    net = Network(params, add_drives_from_params=add_drives_from_params,
+                  legacy_mode=legacy_mode)
 
     delay = net.delay
 
@@ -159,7 +164,8 @@ def jones_2009_model(params=None, add_drives_from_params=False):
     return net
 
 
-def law_2021_model(params=None, add_drives_from_params=False):
+def law_2021_model(params=None, add_drives_from_params=False,
+                   legacy_mode=True):
     """Instantiate the beta modulated ERP network model.
 
     Returns
@@ -237,7 +243,8 @@ def law_2021_model(params=None, add_drives_from_params=False):
 
 # Remove params argument after updating examples
 # (only relevant for Jones 2009 model)
-def calcium_model(params=None, add_drives_from_params=False):
+def calcium_model(params=None, add_drives_from_params=False,
+                  legacy_mode=True):
     """Instantiate the Jones 2009 model with improved calcium dynamics.
 
     Returns

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -461,10 +461,8 @@ def test_network():
     assert pick_connection(
         net, src_gids='L2_pyramidal', receptor='gabab') == list()
     assert pick_connection(
-        net, src_gids='L2_basket', receptor='ampa') == list()
-    assert pick_connection(
         net, src_gids='L2_basket', target_gids='L2_basket',
-        loc='proximal', receptor='ampa') == list()
+        loc='proximal', receptor='nmda') == list()
     assert pick_connection(
         net, src_gids='L2_pyramidal', target_gids='L2_basket',
         loc='distal', receptor='gabab') == list()

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -362,6 +362,28 @@ def test_network():
             kwargs[arg] = string_arg
             net.add_connection(**kwargs)
 
+    # Test warnings for undefined loc
+    with pytest.raises(
+        ValueError,
+        match=r"The loc \'distal\' is not defined for L5_basket"
+              r"cells. Valid locations include \[\'soma\'\]"):
+        kwargs = kwargs_default.copy()
+        kwargs['target_gids'] = 'L5_basket'
+        kwargs['loc'] = 'distal'
+        net.add_connection(**kwargs)
+
+    # Test warnings for undefined synapse for specific loc
+    with pytest.raises(
+        ValueError,
+        match=r"The receptor \'ampa\' is not defined for the loc \'soma\'"
+              r" on \'L5_pyramidal\' cells. Valid receptors include "
+              r"\[\'gabaa\', \'gabab\'\]"):
+        kwargs = kwargs_default.copy()
+        kwargs['target_gids'] = 'L5_pyramidal'
+        kwargs['loc'] = 'soma'
+        kwargs['receptor'] = 'ampa'
+        net.add_connection(**kwargs)
+
     # Check probability=0.5 produces half as many connections as default
     net.add_connection(**kwargs_default)
     kwargs = kwargs_default.copy()

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -362,28 +362,6 @@ def test_network():
             kwargs[arg] = string_arg
             net.add_connection(**kwargs)
 
-    # Test warnings for undefined loc
-    with pytest.raises(
-        ValueError,
-        match=r"The loc \'distal\' is not defined for L5_basket"
-              r"cells. Valid locations include \[\'soma\'\]"):
-        kwargs = kwargs_default.copy()
-        kwargs['target_gids'] = 'L5_basket'
-        kwargs['loc'] = 'distal'
-        net.add_connection(**kwargs)
-
-    # Test warnings for undefined synapse for specific loc
-    with pytest.raises(
-        ValueError,
-        match=r"The receptor \'ampa\' is not defined for the loc \'soma\'"
-              r" on \'L5_pyramidal\' cells. Valid receptors include "
-              r"\[\'gabaa\', \'gabab\'\]"):
-        kwargs = kwargs_default.copy()
-        kwargs['target_gids'] = 'L5_pyramidal'
-        kwargs['loc'] = 'soma'
-        kwargs['receptor'] = 'ampa'
-        net.add_connection(**kwargs)
-
     # Check probability=0.5 produces half as many connections as default
     net.add_connection(**kwargs_default)
     kwargs = kwargs_default.copy()


### PR DESCRIPTION
This PR adds checks inside `net.add_connection` to ensure the valid `loc`, `receptor`, `target_type` combinations are specified. Depending on the definition of the cell, certain combinations will break during `simulate_dipole`. For example, pyramidal cells do not have `ampa` synapses so if the user accidentally defines one with `net.add_connection`, then the simulation will break.

While writing this I am realizing there are some issues with how things are organized internally. At the moment we support `proximal`, `distal`, and `soma` as valid location arguments. However, `soma` is handled a bit strangely since it is not defined in the `sect_loc` attribute but still passes as a valid location because it has defined synapses:
https://github.com/jonescompneurolab/hnn-core/blob/4fde7c6f3058cba1fdef96469aa7c86c9d7940f2/hnn_core/cells_default.py#L289

This brings up an important question, should we allow targeting of locations with more precision? For example `loc='apical_1'`. It would be fairly easy to allow, and may make adding to `network_models.py` easier with that sort of flexibility.
