### PR TITLE
[MRG] Gid offset

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,12 @@ Bug
   connection probability, by `Nick Tolley`_ in :gh:`458`
 
 - Allow regular strings as filenames in :meth:`~hnn_core.Cell_response.write` by
-  `Mainak Jas`_ in :gh:456.
+  `Mainak Jas`_ in :gh:`456`.
+
+- Fix to make network output independent of the order in which drives are added to
+  the network by making the seed of the random process generating spike times in
+  drives use the offset of the gid with respect to the first gid in the population
+  by `Mainak Jas`_ in :gh:`462`.
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,8 @@ Bug
   drives use the offset of the gid with respect to the first gid in the population
   by `Mainak Jas`_ in :gh:`462`.
 
+- Negative ``event_seed`` is no longer allowed by `Mainak Jas`_ in :gh:`462`.
+
 API
 ~~~
 

--- a/examples/howto/plot_firing_pattern.py
+++ b/examples/howto/plot_firing_pattern.py
@@ -42,7 +42,7 @@ synaptic_delays_d1 = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evdist1', mu=63.53, sigma=3.85, numspikes=1, weights_ampa=weights_ampa_d1,
     weights_nmda=weights_nmda_d1, location='distal',
-    synaptic_delays=synaptic_delays_d1, event_seed=4)
+    synaptic_delays=synaptic_delays_d1, event_seed=274)
 
 ###############################################################################
 # The reason it is called an "evoked drive" is it can be used to simulate
@@ -58,7 +58,7 @@ synaptic_delays_prox = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evprox1', mu=26.61, sigma=2.47, numspikes=1, weights_ampa=weights_ampa_p1,
     weights_nmda=None, location='proximal',
-    synaptic_delays=synaptic_delays_prox, event_seed=4)
+    synaptic_delays=synaptic_delays_prox, event_seed=544)
 
 ###############################################################################
 # Now we add the second proximal evoked drive and simulate the network
@@ -70,7 +70,7 @@ weights_ampa_p2 = {'L2_basket': 0.000003, 'L2_pyramidal': 1.438840,
 net.add_evoked_drive(
     'evprox2', mu=137.12, sigma=8.33, numspikes=1,
     weights_ampa=weights_ampa_p2, location='proximal',
-    synaptic_delays=synaptic_delays_prox, event_seed=4)
+    synaptic_delays=synaptic_delays_prox, event_seed=814)
 
 dpls = simulate_dipole(net, tstop=170., record_vsoma=True)
 

--- a/examples/howto/plot_simulate_mpi_backend.py
+++ b/examples/howto/plot_simulate_mpi_backend.py
@@ -37,7 +37,7 @@ weights_ampa = {'L2_pyramidal': 5.4e-5, 'L5_pyramidal': 5.4e-5}
 net.add_bursty_drive(
     'bursty', tstart=50., burst_rate=10, burst_std=20., numspikes=2,
     spike_isi=10, n_drive_cells=10, location='distal',
-    weights_ampa=weights_ampa, event_seed=8)
+    weights_ampa=weights_ampa, event_seed=278)
 
 ###############################################################################
 # Finally, to simulate we use the

--- a/examples/workflows/plot_simulate_alpha.py
+++ b/examples/workflows/plot_simulate_alpha.py
@@ -46,7 +46,7 @@ syn_delays_p = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.}
 net.add_bursty_drive(
     'alpha_prox', tstart=50., burst_rate=10, burst_std=burst_std, numspikes=2,
     spike_isi=10, n_drive_cells=10, location=location,
-    weights_ampa=weights_ampa_p, synaptic_delays=syn_delays_p, event_seed=14)
+    weights_ampa=weights_ampa_p, synaptic_delays=syn_delays_p, event_seed=284)
 
 # simulate the dipole, but do not automatically scale or smooth the result
 dpl = simulate_dipole(net, tstop=310., n_trials=1)
@@ -95,8 +95,7 @@ syn_delays_d = {'L2_pyramidal': 5., 'L5_pyramidal': 5.}
 net.add_bursty_drive(
     'alpha_dist', tstart=50., burst_rate=10, burst_std=burst_std, numspikes=2,
     spike_isi=10, n_drive_cells=10, location=location,
-    weights_ampa=weights_ampa_d, synaptic_delays=syn_delays_d, event_seed=16)
-
+    weights_ampa=weights_ampa_d, synaptic_delays=syn_delays_d, event_seed=286)
 dpl = simulate_dipole(net, tstop=310., n_trials=1)
 
 ###############################################################################

