### PR TITLE
[MRG] remove cells from the Network class

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,7 +17,7 @@ Changelog
 - Store all connectivity information under :attr:`~hnn_core.Network.connectivity` before building
   the network, by `Nick Tolley`_ in :gh:`276`
 
-- Add new function :func:`~hnn_core.viz.plot_cell_morphology` to visualize cell morphology, 
+- Add new function :func:`~hnn_core.viz.plot_cell_morphology` to visualize cell morphology,
   by `Mainak Jas`_ in :gh:`319`
 
 - Compute dipole component in z-direction automatically from cell morphology instead of hard coding,
@@ -68,7 +68,7 @@ Changelog
 Bug
 ~~~
 
-- Remove rounding error caused by repositioning of NEURON cell sections, by `Mainak Jas`_ 
+- Remove rounding error caused by repositioning of NEURON cell sections, by `Mainak Jas`_
   and `Ryan Thorpe`_ in :gh:`314`
 
 - Fix issue where common drives use the same parameters for all cell types, by `Nick Tolley`_
@@ -129,7 +129,8 @@ API
 - Target cell types and their connections are created for each drive according to the synaptic weight
   and delay dictionaries assigned in ``Network.add_xxx_drive()``, by `Ryan Thorpe`_ in :gh:`369`
 
-- Cell objects can no longer be accessed from :class:`~hnn_core.Network` as the :attr:`~hnn_core.Network.cells` attribute has been removed, by `Ryan Thorpe`_ in `#436 <https://github.com/jonescompneurolab/hnn-core/pull/436>`_
+- Cell objects can no longer be accessed from :class:`~hnn_core.Network` as the
+  :attr:`~hnn_core.Network.cells` attribute has been removed, by `Ryan Thorpe`_ in :gh:`436`
 
 .. _0.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -129,6 +129,8 @@ API
 - Target cell types and their connections are created for each drive according to the synaptic weight
   and delay dictionaries assigned in ``Network.add_xxx_drive()``, by `Ryan Thorpe`_ in :gh:`369`
 
+- Cell objects can no longer be accessed from :class:`~hnn_core.Network` as the :attr:`~hnn_core.Network.cells` attribute has been removed, by `Ryan Thorpe`_ in `#436 <https://github.com/jonescompneurolab/hnn-core/pull/436>`_
+
 .. _0.1:
 
 0.1

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -302,9 +302,6 @@ class Network(object):
         Dictionary containing the coordinate positions of all cells.
         Keys are 'L2_pyramidal', 'L5_pyramidal', 'L2_basket', 'L5_basket',
         or any external drive name
-    cells : list of Cell objects.
-        The list of cells of the network, each containing features used in a
-        NEURON simulation.
     cell_response : CellResponse
         An instance of the CellResponse object.
     external_drives : dict (keys: drive names) of dict (keys: parameters)
@@ -968,20 +965,6 @@ class Network(object):
     def gid_to_type(self, gid):
         """Reverse lookup of gid to type."""
         return _gid_to_type(gid, self.gid_ranges)
