### PR TITLE
[MRG] MAINT: Fix bugs from inputs to drives API

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,6 +15,8 @@ Changelog
 
 Bug
 ~~~
+- Fix bugs in drives API to enable: rate constant argument as float; evoked drive with
+  connection probability, by `Nick Tolley`_ in :gh:`458`
 
 API
 ~~~

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -651,6 +651,9 @@ class Network(object):
                                  f"n_drive_cells='n_cells'. Got cell_specific"
                                  f" cell_specific={cell_specific} and "
                                  f"n_drive_cells={n_drive_cells}.")
+        elif isinstance(rate_constant, float):
+            rate_constant = {cell_type: rate_constant for cell_type in
+                             target_populations}
 
         drive = _NetworkDrive()
         drive['type'] = 'poisson'

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -375,8 +375,11 @@ class NetworkBuilder(object):
                     conn_idxs = pick_connection(self.net, src_gids=src_gid)
                     target_gids = list()
                     for conn_idx in conn_idxs:
-                        target_gids += (self.net.connectivity[conn_idx]
-                                        ['gid_pairs'][src_gid])
+                        gid_pairs = self.net.connectivity[
+                            conn_idx]['gid_pairs']
+                        if src_gid in gid_pairs:
+                            target_gids += (self.net.connectivity[conn_idx]
+                                            ['gid_pairs'][src_gid])
 
                     for target_gid in set(target_gids):
                         if (target_gid in self._gid_list and

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -12,7 +12,7 @@ from hnn_core.drives import (drive_event_times, _get_prng, _create_extpois,
                              _create_bursty_input)
 from hnn_core.params import create_pext
 from hnn_core.network import pick_connection
-from hnn_core.network_builder import NetworkBuilder
+from hnn_core import simulate_dipole
 
 
 def test_external_drive_times():
@@ -218,7 +218,7 @@ def test_add_drives():
             assert num_connections == \
                 np.around(len(net.gid_ranges[cell_type]) *
                           probability[cell_type]).astype(int)
-    NetworkBuilder(net)  # smoke test
+    simulate_dipole(net, tstop=1)  # smoke test
 
     # evoked
     with pytest.raises(ValueError,

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -12,6 +12,7 @@ from hnn_core.drives import (drive_event_times, _get_prng, _create_extpois,
                              _create_bursty_input)
 from hnn_core.params import create_pext
 from hnn_core.network import pick_connection
+from hnn_core.network_builder import NetworkBuilder
 
 
 def test_external_drive_times():
@@ -217,6 +218,7 @@ def test_add_drives():
             assert num_connections == \
                 np.around(len(net.gid_ranges[cell_type]) *
                           probability[cell_type]).astype(int)
+    NetworkBuilder(net)  # smoke test
 
     # evoked
     with pytest.raises(ValueError,

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -139,7 +139,7 @@ def test_add_drives():
     n_drive_cells = 'n_cells'  # default for evoked drive
     cell_specific = True
     net.add_evoked_drive(
-        'evoked_dist', mu=1.0, sigma=1.0, numspikes=1.0,
+        'evoked_dist', mu=1.0, sigma=1.0, numspikes=1,
         weights_ampa=weights_ampa, location='distal',
         synaptic_delays=syn_delays, cell_specific=True)
 
@@ -201,7 +201,7 @@ def test_add_drives():
     # drives with cell_specific=True
     probability = {'L2_basket': 0.1, 'L2_pyramidal': 0.25, 'L5_pyramidal': 0.5}
     net.add_evoked_drive(
-        'evoked_prob', mu=1.0, sigma=1.0, numspikes=1.0,
+        'evoked_prob', mu=1.0, sigma=1.0, numspikes=1,
         weights_ampa=weights_ampa, weights_nmda=weights_nmda,
         location='distal', synaptic_delays=syn_delays, cell_specific=True,
         probability=probability)

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -218,7 +218,8 @@ def test_add_drives():
             assert num_connections == \
                 np.around(len(net.gid_ranges[cell_type]) *
                           probability[cell_type]).astype(int)
-    simulate_dipole(net, tstop=1)  # smoke test
+    # Round trip test to ensure drives API produces a functioning Network
+    simulate_dipole(net, tstop=1)
 
     # evoked
     with pytest.raises(ValueError,


### PR DESCRIPTION
Closes #457 and #455. Fairly simple adjustments, adding `simulate_dipole()` inside `test_drives.py` revealed both problems.