### PR TITLE
[MRG] minor optimization workflow issues

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -28,8 +28,16 @@ Bug
 
 - Negative ``event_seed`` is no longer allowed by `Mainak Jas`_ in :gh:`462`.
 
+- Evoked drive optimization no longer assigns a default timing sigma value to
+  a drive if it is not already specified, by `Ryan Thorpe`_ in :gh:`446`.
+
 API
 ~~~
+- Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`
+  template model by passing a :class:`~hnn_core.Network` instance directly into
+  :func:`~hnn_core.optimization.optimize_evoked`. Simulations run during 
+  optimization can now consist of multiple trials over which the simulated
+  dipole is averaged, by `Ryan Thorpe`_ in :gh:`446`.
 
 .. _0.2:
 

--- a/examples/howto/optimize_evoked.py
+++ b/examples/howto/optimize_evoked.py
@@ -69,7 +69,7 @@ with MPIBackend(n_procs=n_procs):
 from hnn_core.optimization import optimize_evoked
 
 with MPIBackend(n_procs=n_procs):
-    net_opt = optimize_evoked(net.copy(), tstop=tstop, n_trials=1,
+    net_opt = optimize_evoked(net, tstop=tstop, n_trials=1,
                               target_dpl=exp_dpl, initial_dpl=initial_dpl,
                               scale_factor=scale_factor,
                               smooth_window_len=smooth_window_len)

--- a/examples/howto/optimize_evoked.py
+++ b/examples/howto/optimize_evoked.py
@@ -69,14 +69,15 @@ with MPIBackend(n_procs=n_procs):
 from hnn_core.optimization import optimize_evoked
 
 with MPIBackend(n_procs=n_procs):
-    net_opt_drives = optimize_evoked(net.copy(), exp_dpl, initial_dpl,
-                                     scale_factor=scale_factor,
-                                     smooth_window_len=smooth_window_len)
+    net_opt = optimize_evoked(net.copy(), tstop=tstop, n_trials=1,
+                              target_dpl=exp_dpl, initial_dpl=initial_dpl,
+                              scale_factor=scale_factor,
+                              smooth_window_len=smooth_window_len)
 
 ###############################################################################
 # Now, let's simulate the dipole with the optimized drive parameters.
 with MPIBackend(n_procs=n_procs):
-    best_dpl = simulate_dipole(net_opt_drives, tstop=tstop, n_trials=1)[0]
+    best_dpl = simulate_dipole(net_opt, tstop=tstop, n_trials=1)[0]
     best_dpl = best_dpl.scale(scale_factor).smooth(smooth_window_len)
 
 ###############################################################################
@@ -95,4 +96,4 @@ exp_dpl.plot(ax=axes[0], layer='agg', show=False)
 initial_dpl.plot(ax=axes[0], layer='agg', show=False)
 best_dpl.plot(ax=axes[0], layer='agg', show=False)
 axes[0].legend(['experimental', 'initial', 'optimized'])
-net_opt_drives.cell_response.plot_spikes_hist(ax=axes[1])
+net_opt.cell_response.plot_spikes_hist(ax=axes[1])

--- a/examples/howto/optimize_evoked.py
+++ b/examples/howto/optimize_evoked.py
@@ -69,8 +69,8 @@ with MPIBackend(n_procs=n_procs):
 from hnn_core.optimization import optimize_evoked
 
 with MPIBackend(n_procs=n_procs):
-    params_optim = optimize_evoked(params, exp_dpl, initial_dpl,
-                                   scale_factor=scale_factor,
+    params_optim = optimize_evoked(jones_2009_model, params, exp_dpl,
+                                   initial_dpl, scale_factor=scale_factor,
                                    smooth_window_len=smooth_window_len)
 
 ###############################################################################

--- a/examples/howto/optimize_evoked.py
+++ b/examples/howto/optimize_evoked.py
@@ -81,14 +81,10 @@ with MPIBackend(n_procs=n_procs):
     best_dpl = best_dpl.scale(scale_factor).smooth(smooth_window_len)
 
 ###############################################################################
-# Finally, we can plot the results against experimental data along with the
-# input histograms:
-# 1. Initial dipole
-# 2. Optimized dipole fit
-#
-# Upon visualizing the change in optimized versus initial dipole, you should
-# consider exploring which parameters were changed to cause the improved dipole
-# fit.
+# Finally, we can plot the pre- and post-optimization simulations alongside the
+# experimental data. Upon visualizing the change in optimized versus initial
+# dipole, you should consider exploring which parameters were changed to cause
+# the improved dipole fit.
 
 fig, axes = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 

--- a/examples/howto/optimize_evoked.py
+++ b/examples/howto/optimize_evoked.py
@@ -69,15 +69,14 @@ with MPIBackend(n_procs=n_procs):
 from hnn_core.optimization import optimize_evoked
 
 with MPIBackend(n_procs=n_procs):
-    params_optim = optimize_evoked(jones_2009_model, params, exp_dpl,
-                                   initial_dpl, scale_factor=scale_factor,
-                                   smooth_window_len=smooth_window_len)
+    net_opt_drives = optimize_evoked(net.copy(), exp_dpl, initial_dpl,
+                                     scale_factor=scale_factor,
+                                     smooth_window_len=smooth_window_len)
 
 ###############################################################################
-# Now, let's simulate the dipole with the optimized parameters.
-net = jones_2009_model(params=params_optim, add_drives_from_params=True)
+# Now, let's simulate the dipole with the optimized drive parameters.
 with MPIBackend(n_procs=n_procs):
-    best_dpl = simulate_dipole(net, tstop=tstop, n_trials=1)[0]
+    best_dpl = simulate_dipole(net_opt_drives, tstop=tstop, n_trials=1)[0]
     best_dpl = best_dpl.scale(scale_factor).smooth(smooth_window_len)
 
 ###############################################################################
@@ -96,4 +95,4 @@ exp_dpl.plot(ax=axes[0], layer='agg', show=False)
 initial_dpl.plot(ax=axes[0], layer='agg', show=False)
 best_dpl.plot(ax=axes[0], layer='agg', show=False)
 axes[0].legend(['experimental', 'initial', 'optimized'])
-net.cell_response.plot_spikes_hist(ax=axes[1])
+net_opt_drives.cell_response.plot_spikes_hist(ax=axes[1])

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1353,7 +1353,7 @@ class _NetworkDrive(dict):
     name : str
         Name of drive (must be unique)
     location : str
-        Target location of synapses ('distal' or 'proximal')
+        Target location of synapses ('distal' or 'proximal').
     type : str
         Examples: 'evoked', 'gaussian', 'poisson', 'bursty'
     events : list of lists
@@ -1383,6 +1383,7 @@ class _NetworkDrive(dict):
         entr = f"<External drive '{self['name']}'"
         if 'type' in self.keys():
             entr += f"\ndrive class: {self['type']}"
+            entr += f"\ntarget location: {self['location']}"
             entr += f"\ntarget cell types: {self['target_types']}"
             entr += f"\nnumber of drive cells: {self['n_drive_cells']}"
             entr += f"\ncell-specific: {self['cell_specific']}"

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -822,8 +822,12 @@ class Network(object):
         Attached drive is stored in self.external_drives[name]
         self.pos_dict is updated, and self._update_gid_ranges() called
         """
+        # clear connectivity for this drive if it already exists
         if name in self.external_drives:
-            raise ValueError(f"Drive {name} already defined")
+            conn_idxs = pick_connection(self, src_gids=name)
+            self.connectivity = [conn for conn_idx, conn
+                                in enumerate(self.connectivity)
+                                if conn_idx not in conn_idxs]
         if location not in ['distal', 'proximal']:
             raise ValueError("Allowed drive target locations are: 'distal', "
                              f"and 'proximal', got {location}")
@@ -1039,7 +1043,7 @@ class Network(object):
     def _add_cell_type(self, cell_name, pos, cell_template=None):
         """Add cell type by updating pos_dict and gid_ranges."""
         ll = self._n_gids
-        self._n_gids = ll + len(pos)
+        self._n_gids += len(pos)
         self.gid_ranges[cell_name] = range(ll, self._n_gids)
 
         self.pos_dict[cell_name] = pos

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -826,8 +826,8 @@ class Network(object):
         if name in self.external_drives:
             conn_idxs = pick_connection(self, src_gids=name)
             self.connectivity = [conn for conn_idx, conn
-                                in enumerate(self.connectivity)
-                                if conn_idx not in conn_idxs]
+                                 in enumerate(self.connectivity)
+                                 if conn_idx not in conn_idxs]
         if location not in ['distal', 'proximal']:
             raise ValueError("Allowed drive target locations are: 'distal', "
                              f"and 'proximal', got {location}")

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -825,12 +825,8 @@ class Network(object):
         Attached drive is stored in self.external_drives[name]
         self.pos_dict is updated, and self._update_gid_ranges() called
         """
-        # clear connectivity for this drive if it already exists
         if name in self.external_drives:
-            conn_idxs = pick_connection(self, src_gids=name)
-            self.connectivity = [conn for conn_idx, conn
-                                 in enumerate(self.connectivity)
-                                 if conn_idx not in conn_idxs]
+            raise ValueError(f"Drive {name} already defined")
         if location not in ['distal', 'proximal']:
             raise ValueError("Allowed drive target locations are: 'distal', "
                              f"and 'proximal', got {location}")

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -553,6 +553,7 @@ class Network(object):
                                           numspikes=numspikes)
         drive = _NetworkDrive()
         drive['type'] = 'evoked'
+        drive['location'] = location
         if name == 'extgauss':
             drive['type'] = 'gaussian'  # XXX needed to pass legacy tests!
         drive['n_drive_cells'] = n_drive_cells
@@ -657,6 +658,7 @@ class Network(object):
 
         drive = _NetworkDrive()
         drive['type'] = 'poisson'
+        drive['location'] = location
         drive['n_drive_cells'] = n_drive_cells
         drive['event_seed'] = event_seed
         drive['conn_seed'] = conn_seed
@@ -755,6 +757,7 @@ class Network(object):
 
         drive = _NetworkDrive()
         drive['type'] = 'bursty'
+        drive['location'] = location
         drive['n_drive_cells'] = n_drive_cells
         drive['event_seed'] = event_seed
         drive['conn_seed'] = conn_seed
@@ -1349,6 +1352,8 @@ class _NetworkDrive(dict):
     ----------
     name : str
         Name of drive (must be unique)
+    location : str
+        Target location of synapses ('distal' or 'proximal')
     type : str
         Examples: 'evoked', 'gaussian', 'poisson', 'bursty'
     events : list of lists

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -185,7 +185,6 @@ def law_2021_model(params=None, add_drives_from_params=False):
     6) Addition of L5_basket -> L5_pyramidal distal connection
     """
 
-
     net = jones_2009_model(params=params,
                            add_drives_from_params=add_drives_from_params)
 

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -159,7 +159,7 @@ def jones_2009_model(params=None, add_drives_from_params=False):
     return net
 
 
-def law_2021_model():
+def law_2021_model(params=None, add_drives_from_params=False):
     """Instantiate the beta modulated ERP network model.
 
     Returns
@@ -185,11 +185,13 @@ def law_2021_model():
     6) Addition of L5_basket -> L5_pyramidal distal connection
     """
 
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, 'param', 'default.json')
-    params = read_params(params_fname)
+    if params is not None:
+        hnn_core_root = op.dirname(hnn_core.__file__)
+        params_fname = op.join(hnn_core_root, 'param', 'default.json')
+        params = read_params(params_fname)
 
-    net = jones_2009_model(params)
+    net = jones_2009_model(params=params,
+                           add_drives_from_params=add_drives_from_params)
 
     # Update biophysics (increase gabab duration of inhibition)
     net.cell_types['L2_pyramidal'].synapses['gabab']['tau1'] = 45.0

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -185,10 +185,6 @@ def law_2021_model(params=None, add_drives_from_params=False):
     6) Addition of L5_basket -> L5_pyramidal distal connection
     """
 
-    if params is not None:
-        hnn_core_root = op.dirname(hnn_core.__file__)
-        params_fname = op.join(hnn_core_root, 'param', 'default.json')
-        params = read_params(params_fname)
 
     net = jones_2009_model(params=params,
                            add_drives_from_params=add_drives_from_params)

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -332,7 +332,7 @@ def _optrun(net, tstop, dt, n_trials, drive_params_updated,
     opt_params['stepminopterr'] = avg_rmse
     opt_dpls['best_dpl'] = avg_dpl
 
-    print("weighted RMSE: %.2f over range [%3.3f-%3.3f] ms" %
+    print("weighted RMSE: %.2e over range [%3.3f-%3.3f] ms" %
           (avg_rmse, opt_params['opt_start'], opt_params['opt_end']))
 
     opt_params['optiter'] += 1
@@ -501,7 +501,7 @@ def optimize_evoked(net, tstop, n_trials, target_dpl, initial_dpl, maxiter=50,
 
     best_rmse = _rmse(initial_dpl, target_dpl, tstop=tstop)
     opt_dpls = dict(best_dpl=initial_dpl, target_dpl=target_dpl)
-    print("Initial RMSE: %.2f" % best_rmse)
+    print("Initial RMSE: %.2e" % best_rmse)
 
     opt_params = dict()
     for step in range(len(param_chunks)):
@@ -589,5 +589,5 @@ def optimize_evoked(net, tstop, n_trials, target_dpl, initial_dpl, maxiter=50,
 
             net = net_opt
 
-    print("Final RMSE: %.2f" % best_rmse)
+    print("Final RMSE: %.2e" % best_rmse)
     return net

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -80,7 +80,7 @@ def _split_by_evinput(drive_names, drive_dynamics, drive_syn_weights, tstop,
                                       'sigma': timing_sigma,
                                       'ranges': {}}
 
-        evinput_params[drive_name]['ranges'][drive_name + '_sigma'] = \
+        evinput_params[drive_name]['ranges'][f'{drive_name}_sigma'] = \
             _get_range(timing_sigma, sigma_range_multiplier)
 
         # calculate range for time
@@ -90,12 +90,12 @@ def _split_by_evinput(drive_names, drive_dynamics, drive_syn_weights, tstop,
 
         evinput_params[drive_name]['start'] = range_min
         evinput_params[drive_name]['end'] = range_max
-        evinput_params[drive_name]['ranges'][drive_name + '_mu'] = \
+        evinput_params[drive_name]['ranges'][f'{drive_name}_mu'] = \
             {'initial': timing_mean, 'minval': range_min, 'maxval': range_max}
 
         # calculate ranges for syn. weights
         for syn_weight_key in drive_syn_weights[drive_idx]:
-            new_key = drive_name + '_gbar_' + syn_weight_key
+            new_key = f'{drive_name}_gbar_{syn_weight_key}'
             weight = drive_syn_weights[drive_idx][syn_weight_key]
             ranges = _get_range(weight, synweight_range_multiplier)
             if weight == 0.0:
@@ -284,13 +284,14 @@ def _optrun(net, tstop, dt, n_trials, drive_params_updated,
 
     # modify drives according to the drive names in the current chunk
     for drive_idx, drive_name in enumerate(opt_params['inputs']):
-        keys_ampa = fnmatch.filter(list(params_dict.keys()),
-                                   drive_name + '_gbar_ampa_*')
-        keys_nmda = fnmatch.filter(list(params_dict.keys()),
-                                   drive_name + '_gbar_nmda_*')
-        weights_ampa = {key.lstrip(drive_name + '_gbar_ampa_'):
+        keys_ampa = fnmatch.filter(params_dict.keys(),
+                                   f'{drive_name}_gbar_ampa_*')
+        keys_nmda = fnmatch.filter(params_dict.keys(),
+                                   f'{drive_name}_gbar_nmda_*')
+        # syn weight dicts should have keys that correspond to cell types
+        weights_ampa = {key.lstrip(f'{drive_name}_gbar_ampa_'):
                         params_dict[key] for key in keys_ampa}
-        weights_nmda = {key.lstrip(drive_name + '_gbar_nmda_'):
+        weights_nmda = {key.lstrip(f'{drive_name}_gbar_nmda_'):
                         params_dict[key] for key in keys_nmda}
         net.add_evoked_drive(
             name=drive_name,
@@ -356,7 +357,7 @@ def _get_drive_params(net, drive_names):
     drive_static_params = dict()
     for drive_name in drive_names:
         drive = net.external_drives[drive_name]
-        drive_dynamics.append(drive['dynamics'])
+        drive_dynamics.append(drive['dynamics'].copy())
         conn_idxs = pick_connection(net, src_gids=drive_name)
         weights = dict()
         delays = dict()

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -30,11 +30,11 @@ def _split_by_evinput(drive_names, drive_dynamics, drive_syn_weights, tstop,
 
     Parameters
     ----------
-    drive_names : list of str
+    drive_names : list of str, shape (n_drives, )
         Names corresponding to n Network drives.
-    drive_dynamics : list of dict
+    drive_dynamics : list of dict, shape (n_drives, )
         Dynamics parameters for each drive specified in drive_names.
-    drive_syn_weights : list of dict
+    drive_syn_weights : list of dict, shape (n_drives, )
         Synaptic weight parameters for each drive specified in drive_names.
     tstop : float
         The simulation stop time (ms).

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -279,17 +279,17 @@ def _optrun(net, tstop, dt, n_trials, drive_params_updated,
     print("Optimization step %d, iteration %d" % (opt_params['cur_step'] + 1,
                                                   opt_params['optiter'] + 1))
 
-    # set parameters
-    # tiny negative weights are possible. Clip them to 0.
-    drive_params_updated = drive_params_updated.copy()
-    drive_params_updated = [0 for val in drive_params_updated if val < 0]
+    # match parameter values contained in list to their respective key names
     params_dict = dict()
     for param_name, test_value in zip(opt_params['ranges'].keys(),
                                       drive_params_updated):
+        # tiny negative weights are possible. Clip them to 0.
+        if test_value < 0:
+            test_value = 0
         params_dict[param_name] = test_value
 
     # modify drives according to the drive names in the current chunk
-    for drive_idx, drive_name in enumerate(opt_params['inputs']):
+    for drive_name in opt_params['inputs']:
         keys_ampa = fnmatch.filter(params_dict.keys(),
                                    f'{drive_name}_gbar_ampa_*')
         keys_nmda = fnmatch.filter(params_dict.keys(),

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -290,15 +290,25 @@ def _optrun(drive_params_updated, drive_params_static, net, tstop, dt,
 
     # modify drives according to the drive names in the current chunk
     for drive_name in opt_params['inputs']:
+
+        # clear drive and its connectivity
+        del net.external_drives[drive_name]
+        conn_idxs = pick_connection(net, src_gids=drive_name)
+        net.connectivity = [conn for conn_idx, conn
+                            in enumerate(net.connectivity)
+                            if conn_idx not in conn_idxs]
+
+        # extract syn weights: final weights dicts should have keys that
+        # correspond to cell types
         keys_ampa = fnmatch.filter(params_dict.keys(),
                                    f'{drive_name}_gbar_ampa_*')
         keys_nmda = fnmatch.filter(params_dict.keys(),
                                    f'{drive_name}_gbar_nmda_*')
-        # syn weight dicts should have keys that correspond to cell types
         weights_ampa = {key.lstrip(f'{drive_name}_gbar_ampa_'):
                         params_dict[key] for key in keys_ampa}
         weights_nmda = {key.lstrip(f'{drive_name}_gbar_nmda_'):
                         params_dict[key] for key in keys_nmda}
+
         net.add_evoked_drive(
             name=drive_name,
             mu=params_dict[drive_name + '_mu'],

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -308,6 +308,7 @@ def _run_optimization(maxiter, param_ranges, optrun):
 
     cons = list()
     x0 = list()
+    print(param_ranges)
     for idx, param_name in enumerate(param_ranges):
         x0.append(param_ranges[param_name]['initial'])
         cons.append(
@@ -388,6 +389,7 @@ def optimize_evoked(net_model, params, target_dpl, initial_dpl, maxiter=50,
     param_chunks = _consolidate_chunks(evinput_params)
 
     avg_rmse = _rmse(initial_dpl, target_dpl, tstop=params['tstop'])
+    opt_dpls = dict(best_dpl=initial_dpl, target_dpl=target_dpl)
     print("Initial RMSE: %.2f" % avg_rmse)
 
     opt_params = dict()
@@ -432,8 +434,10 @@ def optimize_evoked(net_model, params, target_dpl, initial_dpl, maxiter=50,
         print("Starting optimization step %d/%d" % (step + 1, total_steps))
 
         opt_params['optiter'] = 0
-        opt_params['stepminopterr'] = 1e9  # min optimization error so far
-        opt_dpls = dict(best_dpl=None, target_dpl=target_dpl)
+        opt_params['stepminopterr'] = _rmse(opt_dpls['best_dpl'], target_dpl,
+                                            tstart=opt_params['opt_start'],
+                                            tstop=opt_params['opt_end'],
+                                            weights=opt_params['weights'])
 
         def _myoptrun(new_params):
             return _optrun(net_model, new_params, opt_params,

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -412,8 +412,10 @@ def optimize_evoked(net, tstop, n_trials, target_dpl, initial_dpl, maxiter=50,
     Parameters
     ----------
     net : Network instance
-        Network instance with the initial configuration of attached drives to
-        be optimized. This object will be modified in-place.
+        An instance of the Network object with attached evoked drives. Timing 
+        and synaptic weight parameters will be optimized for each attached 
+        evoked drive. Note that no new drives will be created or old drives 
+        destroyed.
     tstop : float
         The simulation stop time (ms).
     n_trials : int
@@ -444,8 +446,9 @@ def optimize_evoked(net, tstop, n_trials, target_dpl, initial_dpl, maxiter=50,
 
     Returns
     -------
-    net : Instance of Network object
-        Network instance with the optimized configuration of attached drives.
+    net : Network instance
+        An instance of the Network object with the optimized configuration of
+        attached drives.
 
     Notes
     -----
@@ -453,6 +456,8 @@ def optimize_evoked(net, tstop, n_trials, target_dpl, initial_dpl, maxiter=50,
     By Linear Approximation (COBYLA) method:
     https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin_cobyla.html  # noqa
     """
+
+    net = net.copy()
 
     drive_names = [key for key in net.external_drives.keys()
                    if net.external_drives[key]['type'] == 'evoked']

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -384,9 +384,9 @@ def optimize_evoked(net_model, params, target_dpl, initial_dpl, maxiter=50,
                                        decay_multiplier)
     param_chunks = _consolidate_chunks(evinput_params)
 
-    avg_rmse = _rmse(initial_dpl, target_dpl, tstop=params['tstop'])
+    best_rmse = _rmse(initial_dpl, target_dpl, tstop=params['tstop'])
     opt_dpls = dict(best_dpl=initial_dpl, target_dpl=target_dpl)
-    print("Initial RMSE: %.2f" % avg_rmse)
+    print("Initial RMSE: %.2f" % best_rmse)
 
     opt_params = dict()
     for step in range(len(param_chunks)):
@@ -448,11 +448,12 @@ def optimize_evoked(net_model, params, target_dpl, initial_dpl, maxiter=50,
         opt_results[opt_results < 0] = 0
 
         # update opt_params for the next round if total rmse decreased
-        new_avg_rmse = _rmse(opt_dpls['best_dpl'],
+        avg_rmse = _rmse(opt_dpls['best_dpl'],
                              opt_dpls['target_dpl'],
                              tstop=params['tstop'],
                              weights=None)
-        if new_avg_rmse <= avg_rmse:
+        if avg_rmse <= best_rmse:
+            best_rmse = avg_rmse
             for var_name, value in zip(opt_params['ranges'], opt_results):
                 opt_params['ranges'][var_name]['initial'] = value
 
@@ -460,5 +461,5 @@ def optimize_evoked(net_model, params, target_dpl, initial_dpl, maxiter=50,
     for var_name in opt_params['ranges']:
         params[var_name] = opt_params['ranges'][var_name]['initial']
 
-    print("Final RMSE: %.2f" % new_avg_rmse)
+    print("Final RMSE: %.2f" % best_rmse)
     return params

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -457,9 +457,9 @@ def optimize_evoked(net_model, params, target_dpl, initial_dpl, maxiter=50,
             for var_name, value in zip(opt_params['ranges'], opt_results):
                 opt_params['ranges'][var_name]['initial'] = value
 
-    # save the optimized params
-    for var_name in opt_params['ranges']:
-        params[var_name] = opt_params['ranges'][var_name]['initial']
+            # save the optimized params
+            for var_name in opt_params['ranges']:
+                params[var_name] = opt_params['ranges'][var_name]['initial']
 
     print("Final RMSE: %.2f" % best_rmse)
     return params

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -238,6 +238,10 @@ def test_add_drives():
         net.add_evoked_drive('evdist1', mu=10, sigma=1, numspikes=1,
                              location='bogus_location')
     with pytest.raises(ValueError,
+                       match='Drive evoked_dist already defined'):
+        net.add_evoked_drive('evoked_dist', mu=10, sigma=1, numspikes=1,
+                             location='distal')
+    with pytest.raises(ValueError,
                        match='No target cell types have been given a synaptic '
                        'weight'):
         net.add_evoked_drive('evdist1', mu=10, sigma=1, numspikes=1,
@@ -336,6 +340,12 @@ def test_add_drives():
                              spike_isi=50)
 
     # attaching drives
+    with pytest.raises(ValueError,
+                       match='Drive evoked_dist already defined'):
+        net.add_poisson_drive('evoked_dist', location='distal',
+                              rate_constant=10.,
+                              weights_ampa=weights_ampa,
+                              synaptic_delays=syn_delays)
     with pytest.raises(ValueError,
                        match='Allowed drive target locations are:'):
         net.add_poisson_drive('weird_poisson', location='inbetween',

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -238,10 +238,6 @@ def test_add_drives():
         net.add_evoked_drive('evdist1', mu=10, sigma=1, numspikes=1,
                              location='bogus_location')
     with pytest.raises(ValueError,
-                       match='Drive evoked_dist already defined'):
-        net.add_evoked_drive('evoked_dist', mu=10, sigma=1, numspikes=1,
-                             location='distal')
-    with pytest.raises(ValueError,
                        match='No target cell types have been given a synaptic '
                        'weight'):
         net.add_evoked_drive('evdist1', mu=10, sigma=1, numspikes=1,
@@ -340,12 +336,6 @@ def test_add_drives():
                              spike_isi=50)
 
     # attaching drives
-    with pytest.raises(ValueError,
-                       match='Drive evoked_dist already defined'):
-        net.add_poisson_drive('evoked_dist', location='distal',
-                              rate_constant=10.,
-                              weights_ampa=weights_ampa,
-                              synaptic_delays=syn_delays)
     with pytest.raises(ValueError,
                        match='Allowed drive target locations are:'):
         net.add_poisson_drive('weird_poisson', location='inbetween',

--- a/hnn_core/tests/test_optimization.py
+++ b/hnn_core/tests/test_optimization.py
@@ -1,10 +1,7 @@
 # Authors: Mainak Jas <mainakjas@gmail.com>
 
-import os.path as op
 import numpy as np
 
-import hnn_core
-from hnn_core import read_params
 from hnn_core.optimization import (_consolidate_chunks, _split_by_evinput,
                                    _generate_weights)
 
@@ -46,24 +43,27 @@ def test_consolidate_chunks():
 
 def test_split_by_evinput():
     """Test splitting evoked input."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, 'param', 'default.json')
-    params = read_params(params_fname)
+    drive_names = ['ev_drive_1', 'ev_drive_2']
+    drive_dynamics = [{'mu': 5., 'sigma': .1}, {'mu': 10., 'sigma': .2}]
+    drive_syn_weights = [{'ampa_L2_pyramidal': 1.}, {'nmda_L5_basket': 2.}]
+    tstop = 20.
+    dt = 0.025
 
     timing_range_multiplier = 3.0
     sigma_range_multiplier = 50.0
     synweight_range_multiplier = 500.0
     decay_multiplier = 1.6
-    evinput_params = _split_by_evinput(params, sigma_range_multiplier,
+    evinput_params = _split_by_evinput(drive_names, drive_dynamics,
+                                       drive_syn_weights, tstop,
+                                       sigma_range_multiplier,
                                        timing_range_multiplier,
                                        synweight_range_multiplier)
-    assert list(evinput_params.keys()) == [
-        'evprox_1', 'evdist_1', 'evprox_2']
+    assert list(evinput_params.keys()) == drive_names
     for evinput in evinput_params.values():
         assert list(evinput.keys()) == ['mean', 'sigma', 'ranges',
                                         'start', 'end']
 
-    evinput_params = _generate_weights(evinput_params, params,
+    evinput_params = _generate_weights(evinput_params, tstop, dt,
                                        decay_multiplier)
     for evinput in evinput_params.values():
         assert list(evinput.keys()) == ['ranges', 'start', 'end',

--- a/hnn_core/tests/test_optimization.py
+++ b/hnn_core/tests/test_optimization.py
@@ -6,7 +6,7 @@ import numpy as np
 import hnn_core
 from hnn_core import read_params, jones_2009_model, simulate_dipole
 from hnn_core.optimization import (_consolidate_chunks, _split_by_evinput,
-                                   _generate_weights,_get_drive_params,
+                                   _generate_weights, _get_drive_params,
                                    optimize_evoked)
 
 

--- a/hnn_core/tests/test_optimization.py
+++ b/hnn_core/tests/test_optimization.py
@@ -2,6 +2,7 @@
 
 import os.path as op
 import numpy as np
+import pytest
 
 import hnn_core
 from hnn_core import read_params, jones_2009_model, simulate_dipole
@@ -107,6 +108,13 @@ def test_optimize_evoked():
     dpl_offset = simulate_dipole(net_offset, tstop=tstop, n_trials=n_trials)[0]
     # get drive params from the pre-optimization Network instance
     _, _, drive_static_params_orig = _get_drive_params(net_offset, ['evprox1'])
+
+    with pytest.raises(ValueError, match='The current Network instance lacks '
+                       'any evoked drives'):
+        net_empty = net_offset.copy()
+        del net_empty.external_drives['evprox1']
+        net_opt = optimize_evoked(net_empty, tstop=tstop, n_trials=n_trials,
+                                  target_dpl=dpl_orig, initial_dpl=dpl_offset)
 
     net_opt = optimize_evoked(net_offset, tstop=tstop, n_trials=n_trials,
                               target_dpl=dpl_orig, initial_dpl=dpl_offset,


### PR DESCRIPTION
Makes the following improvements to the `optimize_evoked()` routine:

- [x] allows the user to optimize the evoked drives of any network template model by passing a `Network` instance directly into `optimize_evoked`
- [x] prevents any given chunking step from increasing the total RMSE
- [x] allows the user to set the number of trials/simulation during optimization

closes #268 