### PR TITLE
[MRG] DOC: build parallel.rst and contributing.rst with sphinx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ To start the GUI, please do::
 **Parallel backends**
 
 For further instructions on installation and usage of parallel backends for using more
-than one CPU core, refer to `parallel_backends`_
+than one CPU core, refer to our :doc:`parallel backend guide <parallel>`.
 
 **Note for Windows users**
 
@@ -129,6 +129,4 @@ report bugs. For user questions and scientific discussions, please join the
 Interested in Contributing?
 ===========================
 
-Read our `contributing guide <https://jonescompneurolab.github.io/hnn-core/stable/contributing.html>`_.
-
-.. _parallel_backends: https://jonescompneurolab.github.io/hnn-core/stable/parallel.html
+Read our :doc:`contributing guide <contributing>`.

--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,6 @@ report bugs. For user questions and scientific discussions, please join the
 Interested in Contributing?
 ===========================
 
-Read our `contributing guide <https://github.com/jonescompneurolab/hnn-core/blob/master/CONTRIBUTING.rst>`_.
+Read our `contributing guide <https://jonescompneurolab.github.io/hnn-core/stable/contributing.html>`_.
 
 .. _parallel_backends: https://jonescompneurolab.github.io/hnn-core/stable/parallel.html

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -70,4 +70,4 @@ Continuous Integration
 The repository is tested via continuous integration with Travis and Circle. The automated
 tests run on Travis while the documentation is built on Circle.
 
-.. _parallel_backends: https://github.com/jonescompneurolab/hnn-core/blob/master/doc/parallel.rst
+.. _parallel_backends: https://jonescompneurolab.github.io/hnn-core/stable/parallel.html

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -60,9 +60,9 @@ You can build the documentation locally using the command::
     $ cd doc/
     $ make html
 
-While MNE is not needed to install hnn-core, as a developer you will need to install it
-to run all the examples successfully. Please find
-the installation instructions on the `MNE website <https://mne.tools/stable/install/mne_python.html>`_.
+While MNE is not needed to install hnn-core, as a developer you will need to
+install it to run all the examples successfully. Please find the installation
+instructions on the `MNE website <https://mne.tools/stable/install/index.html>`_.
 
 If you want to build the documentation locally without running all the examples,
 use the command::

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -10,7 +10,9 @@ it can be incorporated into the master branch.
 To help developing ``hnn-core``, you will need a few adjustments to your
 installation as shown below.
 
-If your contributions will make use of parallel backends for using more than one core, please see the additional installation steps for `parallel_backends`_
+If your contributions will make use of parallel backends for using more than
+one core, please see the additional installation steps in our
+:doc:`parallel backend guide <parallel>`.
 
 Running tests
 =============
@@ -31,7 +33,9 @@ If you update a mod file, you will have to rebuild them using the command::
 
     $ python setup.py build_mod
 
-MPI tests are skipped if the ``mpi4py`` module is not installed. This allows testing features not related to parallelization without installing the extra dependencies as described in `parallel_backends`_.
+MPI tests are skipped if the ``mpi4py`` module is not installed. This allows
+testing features not related to parallelization without installing the extra
+dependencies as described in our :doc:`parallel backend guide <parallel>`.
 
 Updating documentation
 ======================
@@ -46,7 +50,8 @@ install the following::
 
     $ pip install matplotlib sphinx numpydoc sphinx-gallery sphinx_bootstrap_theme pillow mpi4py joblib psutil
 
-If you are using a newer version of pip, you may be prompted to use the flag ``--use-feature=2020-resolver``. If this happens, please add it as recommended::
+If you are using a newer version of pip, you may be prompted to use the flag
+``--use-feature=2020-resolver``. If this happens, please add it as recommended::
 
     $ pip install --use-feature=2020-resolver matplotlib sphinx numpydoc sphinx-gallery sphinx_bootstrap_theme pillow mpi4py joblib psutil
 
@@ -69,5 +74,3 @@ Continuous Integration
 
 The repository is tested via continuous integration with Travis and Circle. The automated
 tests run on Travis while the documentation is built on Circle.
-
-.. _parallel_backends: https://jonescompneurolab.github.io/hnn-core/stable/parallel.html

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -72,5 +72,6 @@ use the command::
 Continuous Integration
 ======================
 
