### PR TITLE
[MRG] DOC: update link to parallel.rst in contributors guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -70,4 +70,4 @@ Continuous Integration
 The repository is tested via continuous integration with Travis and Circle. The automated
 tests run on Travis while the documentation is built on Circle.
 
-.. _parallel_backends: https://jonescompneurolab.github.io/hnn-core/parallel.html
+.. _parallel_backends: https://github.com/jonescompneurolab/hnn-core/blob/master/doc/parallel.rst


### PR DESCRIPTION
The current link in the [contributors guide](https://github.com/jonescompneurolab/hnn-core/blob/master/CONTRIBUTING.rst) for the [parallel backend installation instructions](https://github.com/jonescompneurolab/hnn-core/blob/master/doc/parallel.rst) points [here](https://jonescompneurolab.github.io/hnn-core/parallel.html). Since we don't currently compile the contributors guide via sphinx on the stable branches, the updated link here points toward whichever 'parallel.rst' file is on the master branch.