--- a/examples/workflows/plot_simulate_alpha.py
+++ b/examples/workflows/plot_simulate_alpha.py
@@ -95,7 +95,7 @@ syn_delays_d = {'L2_pyramidal': 5., 'L5_pyramidal': 5.}
 net.add_bursty_drive(
     'alpha_dist', tstart=50., burst_rate=10, burst_std=burst_std, numspikes=2,
     spike_isi=10, n_drive_cells=10, location=location,
-    weights_ampa=weights_ampa_d, synaptic_delays=syn_delays_d, event_seed=286)
+    weights_ampa=weights_ampa_d, synaptic_delays=syn_delays_d, event_seed=296)
 dpl = simulate_dipole(net, tstop=310., n_trials=1)
 
 ###############################################################################

--- a/examples/workflows/plot_simulate_beta.py
+++ b/examples/workflows/plot_simulate_beta.py
@@ -129,7 +129,7 @@ def add_beta_drives(net, beta_start):
         'beta_dist', tstart=beta_start, tstart_std=0., tstop=beta_start + 50.,
         burst_rate=1., burst_std=10., numspikes=2, spike_isi=10,
         n_drive_cells=10, location='distal', weights_ampa=weights_ampa_d1,
-        synaptic_delays=syn_delays_d1, event_seed=20)
+        synaptic_delays=syn_delays_d1, event_seed=290)
 
     # Proximal Drive
     weights_ampa_p1 = {'L2_basket': 0.00004, 'L2_pyramidal': 0.00002,
@@ -141,8 +141,7 @@ def add_beta_drives(net, beta_start):
         'beta_prox', tstart=beta_start, tstart_std=0., tstop=beta_start + 50.,
         burst_rate=1., burst_std=20., numspikes=2, spike_isi=10,
         n_drive_cells=10, location='proximal', weights_ampa=weights_ampa_p1,
-        synaptic_delays=syn_delays_p1, event_seed=20)
-
+        synaptic_delays=syn_delays_p1, event_seed=300)
     return net
 
 

--- a/examples/workflows/plot_simulate_beta.py
+++ b/examples/workflows/plot_simulate_beta.py
@@ -88,7 +88,7 @@ def add_erp_drives(net, stimulus_start):
     net.add_evoked_drive(
         'evdist1', mu=70.0 + stimulus_start, sigma=0.0, numspikes=1,
         weights_ampa=weights_ampa_d1, weights_nmda=weights_nmda_d1,
-        location='distal', synaptic_delays=syn_delays_d1, event_seed=4)
+        location='distal', synaptic_delays=syn_delays_d1, event_seed=274)
 
     # Two proximal drives
     weights_ampa_p1 = {'L2_basket': 0.002, 'L2_pyramidal': 0.0011,
@@ -100,7 +100,7 @@ def add_erp_drives(net, stimulus_start):
     net.add_evoked_drive(
         'evprox1', mu=25.0 + stimulus_start, sigma=0.0, numspikes=1,
         weights_ampa=weights_ampa_p1, weights_nmda=None,
-        location='proximal', synaptic_delays=syn_delays_prox, event_seed=4)
+        location='proximal', synaptic_delays=syn_delays_prox, event_seed=544)
 
     # Second proximal evoked drive. NB: only AMPA weights differ from first
     weights_ampa_p2 = {'L2_basket': 0.005, 'L2_pyramidal': 0.005,
@@ -109,7 +109,7 @@ def add_erp_drives(net, stimulus_start):
     net.add_evoked_drive(
         'evprox2', mu=135.0 + stimulus_start, sigma=0.0, numspikes=1,
         weights_ampa=weights_ampa_p2, location='proximal',
-        synaptic_delays=syn_delays_prox, event_seed=4)
+        synaptic_delays=syn_delays_prox, event_seed=814)
 
     return net
 

--- a/examples/workflows/plot_simulate_evoked.py
+++ b/examples/workflows/plot_simulate_evoked.py
@@ -61,7 +61,7 @@ synaptic_delays_d1 = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evdist1', mu=63.53, sigma=3.85, numspikes=1, weights_ampa=weights_ampa_d1,
     weights_nmda=weights_nmda_d1, location='distal',
