### PR TITLE
Use BSD-3 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,30 @@
-Copyright 2017-2018, Brown University, Providence, RI.
+BSD 3-Clause License
 
-                        All Rights Reserved
+Copyright (c) 2018-2021, hnn-core developers
+All rights reserved.
 
-Permission to use, copy, modify, and distribute this software and
-its documentation for any purpose other than its incorporation into a
-commercial product or service is hereby granted without fee, provided
-that the above copyright notice appear in all copies and that both
-that copyright notice and this permission notice appear in supporting
-documentation, and that the name of Brown University not be used in
-advertising or publicity pertaining to distribution of the software
-without specific, written prior permission.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-BROWN UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
-INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR ANY
-PARTICULAR PURPOSE.  IN NO EVENT SHALL BROWN UNIVERSITY BE LIABLE FOR
-ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+


### PR DESCRIPTION
[GSoC requires](https://developers.google.com/open-source/gsoc/faq#what_are_the_eligibility_requirements_for_a_mentoring_organization) using an [open source initiative approved license](https://opensource.org/licenses). I think we agreed in previous discussions that we will settle with BSD-3 for hnn-core but a more restrictive license for additions on top of hnn-core, for example if there was something built using SBI. The switch to BSD-3 was ultimately never made but I think this is a good moment to do.

@stephanie-r-jones are you okay with this? A quick merge would be appreciated @stephanie-r-jones @ntolley @rythorpe as it will allow me to move forward the application in PSF