-
-    def _gid_to_cell(self, gid):
-        """Reverse lookup of gid to cell.
-
-        Returns None if not a cell; should only be called after self.cells is
-        populated.
-        """
-        src_type = self.gid_to_type(gid)
-        if src_type not in self.cell_types:
-            cell = None
-        else:
-            type_pos_ind = gid - self.gid_ranges[src_type][0]
-            cell = self.cells[src_type][type_pos_ind]
-        return cell
 
     def add_connection(self, src_gids, target_gids, loc, receptor,
                        weight, delay, lamtha, allow_autapses=True,

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -372,7 +372,7 @@ class Network(object):
 
         # contents of pos_dict determines all downstream inferences of
         # cell counts, real and artificial
-        self.n_cells = 0
+        self._n_cells = 0  # currently only used for tests
         self.pos_dict = dict()
         self.cell_types = dict()
 
@@ -960,7 +960,7 @@ class Network(object):
         self.pos_dict[cell_name] = pos
         if cell_template is not None:
             self.cell_types.update({cell_name: cell_template})
-            self.n_cells += len(pos)
+            self._n_cells += len(pos)
 
     def gid_to_type(self, gid):
         """Reverse lookup of gid to type."""

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -364,7 +364,7 @@ class NetworkBuilder(object):
             n_hosts = _get_nhosts()
 
         # round robin assignment of cell gids
-        for gid in range(self._rank, self.net.n_cells, n_hosts):
+        for gid in range(self._rank, self.net._n_cells, n_hosts):
             self._gid_list.append(gid)
 
         for drive in self.net.external_drives.values():

--- a/hnn_core/tests/conftest.py
+++ b/hnn_core/tests/conftest.py
@@ -5,6 +5,7 @@ https://pytest.org/en/stable/example/simple.html#incremental-testing-test-steps
 
 from typing import Dict, Tuple
 import pytest
+import pickle
 
 import os.path as op
 import hnn_core
@@ -110,6 +111,9 @@ def run_hnn_core_fixture():
             dpls = simulate_dipole(net, record_vsoma=record_isoma,
                                    record_isoma=record_vsoma,
                                    postproc=postproc, tstop=tstop)
+
+        # check that the network object is picklable after the simulation
+        pickle.dumps(net)
 
         # number of trials simulated
         for drive in net.external_drives.values():

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -143,7 +143,7 @@ def test_network():
     # instantiate drive events for NetworkBuilder
     net._instantiate_drives(tstop=params['tstop'],
                             n_trials=params['N_trials'])
-    network_builder = NetworkBuilder(net)  # needed to populate net.cells
+    network_builder = NetworkBuilder(net)  # needed to instantiate cells
 
     # Assert that params are conserved across Network initialization
     for p in params:

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -253,9 +253,9 @@ def test_network():
     # Assert that all external drives are initialized
     # Assumes legacy mode where cell-specific drives create artificial cells
     # for all network cells regardless of connectivity
-    n_evoked_sources = 3 * net.n_cells
-    n_pois_sources = net.n_cells
-    n_gaus_sources = net.n_cells
+    n_evoked_sources = 3 * net._n_cells
+    n_pois_sources = net._n_cells
+    n_gaus_sources = net._n_cells
     n_bursty_sources = (net.external_drives['bursty1']['n_drive_cells'] +
                         net.external_drives['bursty2']['n_drive_cells'])
     # test that expected number of external driving events are created
@@ -264,10 +264,10 @@ def test_network():
                                                  n_gaus_sources +
                                                  n_bursty_sources)
     assert len(network_builder._gid_list) ==\
-        len(network_builder._drive_cells) + net.n_cells
+        len(network_builder._drive_cells) + net._n_cells
     # first 'evoked drive' comes after real cells and bursty drive cells
     assert network_builder._drive_cells[n_bursty_sources].gid ==\
-        net.n_cells + n_bursty_sources
+        net._n_cells + n_bursty_sources
 
     # Assert that netcons are created properly
     n_pyr = len(net.gid_ranges['L2_pyramidal'])
@@ -471,7 +471,7 @@ def test_add_cell_type():
     net._instantiate_drives(tstop=params['tstop'],
                             n_trials=params['N_trials'])
 
-    n_total_cells = net.n_cells
+    n_total_cells = net._n_cells
     pos = [(0, idx, 0) for idx in range(10)]
     tau1 = 0.6
 
@@ -486,7 +486,7 @@ def test_add_cell_type():
                        lamtha=2)
 
     network_builder = NetworkBuilder(net)
-    assert net.n_cells == n_total_cells + len(pos)
+    assert net._n_cells == n_total_cells + len(pos)
     n_basket = len(net.gid_ranges['L2_basket'])
     n_connections = n_basket * n_new_type
     assert len(network_builder.ncs['L2Basket_new_type_gabaa']) == n_connections


### PR DESCRIPTION
Issues arose due to the fact that simulations that attach Neuron objects (in `Network.cells`) to a `Network` instance can't be passed back to the user or instantiated a second time (i.e., when running serial simulations on the same network instance) when parallelizing across multiple processes or jobs. This fixes the problem by removing `Network.cells` altogether.

closes #432
closes #434