-    synaptic_delays=synaptic_delays_d1, event_seed=4)
+    synaptic_delays=synaptic_delays_d1, event_seed=274)
 
 ###############################################################################
 # Then, we add two proximal drives
@@ -73,7 +73,7 @@ synaptic_delays_prox = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
 net.add_evoked_drive(
     'evprox1', mu=26.61, sigma=2.47, numspikes=1, weights_ampa=weights_ampa_p1,
     weights_nmda=None, location='proximal',
-    synaptic_delays=synaptic_delays_prox, event_seed=4)
+    synaptic_delays=synaptic_delays_prox, event_seed=544)
 
 # Second proximal evoked drive. NB: only AMPA weights differ from first
 weights_ampa_p2 = {'L2_basket': 0.000003, 'L2_pyramidal': 1.438840,
@@ -82,7 +82,7 @@ weights_ampa_p2 = {'L2_basket': 0.000003, 'L2_pyramidal': 1.438840,
 net.add_evoked_drive(
     'evprox2', mu=137.12, sigma=8.33, numspikes=1,
     weights_ampa=weights_ampa_p2, location='proximal',
-    synaptic_delays=synaptic_delays_prox, event_seed=4)
+    synaptic_delays=synaptic_delays_prox, event_seed=814)
 
 ###############################################################################
 # Now let's simulate the dipole, running 2 trials with the
@@ -126,17 +126,17 @@ cell_specific=False
 net_sync.add_evoked_drive(
     'evdist1', mu=63.53, sigma=3.85, numspikes=1, weights_ampa=weights_ampa_d1,
     weights_nmda=weights_nmda_d1, location='distal', n_drive_cells=n_drive_cells,
-    cell_specific=cell_specific, synaptic_delays=synaptic_delays_d1, event_seed=4)
+    cell_specific=cell_specific, synaptic_delays=synaptic_delays_d1, event_seed=274)
 
 net_sync.add_evoked_drive(
     'evprox1', mu=26.61, sigma=2.47, numspikes=1, weights_ampa=weights_ampa_p1,
     weights_nmda=None, location='proximal', n_drive_cells=n_drive_cells,
-    cell_specific=cell_specific, synaptic_delays=synaptic_delays_prox, event_seed=4)
+    cell_specific=cell_specific, synaptic_delays=synaptic_delays_prox, event_seed=544)
 
 net_sync.add_evoked_drive(
     'evprox2', mu=137.12, sigma=8.33, numspikes=1,
     weights_ampa=weights_ampa_p2, location='proximal', n_drive_cells=n_drive_cells,
-    cell_specific=cell_specific, synaptic_delays=synaptic_delays_prox, event_seed=4)
+    cell_specific=cell_specific, synaptic_delays=synaptic_delays_prox, event_seed=814)
 
 ###############################################################################
 # You may interrogate current values defining the spike event time dynamics by

--- a/examples/workflows/plot_simulate_gamma.py
+++ b/examples/workflows/plot_simulate_gamma.py
@@ -52,7 +52,7 @@ rate_constant = {'L2_pyramidal': 140.0, 'L5_pyramidal': 40.0}
 net.add_poisson_drive(
     'poisson', rate_constant=rate_constant, weights_ampa=weights_ampa,
     location='proximal', synaptic_delays=synaptic_delays,
-    event_seed=1079)
+    event_seed=1349)
 
 ###############################################################################
 dpls = simulate_dipole(net, tstop=250.)