-The repository is tested via continuous integration with Travis and Circle. The automated
-tests run on Travis while the documentation is built on Circle.
+The repository is tested via continuous integration with GitHub Actions and
+Circle. The automated tests run on GitHub Actions while the documentation is
+built on Circle.

--- a/examples/howto/plot_record_extracellular_potentials.py
+++ b/examples/howto/plot_record_extracellular_potentials.py
@@ -111,7 +111,7 @@ plt.show()
 # References
 # ----------
 # .. [1] Jones, S. R. et al. Quantitative analysis and biophysically realistic
-#    neural modeling of the MEG mu rhythm: rhythmogenesis and modulation of
-#    sensory-evoked responses. J. Neurophysiol. 102, 3554–3572 (2009).
+#        neural modeling of the MEG mu rhythm: rhythmogenesis and modulation of
+#        sensory-evoked responses. J. Neurophysiol. 102, 3554–3572 (2009).
 # .. [2] Kajikawa, Y. & Schroeder, C. E. How local is the local field
 #        potential? Neuron 72, 847–858 (2011).

--- a/examples/workflows/plot_simulate_alpha.py
+++ b/examples/workflows/plot_simulate_alpha.py
@@ -121,5 +121,5 @@ plt.tight_layout()
 # References
 # ----------
 # .. [1] Jones, S. R. et al. Quantitative analysis and biophysically realistic
-#    neural modeling of the MEG mu rhythm: rhythmogenesis and modulation of
-#    sensory-evoked responses. J. Neurophysiol. 102, 3554–3572 (2009).
+#        neural modeling of the MEG mu rhythm: rhythmogenesis and modulation of
+#        sensory-evoked responses. J. Neurophysiol. 102, 3554–3572 (2009).

--- a/examples/workflows/plot_simulate_evoked.py
+++ b/examples/workflows/plot_simulate_evoked.py
@@ -170,5 +170,5 @@ net_sync.cell_response.plot_spikes_hist()
 # References
 # ----------
 # .. [1] Jones, Stephanie R., et al. "Neural correlates of tactile detection:
-# a combined magnetoencephalography and biophysically based computational
-# modeling study." Journal of Neuroscience 27.40 (2007): 10751-10764.
+#        a combined magnetoencephalography and biophysically based computational
+#        modeling study." Journal of Neuroscience 27.40 (2007): 10751-10764.

--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -354,15 +354,22 @@ class CellResponse(object):
             An axis object from matplotlib. If None, a new figure is created.
         spike_types: string | list | dictionary | None
             String input of a valid spike type is plotted individually.
-                Ex: 'common', 'evdist', 'evprox', 'extgauss', 'extpois'
+
+            | Ex: ``'poisson'``, ``'evdist'``, ``'evprox'``, ...
+
             List of valid string inputs will plot each spike type individually.
-                Ex: ['common', 'evdist']
+
+            | Ex: ``['poisson', 'evdist']``
+
             Dictionary of valid lists will plot list elements as a group.
-                Ex: {'Evoked': ['evdist', 'evprox'], 'External': ['extpois']}
+
+            | Ex: ``{'Evoked': ['evdist', 'evprox'], 'Tonic': ['poisson']}``
+
             If None, all input spike types are plotted individually if any
             are present. Otherwise spikes from all cells are plotted.
             Valid strings also include leading characters of spike types
-                Example: 'ext' is equivalent to ['extgauss', 'extpois']
+
+            | Ex: ``'ev'`` is equivalent to ``['evdist', 'evprox']``
         show : bool
             If True, show the figure.
 
@@ -370,7 +377,6 @@ class CellResponse(object):
         -------
         fig : instance of matplotlib Figure
             The matplotlib figure handle.
