### PR TITLE
[MRG] DOC: update badges in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 hnn-core
 ========
 
-|tests| |CircleCI| |Codecov| |PyPI| |voila-binder|
+|tests| |CircleCI| |Codecov| |PyPI|
 
 |HNN-GUI|
 
@@ -16,9 +16,6 @@ hnn-core
 
 .. |PyPI| image:: https://img.shields.io/pypi/dm/hnn-core.svg?label=PyPI%20downloads
 	:target: https://pypi.org/project/hnn-core/
-
-.. |voila-binder| .. image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/jonescompneurolab/hnn-core/HEAD?urlpath=voila%2Frender%2Fhnn_core%2Fgui%2Fhnn_widget.ipynb
 
 .. |HNN-GUI| image:: https://user-images.githubusercontent.com/11160442/178095018-35d2619a-6a82-4e27-91c9-ff2796fab435.png
 

--- a/README.rst
+++ b/README.rst
@@ -131,4 +131,6 @@ report bugs. For user questions and scientific discussions, please join the
 Interested in Contributing?
 ===========================
 
-Read our :doc:`contributing guide <contributing>`.
+Read our `contributing guide`_.
+
+.. _contributing guide: https://jonescompneurolab.github.io/hnn-core/dev/contributing.html

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ To start the GUI, please do::
 **Parallel backends**
 
 For further instructions on installation and usage of parallel backends for using more
-than one CPU core, refer to our :doc:`parallel backend guide <parallel>`.
+than one CPU core, refer to our `parallel backend guide`_.
 
 **Note for Windows users**
 
@@ -133,4 +133,5 @@ Interested in Contributing?
 
 Read our `contributing guide`_.
 
+.. _parallel backend guide: https://jonescompneurolab.github.io/hnn-core/dev/parallel.html
 .. _contributing guide: https://jonescompneurolab.github.io/hnn-core/dev/contributing.html

--- a/README.rst
+++ b/README.rst
@@ -1,21 +1,20 @@
 hnn-core
 ========
 
-.. image:: https://circleci.com/gh/jonescompneurolab/hnn-core.svg?style=svg
+|tests| |CircleCI| |Codecov|
+
+|HNN-GUI|
+
+.. |tests| image:: https://github.com/jonescompneurolab/hnn-core/actions/workflows/unit_tests.yml/badge.svg?branch=master
+   :target: https://github.com/jonescompneurolab/hnn-core/actions/?query=branch:master+event:push
+
+.. |CircleCI| image:: https://circleci.com/gh/jonescompneurolab/hnn-core.svg?style=svg
    :target: https://circleci.com/gh/jonescompneurolab/hnn-core
-   :alt: CircleCi
 
-.. image:: https://api.travis-ci.org/jonescompneurolab/hnn-core.svg?branch=master
-    :target: https://travis-ci.org/jonescompneurolab/hnn-core
-    :alt: Build Status
-
-.. image:: https://codecov.io/gh/jonescompneurolab/hnn-core/branch/master/graph/badge.svg
+.. |Codecov| image:: https://codecov.io/gh/jonescompneurolab/hnn-core/branch/master/graph/badge.svg
 	:target: https://codecov.io/gh/jonescompneurolab/hnn-core
-	:alt: Test coverage
 
-.. image:: https://user-images.githubusercontent.com/11160442/178095018-35d2619a-6a82-4e27-91c9-ff2796fab435.png
-   :target: https://user-images.githubusercontent.com/11160442/178095018-35d2619a-6a82-4e27-91c9-ff2796fab435.png
-   :alt: HNN-core GUI
+.. |HNN-GUI| image:: https://user-images.githubusercontent.com/11160442/178095018-35d2619a-6a82-4e27-91c9-ff2796fab435.png
 
 This is a leaner and cleaner version of the code based off the `HNN repository <https://github.com/jonescompneurolab/hnn>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 hnn-core
 ========
 
-|tests| |CircleCI| |Codecov|
+|tests| |CircleCI| |Codecov| |PyPI|
 
 |HNN-GUI|
 
@@ -13,6 +13,9 @@ hnn-core
 
 .. |Codecov| image:: https://codecov.io/gh/jonescompneurolab/hnn-core/branch/master/graph/badge.svg
 	:target: https://codecov.io/gh/jonescompneurolab/hnn-core
+
+.. |PyPI| image:: https://img.shields.io/pypi/dm/hnn-core.svg?label=PyPI%20downloads
+	:target: https://pypi.org/project/hnn-core/
 
 .. |HNN-GUI| image:: https://user-images.githubusercontent.com/11160442/178095018-35d2619a-6a82-4e27-91c9-ff2796fab435.png
 

--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,8 @@ hnn-core
 .. |PyPI| image:: https://img.shields.io/pypi/dm/hnn-core.svg?label=PyPI%20downloads
 	:target: https://pypi.org/project/hnn-core/
 
-.. |voila-binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/jonescompneurolab/hnn-core/HEAD?labpath=hnn-core%2Fhnn_core%2Fgui%2Fhnn_widget.ipynb
+.. |voila-binder| .. image:: https://mybinder.org/badge_logo.svg
+   :target: https://mybinder.org/v2/gh/jonescompneurolab/hnn-core/HEAD?urlpath=voila%2Frender%2Fhnn_core%2Fgui%2Fhnn_widget.ipynb
 
 .. |HNN-GUI| image:: https://user-images.githubusercontent.com/11160442/178095018-35d2619a-6a82-4e27-91c9-ff2796fab435.png
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 hnn-core
 ========
 
-|tests| |CircleCI| |Codecov| |PyPI|
+|tests| |CircleCI| |Codecov| |PyPI| |voila-binder|
 
 |HNN-GUI|
 
@@ -16,6 +16,9 @@ hnn-core
 
 .. |PyPI| image:: https://img.shields.io/pypi/dm/hnn-core.svg?label=PyPI%20downloads
 	:target: https://pypi.org/project/hnn-core/
+
+.. |voila-binder| image:: https://mybinder.org/badge_logo.svg
+   :target: https://mybinder.org/v2/gh/jonescompneurolab/hnn-core/HEAD?labpath=hnn-core%2Fhnn_core%2Fgui%2Fhnn_widget.ipynb
 
 .. |HNN-GUI| image:: https://user-images.githubusercontent.com/11160442/178095018-35d2619a-6a82-4e27-91c9-ff2796fab435.png
 


### PR DESCRIPTION
I just noticed that our test badge in README.rst was still referencing Travis. I've now updated it to reference our CI with GH Actions. Here's what our compiled README.rst looks like now:

![image](https://user-images.githubusercontent.com/20212206/179062873-224afc5b-1adb-4417-af35-37803274bbe3.png)