--- a/examples/workflows/plot_simulate_somato.py
+++ b/examples/workflows/plot_simulate_somato.py
@@ -172,7 +172,7 @@ net.add_evoked_drive(
     'evprox1', mu=21., sigma=4., numspikes=1, location='proximal',
     n_drive_cells=1, cell_specific=False, weights_ampa=weights_ampa_p,
     weights_nmda=weights_nmda_p, synaptic_delays=synaptic_delays_p,
-    event_seed=6)
+    event_seed=276)
 
 # Late proximal drive
 weights_ampa_p = {'L2_basket': 0.003, 'L2_pyramidal': 0.0039,
@@ -186,7 +186,7 @@ net.add_evoked_drive(
     'evprox2', mu=134., sigma=4.5, numspikes=1, location='proximal',
     n_drive_cells=1, cell_specific=False, weights_ampa=weights_ampa_p,
     weights_nmda=weights_nmda_p, synaptic_delays=synaptic_delays_p,
-    event_seed=5)
+    event_seed=276)
 
 # Early distal drive
 weights_ampa_d = {'L2_basket': 0.0043, 'L2_pyramidal': 0.0032,
@@ -200,7 +200,7 @@ net.add_evoked_drive(
     'evdist1', mu=32., sigma=2.5, numspikes=1, location='distal',
     n_drive_cells=1, cell_specific=False, weights_ampa=weights_ampa_d,
     weights_nmda=weights_nmda_d, synaptic_delays=synaptic_delays_d,
-    event_seed=5)
+    event_seed=277)
 
 # Late distal drive
 weights_ampa_d = {'L2_basket': 0.0041, 'L2_pyramidal': 0.0019,
@@ -214,7 +214,7 @@ net.add_evoked_drive(
     'evdist2', mu=84., sigma=4.5, numspikes=1, location='distal',
     n_drive_cells=1, cell_specific=False, weights_ampa=weights_ampa_d,
     weights_nmda=weights_nmda_d, synaptic_delays=synaptic_delays_d,
-    event_seed=2)
+    event_seed=275)
 
 ###############################################################################
 # Now we run the simulation over 2 trials so that we can plot the average

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -191,6 +191,8 @@ def _add_drives_from_params(net):
             t0=bias_specs['tonic'][cellname]['t0'],
             tstop=bias_specs['tonic'][cellname]['tstop'])
 
+    # in HNN-GUI, seed is determined by "absolute GID" instead of the
+    # gid offset with respect to the first cell of a population.
     for drive_name, drive in net.external_drives.items():
         drive['event_seed'] += net.gid_ranges[drive_name][0]
 

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -191,6 +191,9 @@ def _add_drives_from_params(net):
             t0=bias_specs['tonic'][cellname]['t0'],
             tstop=bias_specs['tonic'][cellname]['tstop'])
 
