### PR TITLE
[MRG] Add average dpl plot

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,6 +34,9 @@ Bug
 - Subsets of trials can be indexed when using :func:`~hnn_core.viz.plot_spikes_raster`
   and :func:`~hnn_core.viz.plot_spikes_hist`, by `Nick Tolley`_ in :gh:`472`.
 
+- Add option to plot the averaged dipole in `~hnn_core.viz.plot_dipole` when `dpl` is a list of dipoles, 
+  by `Huzi Cheng`_ in :gh:`475`.
+
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -303,6 +303,7 @@ People who contributed to this release (in alphabetical order):
 .. _Christopher Bailey: https://github.com/cjayb
 .. _Carmen Kohl: https://github.com/kohl-carmen
 .. _Dylan Daniels: https://github.com/dylansdaniels
+.. _Huzi Cheng: https://github.com/chenghuzi
 .. _Kenneth Loi: https://github.com/kenloi
 .. _Mainak Jas: http://jasmainak.github.io/
 .. _Nick Tolley: https://github.com/ntolley

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,8 +34,8 @@ Bug
 - Subsets of trials can be indexed when using :func:`~hnn_core.viz.plot_spikes_raster`
   and :func:`~hnn_core.viz.plot_spikes_hist`, by `Nick Tolley`_ in :gh:`472`.
 
-- Add option to plot the averaged dipole in `~hnn_core.viz.plot_dipole` when `dpl` is a list of dipoles, 
-  by `Huzi Cheng`_ in :gh:`475`.
+- Add option to plot the averaged dipole in `~hnn_core.viz.plot_dipole` when `dpl`
+  is a list of dipoles, by `Huzi Cheng`_ in :gh:`475`.
 
 API
 ~~~

--- a/examples/workflows/plot_simulate_alpha.py
+++ b/examples/workflows/plot_simulate_alpha.py
@@ -74,10 +74,9 @@ dpl_smooth = dpl[trial_idx].copy().smooth(window_len)
 
 # Overlay the traces for comparison. The function plot_dipole can plot a list
 # of dipoles at once
-dpl_list = [dpl[trial_idx], dpl_smooth]
-plot_dipole(dpl_list, tmin=tmin, tmax=tmax, ax=axes[0], show=False)
+dpl[trial_idx].plot(tmin=tmin, tmax=tmax, color='b', ax=axes[0], show=False)
+dpl_smooth.plot(tmin=tmin, tmax=tmax, color='r', ax=axes[0], show=False)
 axes[0].set_xlim((1, 399))
-axes[0].legend(['orig', 'smooth'])
 
 plot_psd(dpl[trial_idx], fmin=1., fmax=1e3, tmin=tmin, ax=axes[1], show=False)
 axes[1].set_xscale('log')
@@ -112,8 +111,8 @@ net.cell_response.plot_spikes_hist(ax=axes[0])
 smooth_dpl = dpl[trial_idx].copy().smooth(window_len)
 
 # Note that using the ``plot_*``-functions are available as ``Dipole``-methods:
-dpl[trial_idx].plot(tmin=tmin, tmax=tmax, ax=axes[1], show=False)
-smooth_dpl.plot(tmin=tmin, tmax=tmax, ax=axes[1], show=False)
+dpl[trial_idx].plot(tmin=tmin, tmax=tmax, ax=axes[1], color='b', show=False)
+smooth_dpl.plot(tmin=tmin, tmax=tmax, ax=axes[1], color='r', show=False)
 
 dpl[trial_idx].plot_psd(fmin=0., fmax=40., tmin=tmin, ax=axes[2])
 plt.tight_layout()

--- a/examples/workflows/plot_simulate_beta.py
+++ b/examples/workflows/plot_simulate_beta.py
@@ -178,7 +178,7 @@ fig, axes = plt.subplots(4, 1, sharex=True, figsize=(7, 7),
                          constrained_layout=True)
 net_beta.cell_response.plot_spikes_hist(ax=axes[0], show=False)
 axes[0].set_title('Beta Event Generation')
