### PR TITLE
[MRG] Add ability to index individual trials when plotting rasters/histograms

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,9 @@ Bug
 - Evoked drive optimization no longer assigns a default timing sigma value to
   a drive if it is not already specified, by `Ryan Thorpe`_ in :gh:`446`.
 
+- Subsets of trials can be indexed when using :func:`~hnn_core.viz.plot_spikes_raster`
+  and :func:`~hnn_core.viz.plot_spikes_hist`, by `Nick Tolley`_ in :gh:`472`.
+
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`

--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -328,11 +328,9 @@ class CellResponse(object):
         Parameters
         ----------
         trial_idx : int | list of int | None
-            Index of trials to be plotted. If None,
-            all trials plotted
+            Index of trials to be plotted. If None, all trials plotted.
         ax : instance of matplotlib axis | None
-            An axis object from matplotlib. If None,
-            a new figure is created.
+            An axis object from matplotlib. If None, a new figure is created.
         show : bool
             If True, show the figure.
 
@@ -344,14 +342,16 @@ class CellResponse(object):
         return plot_spikes_raster(
             cell_response=self, trial_idx=trial_idx, ax=ax, show=show)
 
-    def plot_spikes_hist(self, ax=None, spike_types=None, show=True):
+    def plot_spikes_hist(self, trial_idx=None, ax=None, spike_types=None,
+                         show=True):
         """Plot the histogram of spiking activity across trials.
 
         Parameters
         ----------
+        trial_idx : int | list of int | None
+            Index of trials to be plotted. If None, all trials plotted.
         ax : instance of matplotlib axis | None
-            An axis object from matplotlib. If None,
-            a new figure is created.
+            An axis object from matplotlib. If None, a new figure is created.
         spike_types: string | list | dictionary | None
             String input of a valid spike type is plotted individually.
                 Ex: 'common', 'evdist', 'evprox', 'extgauss', 'extpois'
@@ -371,8 +371,8 @@ class CellResponse(object):
         fig : instance of matplotlib Figure
             The matplotlib figure handle.
         """
-        return plot_spikes_hist(
-            self, ax=ax, spike_types=spike_types, show=show)
+        return plot_spikes_hist(self, trial_idx=trial_idx, ax=ax,
+                                spike_types=spike_types, show=show)
 
     def write(self, fname):
         """Write spiking activity per trial to a collection of files.

--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -322,11 +322,14 @@ class CellResponse(object):
 
         return spike_rates
 
-    def plot_spikes_raster(self, ax=None, show=True):
+    def plot_spikes_raster(self, trial_idx=None, ax=None, show=True):
         """Plot the aggregate spiking activity according to cell type.
 
         Parameters
         ----------
+        trial_idx : int | list of int | None
+            Index of trials to be plotted. If None,
+            all trials plotted
         ax : instance of matplotlib axis | None
             An axis object from matplotlib. If None,
             a new figure is created.
@@ -338,7 +341,8 @@ class CellResponse(object):
         fig : instance of matplotlib Figure
             The matplotlib figure object.
         """
-        return plot_spikes_raster(cell_response=self, ax=ax, show=show)
+        return plot_spikes_raster(
+            cell_response=self, trial_idx=trial_idx, ax=ax, show=show)
 
     def plot_spikes_hist(self, ax=None, spike_types=None, show=True):
         """Plot the histogram of spiking activity across trials.

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -66,7 +66,7 @@ def test_network_visualization():
                        'L5_basket', 'soma',
                        'ampa', 0.00025, 1.0, lamtha=3.0,
                        probability=0.8)
-    fig = plot_cell_connectivity(net, conn_idx)
+    fig = plot_cell_connectivity(net, conn_idx, show=False)
     ax_src, ax_target, _ = fig.axes
 
     pos = net.pos_dict['L2_pyramidal'][2]
@@ -99,17 +99,18 @@ def test_dipole_visualization():
     dpls[0].copy().savgol_filter(h_freq=30).plot(ax=axes)  # on top
 
     # test decimation options
-    plot_dipole(dpls[0], decim=2)
+    plot_dipole(dpls[0], decim=2, show=False)
     for dec in [-1, [2, 2.]]:
         with pytest.raises(ValueError,
                            match='each decimation factor must be a positive'):
-            plot_dipole(dpls[0], decim=dec)
+            plot_dipole(dpls[0], decim=dec, show=False)
 
     # test plotting multiple dipoles as overlay
-    fig = plot_dipole(dpls)
+    fig = plot_dipole(dpls, show=False)
 
     # multiple TFRs get averaged
-    fig = plot_tfr_morlet(dpls, freqs=np.arange(23, 26, 1.), n_cycles=3)
+    fig = plot_tfr_morlet(dpls, freqs=np.arange(23, 26, 1.), n_cycles=3,
+                          show=False)
 
     with pytest.raises(RuntimeError,
                        match="All dipoles must be scaled equally!"):
@@ -125,11 +126,11 @@ def test_dipole_visualization():
 
     # test cell response plotting
     with pytest.raises(TypeError, match="trial_idx must be an instance of"):
-        net.cell_response.plot_spikes_raster(trial_idx='blah')
-    net.cell_response.plot_spikes_raster(trial_idx=0)
-    net.cell_response.plot_spikes_raster(trial_idx=[0, 1])
+        net.cell_response.plot_spikes_raster(trial_idx='blah', show=False)
+    net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
+    net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
 
     with pytest.raises(TypeError, match="trial_idx must be an instance of"):
         net.cell_response.plot_spikes_hist(trial_idx='blah')
-    net.cell_response.plot_spikes_hist(trial_idx=0)
-    net.cell_response.plot_spikes_hist(trial_idx=[0, 1])
+    net.cell_response.plot_spikes_hist(trial_idx=0, show=False)
+    net.cell_response.plot_spikes_hist(trial_idx=[0, 1], show=False)

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -128,3 +128,8 @@ def test_dipole_visualization():
         net.cell_response.plot_spikes_raster(trial_idx='blah')
     net.cell_response.plot_spikes_raster(trial_idx=0)
     net.cell_response.plot_spikes_raster(trial_idx=[0, 1])
+
+    with pytest.raises(TypeError, match="trial_idx must be an instance of"):
+        net.cell_response.plot_spikes_hist(trial_idx='blah')
+    net.cell_response.plot_spikes_hist(trial_idx=0)
+    net.cell_response.plot_spikes_hist(trial_idx=[0, 1])

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -122,3 +122,9 @@ def test_dipole_visualization():
         dpl_sfreq = dpls[0].copy()
         dpl_sfreq.sfreq /= 10
         plot_psd([dpls[0], dpl_sfreq])
+
+    # test cell response plotting
+    with pytest.raises(TypeError, match="trial_idx must be an instance of"):
+        net.cell_response.plot_spikes_raster(trial_idx='blah')
+    net.cell_response.plot_spikes_raster(trial_idx=0)
+    net.cell_response.plot_spikes_raster(trial_idx=[0, 1])

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -334,8 +334,6 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
     else:
         spike_times = np.array([])
         spike_types_data = np.array([])
-    # spike_times = np.array(sum(cell_response._spike_times, []))
-    # spike_types_data = np.array(sum(cell_response._spike_types, []))
 
     unique_types = np.unique(spike_types_data)
     spike_types_mask = {s_type: np.in1d(spike_types_data, s_type)

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -321,10 +321,9 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
     if trial_idx is None:
         trial_idx = list(range(n_trials))
 
-    _validate_type(trial_idx, (int, list), 'trial_idx', 'int, list of int')
-
     if isinstance(trial_idx, int):
         trial_idx = [trial_idx]
+    _validate_type(trial_idx, list, 'trial_idx', 'int, list of int')
 
     # Extract desired trials
     if cell_response._spike_times[0]:
@@ -428,10 +427,9 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
     if trial_idx is None:
         trial_idx = list(range(n_trials))
 
-    _validate_type(trial_idx, (int, list), 'trial_idx', 'int, list of int')
-
     if isinstance(trial_idx, int):
         trial_idx = [trial_idx]
+    _validate_type(trial_idx, list, 'trial_idx', 'int, list of int')
 
     # Extract desired trials
     if cell_response._spike_times[0]:

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -326,7 +326,7 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
     _validate_type(trial_idx, list, 'trial_idx', 'int, list of int')
 
     # Extract desired trials
-    if cell_response._spike_times[0]:
+    if len(cell_response._spike_times[0]) > 0:
         spike_times = np.concatenate(
             np.array(cell_response._spike_times)[trial_idx])
         spike_types_data = np.concatenate(
@@ -430,7 +430,7 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
     _validate_type(trial_idx, list, 'trial_idx', 'int, list of int')
 
     # Extract desired trials
-    if cell_response._spike_times[0]:
+    if len(cell_response._spike_times[0]) > 0:
         spike_times = np.concatenate(
             np.array(cell_response._spike_times)[trial_idx])
         spike_types = np.concatenate(

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -284,13 +284,16 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
     return ax.get_figure()
 
 
-def plot_spikes_hist(cell_response, ax=None, spike_types=None, show=True):
+def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
+                     show=True):
     """Plot the histogram of spiking activity across trials.
 
     Parameters
     ----------
     cell_response : instance of CellResponse
         The CellResponse object from net.cell_response
+    trial_idx : int | list of int | None
+        Index of trials to be plotted. If None, all trials plotted.
     ax : instance of matplotlib axis | None
         An axis object from matplotlib. If None,
         a new figure is created.
@@ -314,8 +317,26 @@ def plot_spikes_hist(cell_response, ax=None, spike_types=None, show=True):
         The matplotlib figure handle.
     """
     import matplotlib.pyplot as plt
-    spike_times = np.array(sum(cell_response._spike_times, []))
-    spike_types_data = np.array(sum(cell_response._spike_types, []))
+    n_trials = len(cell_response.spike_times)
+    if trial_idx is None:
+        trial_idx = list(range(n_trials))
+
+    _validate_type(trial_idx, (int, list), 'trial_idx', 'int, list of int')
+
+    if isinstance(trial_idx, int):
+        trial_idx = [trial_idx]
+
+    # Extract desired trials
+    if cell_response._spike_times[0]:
+        spike_times = np.concatenate(
+            np.array(cell_response._spike_times)[trial_idx])
+        spike_types_data = np.concatenate(
+            np.array(cell_response._spike_types)[trial_idx])
+    else:
+        spike_times = np.array([])
+        spike_types_data = np.array([])
+    # spike_times = np.array(sum(cell_response._spike_times, []))
+    # spike_types_data = np.array(sum(cell_response._spike_types, []))
 
     unique_types = np.unique(spike_types_data)
     spike_types_mask = {s_type: np.in1d(spike_types_data, s_type)
@@ -390,11 +411,9 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
     cell_response : instance of CellResponse
         The CellResponse object from net.cell_response
     trial_idx : int | list of int | None
-        Index of trials to be plotted. If None,
-        all trials plotted
+        Index of trials to be plotted. If None, all trials plotted
     ax : instance of matplotlib axis | None
-        An axis object from matplotlib. If None,
-        a new figure is created.
+        An axis object from matplotlib. If None, a new figure is created.
     show : bool
         If True, show the figure.
 


### PR DESCRIPTION
Closes #471 Implements the ability to filter out specific trials either through lists or integers:
```py
net.cell_response.plot_spikes_raster(trial_idx=0)
net.cell_response.plot_spikes_raster(trial_idx=[0, 1])
```

