### PR TITLE
[MRG] allow multiple extracellular simulations in single python process

### DIFF
--- a/hnn_core/extracellular.py
+++ b/hnn_core/extracellular.py
@@ -523,7 +523,7 @@ class _ExtracellularArrayBuilder(object):
 
         # NB we must make a copy of the function reference, and keep it for
         # later decoupling using extra_scatter_gather_remove
-        # (instead of a new function the reference)
+        # (instead of a new function reference)
         self._recording_callback = self._gather_nrn_voltages
         # Nb extra_scatter_gather is called _after_ the solver takes a step,
         # so the initial state is not recorded (initialised to zero above)

--- a/hnn_core/extracellular.py
+++ b/hnn_core/extracellular.py
@@ -559,7 +559,7 @@ class _ExtracellularArrayBuilder(object):
             raise RuntimeError('Simulation not yet run!')
 
 
-def _calc_potentials_callback(nrn_arr):
+def _gather_nrn_voltages(nrn_arr):
     """Callback function for _CVODE.extra_scatter_gather
 
     Enables fast calculation of transmembrane current (nA) at each

--- a/hnn_core/extracellular.py
+++ b/hnn_core/extracellular.py
@@ -445,8 +445,9 @@ class _ExtracellularArrayBuilder(object):
         self._nrn_r_transfer = None
         self._nrn_times = None
         self._nrn_voltages = None
+        self._recording_callback = None
 
-    def _build(self, include_celltypes='all'):
+    def _build(self, cvode=None, include_celltypes='all'):
         """Assemble NEURON objects for calculating extracellular potentials.
 
         The handler is set up to maintain a vector of membrane currents at at
@@ -517,14 +518,34 @@ class _ExtracellularArrayBuilder(object):
         # contributions of all segments on this rank to total calculated
         # potential at electrode (_PC.allreduce called in _simulate_dipole)
         self._nrn_voltages = h.Vector()
-        # NB the vector is only initialised here: a separate callback-function
-        # must be attached to the _CVODE (extra_scatter_gather), which
-        # will append the summed potential of each electrode at each time step.
-        # The callback-function is included in this file (below), but must
-        # be called in network_builder during the actual simulation (including
-        # the callback as a method of the present class lead to segmentation
-        # violations when simulate_dipole was called multiple times in the same
-        # python process; extra_scatter_gather_remove did not work)
+
+        # NB we must make a copy of the function reference, and keep it for
+        # later decoupling using extra_scatter_gather_remove
+        # (instead of a new function the reference)
+        self._recording_callback = self._gather_nrn_voltages
+        cvode.extra_scatter_gather(0, self._recording_callback)
+
+    def _gather_nrn_voltages(self):
+        """Callback function for _CVODE.extra_scatter_gather
+
+        Enables fast calculation of transmembrane current (nA) at each
+        segment. Note that this will run on each rank, so it is safe to use
+        the extra_scatter_gather-method, which docs say doesn't support
+        'multiple threads'.
+        """
+        # keep all data in Neuron objects for efficiency
+
+        # 'gather' the values of seg.i_membrane_ into self.imem_vec
+        self._nrn_imem_ptrvec.gather(self._nrn_imem_vec)
+
+        # Calculate potentials by multiplying the _nrn_imem_vec by the matrix
+        # _nrn_r_transfer. This is equivalent to a row-by-row dot-product:
+        # V_i(t) = SUM_j ( R_i,j x I_j (t) )
+        self._nrn_voltages.append(
+            self._nrn_r_transfer.mulv(self._nrn_imem_vec))
+        # NB all values appended to the h.Vector _nrn_voltages at current time
+        # step. The vector will have size (n_contacts x n_samples, 1), which
+        # will be reshaped later to (n_contacts, n_samples).
 
     @property
     def _nrn_n_samples(self):
@@ -557,26 +578,3 @@ class _ExtracellularArrayBuilder(object):
             return self._nrn_times.to_python()[:self._nrn_n_samples]
         else:
             raise RuntimeError('Simulation not yet run!')
-
-
-def _gather_nrn_voltages(nrn_arr):
-    """Callback function for _CVODE.extra_scatter_gather
-
-    Enables fast calculation of transmembrane current (nA) at each
-    segment. Note that this will run on each rank, so it is safe to use
-    the extra_scatter_gather-method, which docs say doesn't support
-    'multiple threads'.
-    """
-    # keep all data in Neuron objects for efficiency
-
-    # 'gather' the values of seg.i_membrane_ into self.imem_vec
-    nrn_arr._nrn_imem_ptrvec.gather(nrn_arr._nrn_imem_vec)
-
-    # Calculate potentials by multiplying the _nrn_imem_vec by the matrix
-    # _nrn_r_transfer. This is equivalent to a row-by-row dot-product:
-    # V_i(t) = SUM_j ( R_i,j x I_j (t) )
-    nrn_arr._nrn_voltages.append(
-        nrn_arr._nrn_r_transfer.mulv(nrn_arr._nrn_imem_vec))
-    # NB all values appended to the h.Vector _nrn_voltages at current time
-    # step. The vector will have size (n_contacts x n_samples, 1), which
-    # will be reshaped later to (n_contacts, n_samples).

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -504,7 +504,7 @@ class NetworkBuilder(object):
                         self.ncs[connection_name].append(nc)
 
     def _record_extracellular(self):