-plot_dipole(dpls_beta, ax=axes[1], layer='agg', tmin=1.0, show=False)
+plot_dipole(dpls_beta, ax=axes[1], layer='agg', tmin=1.0, color='b', show=False)
 net_beta.cell_response.plot_spikes_raster(ax=axes[2], show=False)
 axes[2].set_title('Spike Raster')
 
@@ -194,7 +194,8 @@ dpls_beta[0].plot_tfr_morlet(freqs, n_cycles=7, ax=axes[3])
 dpls_beta_erp[0].smooth(45)
 fig, axes = plt.subplots(3, 1, sharex=True, figsize=(7, 7),
                          constrained_layout=True)
-plot_dipole(dpls_beta_erp, ax=axes[0], layer='agg', tmin=1.0, show=False)
+plot_dipole(dpls_beta_erp, ax=axes[0], layer='agg', tmin=1.0, color='r',
+            show=False)
 axes[0].set_title('Beta Event + ERP')
 net_beta_erp.cell_response.plot_spikes_hist(ax=axes[1], show=False)
 axes[1].set_title('Input Drives Histogram')
@@ -210,8 +211,9 @@ axes[2].set_title('Spike Raster')
 dpls_erp[0].smooth(45)
 fig, axes = plt.subplots(3, 1, sharex=True, figsize=(7, 7),
                          constrained_layout=True)
-plot_dipole(dpls_beta_erp, ax=axes[0], layer='agg', tmin=1.0, show=False)
-plot_dipole(dpls_erp, ax=axes[0], layer='agg', tmin=1.0, show=False)
+plot_dipole(dpls_beta_erp, ax=axes[0], layer='agg', tmin=1.0, color='r',
+            show=False)
+plot_dipole(dpls_erp, ax=axes[0], layer='agg', tmin=1.0, color='b', show=False)
 axes[0].set_title('Beta ERP Comparison')
 axes[0].legend(['ERP + Beta', 'ERP'])
 net_beta_erp.cell_response.plot_spikes_raster(ax=axes[1], show=False)

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -151,6 +151,8 @@ def average_dipoles(dpls):
         )
     avg_data = np.c_[avg_data].T
     avg_dpl = Dipole(dpls[0].times, avg_data)
+    # The averaged scale should equal all scals in the input dpl list.
+    avg_dpl.scale_applied = dpls[0].scale_applied
 
     # set nave to the number of trials averaged in this dipole
     avg_dpl.nave = len(dpls)

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -133,7 +133,10 @@ def average_dipoles(dpls):
         A new dipole object with each component of `dpl.data` representing the
         average over the same components in the input list
     """
+    scale_applied = dpls[0].scale_applied
     for dpl_idx, dpl in enumerate(dpls):
+        if dpl.scale_applied != scale_applied:
+            raise RuntimeError('All dipoles must be scaled equally!')
         if not isinstance(dpl, Dipole):
             raise ValueError(
                 f"All elements in the list should be instances of "
@@ -152,7 +155,7 @@ def average_dipoles(dpls):
     avg_data = np.c_[avg_data].T
     avg_dpl = Dipole(dpls[0].times, avg_data)
     # The averaged scale should equal all scals in the input dpl list.
-    avg_dpl.scale_applied = dpls[0].scale_applied
+    avg_dpl.scale_applied = scale_applied
 
     # set nave to the number of trials averaged in this dipole
     avg_dpl.nave = len(dpls)

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -392,7 +392,7 @@ class Dipole(object):
         return self
 
     def plot(self, tmin=None, tmax=None, layer='agg', decim=None, ax=None,
-             color=None, show=True):
+             color='k', show=True):
         """Simple layer-specific plot function.
 
         Parameters
@@ -408,7 +408,7 @@ class Dipole(object):
         ax : instance of matplotlib figure | None
             The matplotlib axis
         color : tuple of float
-            RGBA value to use for plotting (optional)
+            RGBA value to use for plotting. By default, 'k' (black)
         show : bool
             If True, show the figure
 

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -49,6 +49,12 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
         assert_allclose(dipole_read.data[dpl_key],
                         dipole.data[dpl_key], rtol=0, atol=0.000051)
 