-
         """
         return plot_spikes_hist(self, trial_idx=trial_idx, ax=ax,
                                 spike_types=spike_types, show=show)

--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -370,6 +370,7 @@ class CellResponse(object):
         -------
         fig : instance of matplotlib Figure
             The matplotlib figure handle.
+
         """
         return plot_spikes_hist(self, trial_idx=trial_idx, ax=ax,
                                 spike_types=spike_types, show=show)

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -540,6 +540,7 @@ class Network(object):
         -----
         Random seeding behavior across trials is different for event_seed
         and conn_seed (n_trials > 1 in simulate_dipole(..., n_trials)
+
         event_seed
             Across trials, the random seed is incremented leading such that
             the exact spike times are different
@@ -1097,6 +1098,7 @@ class Network(object):
         Notes
         -----
         Connections are stored in:
+
         net.connectivity[idx]['gid_pairs'] : dict
             dict indexed by src gids with the format:
             {src_gid: [target_gids, ...], ...}

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -327,11 +327,11 @@ class Network(object):
         Synaptic delay in ms.
 
     Notes
-    ----
-    `net = jones_2009_model(params)` is the reccomended path for creating a
-    network. Instantiating the network as `net = Network(params)` will
+    -----
+    ``net = jones_2009_model(params)`` is the reccomended path for creating a
+    network. Instantiating the network as ``net = Network(params)`` will
     produce a network with no cell-to-cell connections. As such,
-    connectivity information contained in `params` will be ignored.
+    connectivity information contained in ``params`` will be ignored.
     """
 
     def __init__(self, params, add_drives_from_params=False, legacy_mode=True):
@@ -539,15 +539,14 @@ class Network(object):
         Notes
         -----
         Random seeding behavior across trials is different for event_seed
-        and conn_seed (n_trials > 1 in simulate_dipole(..., n_trials)
+        and conn_seed (n_trials > 1 in simulate_dipole(..., n_trials):
 
-        event_seed
+        - event_seed
             Across trials, the random seed is incremented leading such that
             the exact spike times are different
-        conn_seed
+        - conn_seed
             The random seed does not change across trials. This means for
             probability < 1.0, the random subset of gids targeted is the same.
-
         """
         if not self._legacy_mode:
             _check_drive_parameter_values('evoked', sigma=sigma,
@@ -1097,12 +1096,10 @@ class Network(object):
 
         Notes
         -----
-        Connections are stored in:
-
-        net.connectivity[idx]['gid_pairs'] : dict
-            dict indexed by src gids with the format:
-            {src_gid: [target_gids, ...], ...}
-            where each src_gid indexes a list of all its targets.
+        Connections are stored in ``net.connectivity[idx]['gid_pairs']``, a
+        dictionary indexed by src gids with the format:
+        {src_gid: [target_gids, ...], ...} where each src_gid indexes a list of
+        all its targets.
         """
         conn = _Connectivity()
         threshold = self.threshold

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -321,15 +321,22 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
         a new figure is created.
     spike_types: string | list | dictionary | None
         String input of a valid spike type is plotted individually.
-            Ex: 'poisson', 'evdist', 'evprox', ...
+
+        | Ex: ``'poisson'``, ``'evdist'``, ``'evprox'``, ...
+
         List of valid string inputs will plot each spike type individually.
-            Ex: ['poisson', 'evdist']
+
+        | Ex: ``['poisson', 'evdist']``
+
         Dictionary of valid lists will plot list elements as a group.
-            Ex: {'Evoked': ['evdist', 'evprox'], 'Tonic': ['poisson']}
+
+        | Ex: ``{'Evoked': ['evdist', 'evprox'], 'Tonic': ['poisson']}``
+
         If None, all input spike types are plotted individually if any
         are present. Otherwise spikes from all cells are plotted.
         Valid strings also include leading characters of spike types
-            Example: 'ev' is equivalent to ['evdist', 'evprox']
+
+        | Ex: ``'ev'`` is equivalent to ``['evdist', 'evprox']``
     show : bool
         If True, show the figure.
 
@@ -337,7 +344,6 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
     -------
     fig : instance of matplotlib Figure
         The matplotlib figure handle.
-
     """
     import matplotlib.pyplot as plt
     n_trials = len(cell_response.spike_times)

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -337,6 +337,7 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
     -------
     fig : instance of matplotlib Figure
         The matplotlib figure handle.
+
     """
     import matplotlib.pyplot as plt
     n_trials = len(cell_response.spike_times)


### PR DESCRIPTION
This is a quick follow-up to #483, based off of a prior [suggestion](https://github.com/jonescompneurolab/hnn-core/pull/483#issuecomment-1179569301) given that our contributing guide is not currently compiled along with the rest of the `doc/` directory. Note that instead of referencing `hnn-core/contributing.rst` in `hnn-core/doc/index.rst`, however, I've just moved the actual contributing guide file to `hnn-core/doc/contributing.rst`.

Also, all links in the docs to the parallel backend instructions and contributing guide now reference the latest stable version.