-        from .extracellular import _calc_potentials_callback
+        from .extracellular import _gather_nrn_voltages
 
         for arr_name, arr in self.net.rec_arrays.items():
             nrn_arr = _ExtracellularArrayBuilder(arr)
@@ -513,7 +513,7 @@ class NetworkBuilder(object):
 
             # Attach a callback for calculating the potentials at each time
             # step. Keep the callbacks in a list so they can be removed later.
-            recording_callback = (_calc_potentials_callback, nrn_arr)
+            recording_callback = (_gather_nrn_voltages, nrn_arr)
             _CVODE.extra_scatter_gather(0, recording_callback)
             self._nrn_rec_callbacks.append(recording_callback)
 

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -6,7 +6,6 @@ import os.path as op
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
-from time import time
 
 import hnn_core
 from hnn_core import read_params, jones_2009_model, simulate_dipole

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -203,11 +203,11 @@ def test_rec_array_calculation():
         start_time = time()
         _ = simulate_dipole(net, tstop=25, n_trials=1)
         run_times.append(time() - start_time)
-        # choice of 5% increase arbitrary
-        if (run_times[-1] - run_times[0]) / run_times[0] > 0.05:
-            raise RuntimeError('Repeated simulations increase in time spent; '
-                               'check for pointer leaks in extracellular '
-                               'potential calculation callback')
+        # choice of 50% increase arbitrary (heuristic)
+        if (run_times[-1] - run_times[0]) / run_times[0] > 0.50:
+            raise RuntimeError('Time for repeated simulations increases '
+                               'greatly; check for pointer leaks in '
+                               'extracellular potential calculation callback')
 
     # test accessing simulated voltages
     assert (len(net.rec_arrays['arr1']) ==

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -195,7 +195,7 @@ def test_rec_array_calculation():
     # one electrode inside, one above the active elements of the network
     electrode_pos = [(1.5, 1.5, 1000), (1.5, 1.5, 3000)]
     net.add_electrode_array('arr1', electrode_pos)
-    _ = simulate_dipole(net, tstop=25, n_trials=1)
+    _ = simulate_dipole(net, tstop=5, n_trials=1)
 
     # test accessing simulated voltages
     assert (len(net.rec_arrays['arr1']) ==
@@ -216,7 +216,7 @@ def test_rec_array_calculation():
 
     # make sure no sinister segfaults are triggered when running mult. trials
     n_trials = 5  # NB 5 trials!
-    _ = simulate_dipole(net, tstop=25, n_trials=n_trials)
+    _ = simulate_dipole(net, tstop=5, n_trials=n_trials)
 
     # simulate_dipole is run twice above, first 1 then 5 trials.
     # Make sure that previous results are discarded on each run

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -196,18 +196,7 @@ def test_rec_array_calculation():
     # one electrode inside, one above the active elements of the network
     electrode_pos = [(1.5, 1.5, 1000), (1.5, 1.5, 3000)]
     net.add_electrode_array('arr1', electrode_pos)
-    # run a single trial multiple times in this python process to ensure
-    # nothing funky happens with potential calculation callback (cf. #409)
-    run_times = list()
-    for _ in range(5):
-        start_time = time()
-        _ = simulate_dipole(net, tstop=25, n_trials=1)
-        run_times.append(time() - start_time)
-        # choice of 50% increase arbitrary (heuristic)
-        if (run_times[-1] - run_times[0]) / run_times[0] > 0.50:
-            raise RuntimeError('Time for repeated simulations increases '
-                               'greatly; check for pointer leaks in '
-                               'extracellular potential calculation callback')
+    _ = simulate_dipole(net, tstop=25, n_trials=1)
 
     # test accessing simulated voltages
     assert (len(net.rec_arrays['arr1']) ==


### PR DESCRIPTION
This fixes the issues met in #370 #401 #408 related to extracellular potential calculations, where repeated simulations in the same python process caused segmentation violations.

The test in  c8f60aa fails in `master` because the buggy implementation causes the simulation time to start to creep. The 5% limit is quite strict and may need to be relaxed (leading to a longer test time). I could not generate segfaults on less-than-complete networks, so this was the best compromise I could come up with. EDIT: **this will be removed as it's not a unit test**. However, the code demonstrates a simple way to catch the underlying problem.

~The fix in  b6ee4fc just moves the callback-function out of the `_ExtracellularArrayBuilder` class/object. Now `extra_scatter_gather` and `extra_scatter_gather_remove` are called in `network_builder`, giving the built array as argument. I haven't tested performance or memory hits, but didn't notice anything getting dramatically slower.~

The core issue turned out to be that `extra_scatter_gather_remove` needs to be passed the same _reference_ to the callback function as got `extra_scatter_gather`. Calling `foo = self._method` repeatedly creates a _new_ reference every time, which is what tripped us. The _proper_ fix is to have each `_ExtracellularArrayBuilder` object store the callback reference passed to `extra_scatter_gather`. This is then `_remove`d in the cleanup phase of `NetworkBuilder` (after `_PC.allreduce` in case of MPI jobs). e8125d0

Supersedes #409 (can be closed)