+    # dpls with different scale_applied should not be averaged.
+    with pytest.raises(RuntimeError, match="All dipoles must be scaled equally"
+                       "!"):
+        dipole_avg = average_dipoles([dipole, dipole_read])
+    # force the scale_applied to be identical across dpls to allow averaging.
+    dipole.scale_applied = dipole_read.scale_applied
     # average two identical dipole objects
     dipole_avg = average_dipoles([dipole, dipole_read])
     for dpl_key in dipole_avg.data.keys():

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -50,8 +50,7 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
                         dipole.data[dpl_key], rtol=0, atol=0.000051)
 
     # dpls with different scale_applied should not be averaged.
-    with pytest.raises(RuntimeError, match="All dipoles must be scaled equally"
-                       "!"):
+    with pytest.raises(RuntimeError, match="All dipoles must be scaled equally"):
         dipole_avg = average_dipoles([dipole, dipole_read])
     # force the scale_applied to be identical across dpls to allow averaging.
     dipole.scale_applied = dipole_read.scale_applied

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -50,7 +50,8 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
                         dipole.data[dpl_key], rtol=0, atol=0.000051)
 
     # dpls with different scale_applied should not be averaged.
-    with pytest.raises(RuntimeError, match="All dipoles must be scaled equally"):
+    with pytest.raises(RuntimeError,
+                       match="All dipoles must be scaled equally"):
         dipole_avg = average_dipoles([dipole, dipole_read])
     # force the scale_applied to be identical across dpls to allow averaging.
     dipole.scale_applied = dipole_read.scale_applied

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -108,6 +108,9 @@ def test_dipole_visualization():
     # test plotting multiple dipoles as overlay
     fig = plot_dipole(dpls, show=False)
 
+    # test plotting multiple dipoles with average
+    fig = plot_dipole(dpls, average=True, show=False)
+
     # multiple TFRs get averaged
     fig = plot_tfr_morlet(dpls, freqs=np.arange(23, 26, 1.), n_cycles=3,
                           show=False)

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -256,7 +256,6 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
     if isinstance(dpl, Dipole):
         dpl = [dpl]
         average = False
-        alpha = 1
     else:
         # add average plot when we have dpl>1 and `average` is specified.
         if average:

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -252,7 +252,6 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
     if isinstance(dpl, Dipole):
         dpl = [dpl]
     else:
-        # add average plot when we have dpl>1 and `average` is specified.
         if average:
             dpl = dpl + [average_dipoles(dpl)]
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -251,7 +251,8 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
 
     if isinstance(dpl, Dipole):
         dpl = [dpl]
-    dpl = dpl + [average_dipoles(dpl)]
+    else:
+        dpl = dpl + [average_dipoles(dpl)]
 
     scale_applied = dpl[0].scale_applied
     for idx, dpl_trial in enumerate(dpl):

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -280,7 +280,8 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
                         label="average",
                         lw=linewidth * 1.5)
             else:
-                ax.plot(times, data, color="gray", alpha=0.5, lw=linewidth)
+                alpha = 0.5 if average else 1.
+                ax.plot(times, data, color=color, alpha=alpha, lw=linewidth)
     if average:
         ax.legend()
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -251,7 +251,6 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
 
     if isinstance(dpl, Dipole):
         dpl = [dpl]