+    for drive_name, drive in net.external_drives.items():
+        drive['event_seed'] += net.gid_ranges[drive_name][0]
+
 
 def _get_prng(seed, gid, sync_evinput=False):
     """Random generator for this instance.

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -965,7 +965,8 @@ class Network(object):
             for drive in self.external_drives.values():
                 event_times = list()  # new list for each trial and drive
                 for drive_cell_gid in self.gid_ranges[drive['name']]:
-                    drive_cell_gid_offset = drive_cell_gid - self.gid_ranges[drive['name']][0]
+                    drive_cell_gid_offset = (drive_cell_gid -
+                                             self.gid_ranges[drive['name']][0])
                     if drive['cell_specific']:
                         # loop over drives (one for each target cell
                         # population) and create event times

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -965,6 +965,7 @@ class Network(object):
             for drive in self.external_drives.values():
                 event_times = list()  # new list for each trial and drive
                 for drive_cell_gid in self.gid_ranges[drive['name']]:
+                    drive_cell_gid_offset = drive_cell_gid - self.gid_ranges[drive['name']][0]
                     if drive['cell_specific']:
                         # loop over drives (one for each target cell
                         # population) and create event times
@@ -979,7 +980,7 @@ class Network(object):
                                 drive['dynamics'],
                                 target_type=target_type,
                                 trial_idx=trial_idx,
-                                drive_cell_gid=drive_cell_gid,
+                                drive_cell_gid=drive_cell_gid_offset,
                                 event_seed=drive['event_seed'],
                                 tstop=tstop)
                             )
@@ -990,7 +991,7 @@ class Network(object):
                             tstop=tstop,
                             target_type='any',
                             trial_idx=trial_idx,
-                            drive_cell_gid=drive_cell_gid,
+                            drive_cell_gid=drive_cell_gid_offset,
                             event_seed=drive['event_seed'])
                         event_times.append(src_event_times)
                 # 'events': nested list (n_trials x n_drive_cells x n_events)

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -307,7 +307,7 @@ def add_erp_drives_to_jones_model(net, tstart=0.0):
     net.add_evoked_drive(
         'evdist1', mu=63.53 + tstart, sigma=3.85, numspikes=1,
         weights_ampa=weights_ampa_d1, weights_nmda=weights_nmda_d1,
-        location='distal', synaptic_delays=synaptic_delays_d1, event_seed=4)
+        location='distal', synaptic_delays=synaptic_delays_d1, event_seed=274)
 
     # Add proximal drives
     weights_ampa_p1 = {'L2_basket': 0.08831, 'L2_pyramidal': 0.01525,
@@ -317,11 +317,11 @@ def add_erp_drives_to_jones_model(net, tstart=0.0):
     net.add_evoked_drive(
         'evprox1', mu=26.61 + tstart, sigma=2.47, numspikes=1,
         weights_ampa=weights_ampa_p1, weights_nmda=None, location='proximal',
-        synaptic_delays=synaptic_delays_prox, event_seed=4)
+        synaptic_delays=synaptic_delays_prox, event_seed=544)
 
     weights_ampa_p2 = {'L2_basket': 0.000003, 'L2_pyramidal': 1.438840,
                        'L5_basket': 0.008958, 'L5_pyramidal': 0.684013}
     net.add_evoked_drive(
         'evprox2', mu=137.12 + tstart, sigma=8.33, numspikes=1,
         weights_ampa=weights_ampa_p2, location='proximal',
-        synaptic_delays=synaptic_delays_prox, event_seed=4)
+        synaptic_delays=synaptic_delays_prox, event_seed=814)

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -217,10 +217,7 @@ def _extract_drive_specs_from_hnn_params(params, cellname_list):
                                  'numspikes': par['numspikes'],
                                  'n_drive_cells': n_drive_cells}
             drive['space_constant'] = par['lamtha']
-            # XXX Force random states to be the same as HNN-gui for the default
-            # parameter set after increasing the number of bursty drive
-            # gids from 2 to 20
-            drive['event_seed'] = par['prng_seedcore'] - 18
+            drive['event_seed'] = par['prng_seedcore']
             for cellname in cellname_list:
                 if cellname in par:
                     ampa_weight = par[cellname][0]

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -217,7 +217,10 @@ def _extract_drive_specs_from_hnn_params(params, cellname_list):
                                  'numspikes': par['numspikes'],
                                  'n_drive_cells': n_drive_cells}
             drive['space_constant'] = par['lamtha']
-            drive['event_seed'] = par['prng_seedcore']
+            # XXX Force random states to be the same as HNN-gui for the default
+            # parameter set after increasing the number of bursty drive
+            # gids from 2 to 20
+            drive['event_seed'] = par['prng_seedcore'] - 18
             for cellname in cellname_list:
                 if cellname in par:
                     ampa_weight = par[cellname][0]

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -12,6 +12,7 @@ from hnn_core.drives import (drive_event_times, _get_prng, _create_extpois,
                              _create_bursty_input)
 from hnn_core.params import create_pext
 from hnn_core.network import pick_connection
+from hnn_core.network_models import jones_2009_model
 from hnn_core import simulate_dipole
 
 
@@ -402,3 +403,23 @@ def test_add_drives():
             weights_ampa={'L2_pyramidal': 1.},
             synaptic_delays={'L2_pyramidal': 1.},
             probability={'L2_pyramidal': 2.0})
+
+
+def test_drive_random_state():
+    """Tests to check same random state always gives same spike times."""
+
+    weights_ampa = {'L2_basket': 0.08, 'L2_pyramidal': 0.02,
+                    'L5_basket': 0.2, 'L5_pyramidal': 0.00865}
+    synaptic_delays = {'L2_basket': 0.1, 'L2_pyramidal': 0.1,
+                       'L5_basket': 1., 'L5_pyramidal': 1.}
+
+    net = jones_2009_model()
+    for drive_name in ['evprox1', 'evprox2']:
+        net.add_evoked_drive(
+            drive_name, mu=137.12, sigma=8, numspikes=1,
+            weights_ampa=weights_ampa, weights_nmda=None,
+            location='proximal', synaptic_delays=synaptic_delays, event_seed=4)
+
+    net._instantiate_drives(tstop=170.)
+    assert (net.external_drives['evprox1']['events'] ==
+            net.external_drives['evprox2']['events'])


### PR DESCRIPTION
closes #454 

Examples: https://2122-168215891-gh.circle-artifacts.com/0/html/index.html

This PR makes the simulation output agnostic of the order in which the drives are added. The seeds of the drives have to be adjusted for the new scheme.

Another problem that is fixed in this new scheme is that negative seeds are no longer allowed (as in numpy and other software). Earlier a negative seed would be okay because the final seed used would be `event_seed + gid` and `gid` may start from a large positive number instead of 0