-        average = False
     else:
         # add average plot when we have dpl>1 and `average` is specified.
         if average:

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -276,7 +276,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
                 # the last one (average dpl)
                 ax.plot(times,
                         data,
-                        color=color,
+                        color='g',
                         label="average",
                         lw=linewidth * 1.5)
             else:

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -217,7 +217,7 @@ def plot_dipole(dpl,
                 decim=None,
                 color=None,
                 average=True,
-                individual_alpha=0.5,
+                alpha=0.5,
                 linewidth=1.5,
                 show=True):
     """Simple layer-specific plot function.
@@ -244,7 +244,7 @@ def plot_dipole(dpl,
         RGBA value to use for plotting (optional)
     average : bool
         If True, render the average across all dpls.
-    individual_alpha : float
+    alpha : float
         The alpha value of individual dpls.
     linewidth : float
         The width of dpl lines.
@@ -265,7 +265,7 @@ def plot_dipole(dpl,
     if isinstance(dpl, Dipole):
         dpl = [dpl]
         average = False
-        individual_alpha = 1
+        alpha = 1
     else:
         # add average plot when we have dpl>1 and `average` is specified.
         if average:
@@ -293,11 +293,7 @@ def plot_dipole(dpl,
                         label="average",
                         lw=linewidth * 1.5)
             else:
-                ax.plot(times,
-                        data,
-                        color="gray",
-                        alpha=individual_alpha,
-                        lw=linewidth)
+                ax.plot(times, data, color="gray", alpha=alpha, lw=linewidth)
     if average:
         ax.legend()
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -210,7 +210,7 @@ def plot_extracellular(times, data, tmin=None, tmax=None, ax=None,
 
 
 def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
-                color=None, average=True, alpha=0.5, linewidth=1.5, show=True):
+                color=None, average=True, show=True):
     """Simple layer-specific plot function.
 
     Parameters
@@ -235,10 +235,6 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
         RGBA value to use for plotting (optional)
     average : bool
         If True, render the average across all dpls.
-    alpha : float
-        The alpha value of individual dpls.
-    linewidth : float
-        The width of dpl lines.
     show : bool
         If True, show the figure
 
@@ -261,6 +257,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
         if average:
             dpl = dpl + [average_dipoles(dpl)]
 
+    linewidth = 1.5
     scale_applied = dpl[0].scale_applied
     for idx, dpl_trial in enumerate(dpl):
         if dpl_trial.scale_applied != scale_applied:
@@ -283,7 +280,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
                         label="average",
                         lw=linewidth * 1.5)
             else:
-                ax.plot(times, data, color="gray", alpha=alpha, lw=linewidth)
+                ax.plot(times, data, color="gray", alpha=0.5, lw=linewidth)
     if average:
         ax.legend()
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -210,7 +210,7 @@ def plot_extracellular(times, data, tmin=None, tmax=None, ax=None,
 
 
 def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
-                color=None, average=False, show=True):
+                color='k', average=False, show=True):
     """Simple layer-specific plot function.
 
     Parameters
@@ -232,7 +232,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
         recommends values <13. To achieve higher decimation factors, a list of
         ints can be provided. These are applied successively.
     color : tuple of float
-        RGBA value to use for plotting (optional)
+        RGBA value to use for plotting. By default, 'k' (black)
     average : bool
         If True, render the average across all dpls.
     show : bool
@@ -251,10 +251,8 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
 
     if isinstance(dpl, Dipole):
         dpl = [dpl]
-    else:
-        dpl = dpl + [average_dipoles(dpl)]
+    dpl = dpl + [average_dipoles(dpl)]
 
-    linewidth = 1.5
     scale_applied = dpl[0].scale_applied
     for idx, dpl_trial in enumerate(dpl):
         if dpl_trial.scale_applied != scale_applied:
@@ -270,15 +268,12 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
                 data, times = _decimate_plot_data(decim, data, times)
 
             if idx == len(dpl) - 1 and average:
-                # the last one (average dpl)
-                ax.plot(times,
-                        data,
-                        color='g',
-                        label="average",
-                        lw=linewidth * 1.5)
+                # the average dpl
+                ax.plot(times, data, color='g', label="average", lw=1.5)
             else:
                 alpha = 0.5 if average else 1.
-                ax.plot(times, data, color=color, alpha=alpha, lw=linewidth)
+                ax.plot(times, data, color=color, alpha=alpha, lw=1.)
+
     if average:
         ax.legend()
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -210,7 +210,7 @@ def plot_extracellular(times, data, tmin=None, tmax=None, ax=None,
 
 
 def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
-                color=None, average=True, show=True):
+                color=None, average=False, show=True):
     """Simple layer-specific plot function.
 
     Parameters

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -252,7 +252,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
     if isinstance(dpl, Dipole):
         dpl = [dpl]
     else:
-            dpl = dpl + [average_dipoles(dpl)]
+        dpl = dpl + [average_dipoles(dpl)]
 
     linewidth = 1.5
     scale_applied = dpl[0].scale_applied

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -209,17 +209,8 @@ def plot_extracellular(times, data, tmin=None, tmax=None, ax=None,
     return ax.get_figure()
 
 
-def plot_dipole(dpl,
-                tmin=None,
-                tmax=None,
-                ax=None,
-                layer='agg',
-                decim=None,
-                color=None,
-                average=True,
-                alpha=0.5,
-                linewidth=1.5,
-                show=True):
+def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
+                color=None, average=True, alpha=0.5, linewidth=1.5, show=True):
     """Simple layer-specific plot function.
 
     Parameters

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -269,7 +269,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
 
             if i == len(dpls) - 1:
                 # the last one (average dpl) or the single dpl
-                ax.plot(times, data, color="green")
+                ax.plot(times, data, color=color)
             else:
                 ax.plot(times, data, color="gray")
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -242,16 +242,19 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
         The matplotlib figure handle.
     """
     import matplotlib.pyplot as plt
-    from .dipole import Dipole
+    from .dipole import Dipole, average_dipoles
 
     if ax is None:
         _, ax = plt.subplots(1, 1, constrained_layout=True)
 
     if isinstance(dpl, Dipole):
-        dpl = [dpl]
+        dpls = [dpl]
+    else:
+        # add average plot only when we have  trials>1.
+        dpls = dpl + [average_dipoles(dpl)]
 
-    scale_applied = dpl[0].scale_applied
-    for dpl_trial in dpl:
+    scale_applied = dpls[0].scale_applied
+    for i, dpl_trial in enumerate(dpls):
         if dpl_trial.scale_applied != scale_applied:
             raise RuntimeError('All dipoles must be scaled equally!')
 
@@ -259,12 +262,16 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
 
             # extract scaled data and times
             data, times = _get_plot_data_trange(dpl_trial.times,
-                                                dpl_trial.data[layer],
-                                                tmin, tmax)
+                                                dpl_trial.data[layer], tmin,
+                                                tmax)
             if decim is not None:
                 data, times = _decimate_plot_data(decim, data, times)
 
-            ax.plot(times, data, color=color)
+            if i == len(dpls) - 1:
+                # the last one (average dpl) or the single dpl
+                ax.plot(times, data, color="green")
+            else:
+                ax.plot(times, data, color="gray")
 
     ax.ticklabel_format(axis='both', scilimits=(-2, 3))
     ax.set_xlabel('Time (ms)')

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -252,7 +252,6 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
     if isinstance(dpl, Dipole):
         dpl = [dpl]
     else:
-        if average:
             dpl = dpl + [average_dipoles(dpl)]
 
     linewidth = 1.5

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -273,7 +273,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
                 data, times = _decimate_plot_data(decim, data, times)
 
             if idx == len(dpl) - 1 and average:
-                # the last one (average dpl) or the single dpl
+                # the last one (average dpl)
                 ax.plot(times,
                         data,
                         color=color,

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -251,7 +251,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
 
     if isinstance(dpl, Dipole):
         dpl = [dpl]
-    else:
+    elif average:
         dpl = dpl + [average_dipoles(dpl)]
 
     scale_applied = dpl[0].scale_applied


### PR DESCRIPTION
To address #473 , we add an extra line plot when the `dpl` in `plot_dipole` is a list. All individual trial lines are colored gray while the average one is green. And if the dpl is a `Dipole` instance, the single trial will be green. 

Below is the current behavior:
<img width="643" alt="image" src="https://user-images.githubusercontent.com/11160442/159425125-63940e2f-e873-4da5-a9bd-35e2de9253be.png">


Also, I changed the way to turn `dpl` into a list, as a function should not modify its parameters especially when the purpose is to draw something. Because the user may expect the `dpl` to stay the original type after multiple calls of the visualization function (for reasons like refining styles).
