### PR TITLE
[WIP] ENH: add ability to spawn MPI jobs from parent job

### DIFF
--- a/examples/howto/plot_simulate_mpi_backend.py
+++ b/examples/howto/plot_simulate_mpi_backend.py
@@ -47,8 +47,11 @@ net.add_bursty_drive(
 # ``openmpi``, which must be installed on the system
 from hnn_core import MPIBackend
 
-with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
-    dpls = simulate_dipole(net, tstop=310., n_trials=1)
+# to create a parent MPI job that uses MPIBackend to spawn child jobs, set
+# mpi_comm_spawn=True and call this script from terminal using
+# $ mpiexec -np 1 --oversubscribe python -m mpi4py /home/ryan/hnn-core/examples/howto/plot_simulate_mpi_backend.py
+with MPIBackend(n_procs=5, mpi_cmd='mpiexec', mpi_comm_spawn=False):
+    dpls = simulate_dipole(net, tstop=200., n_trials=1)
 
 trial_idx = 0
 dpls[trial_idx].plot()

--- a/examples/howto/plot_simulate_mpi_backend.py
+++ b/examples/howto/plot_simulate_mpi_backend.py
@@ -49,8 +49,8 @@ from hnn_core import MPIBackend
 
 # to create a parent MPI job that uses MPIBackend to spawn child jobs, set
 # mpi_comm_spawn=True and call this script from terminal using
-# $ mpiexec -np 1 --oversubscribe python -m mpi4py /home/ryan/hnn-core/examples/howto/plot_simulate_mpi_backend.py
-with MPIBackend(n_procs=5, mpi_cmd='mpiexec', mpi_comm_spawn=False):
+# ``$ mpiexec -np 1 --oversubscribe python -m mpi4py /path/to/hnn-core/examples/howto/plot_simulate_mpi_backend.py``
+with MPIBackend(n_procs=5, mpi_cmd='mpiexec', mpi_comm_spawn=True):
     dpls = simulate_dipole(net, tstop=200., n_trials=1)
 
 trial_idx = 0

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -9,9 +9,6 @@ import sys
 import pickle
 import base64
 import re
-import shlex
-from os import environ
-from mpi4py import MPI
 
 from hnn_core.parallel_backends import _extract_data, _extract_data_length
 

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -151,39 +151,11 @@ if __name__ == '__main__':
     rc = 0
 
     try:
-        try:
-            if bool(environ['HNN_CORE_MPI_COMM_SPAWN']):
-                cmd = environ['HNN_CORE_SPAWN_CMD']
-                # Split the command into shell arguments for passing to Popen
-                if 'win' in sys.platform:
-                    use_posix = True
-                else:
-                    use_posix = False
-                cmd = shlex.split(cmd, posix=use_posix)
-
-                n_procs = int(environ['HNN_CORE_SPAWN_N_PROCS'])
-                info = environ['HNN_CORE_SPAWN_INFO']
-
-                # important: update MPI_COMM_SPAWN env var so that it can call
-                # mpi_child.py again without spawning its own child MPI process
-                environ['HNN_CORE_MPI_COMM_SPAWN'] = '0'
-                
-                if not info:
-                    subcomm = MPI.COMM_SELF.Spawn('nrniv', args=cmd,
-                                                  maxprocs=n_procs)
-                else:
-                    subcomm = MPI.COMM_SELF.Spawn('nrniv', args=cmd,
-                                                  info=info,
-                                                  maxprocs=n_procs)
-            else:
-                raise KeyError  # trigger exception where the simulation is run
-
-        except KeyError:
-            with MPISimulation() as mpi_sim:
-                net, tstop, dt, n_trials = mpi_sim._read_net()
-                sim_data = mpi_sim.run(net, tstop, dt, n_trials)
-                mpi_sim._write_data_stderr(sim_data)
-                mpi_sim._wait_for_exit_signal()
+        with MPISimulation() as mpi_sim:
+            net, tstop, dt, n_trials = mpi_sim._read_net()
+            sim_data = mpi_sim.run(net, tstop, dt, n_trials)
+            mpi_sim._write_data_stderr(sim_data)
+            mpi_sim._wait_for_exit_signal()
 
     except Exception:
         # This can be useful to indicate the problem to the

--- a/hnn_core/mpi_comm_spawn_child.py
+++ b/hnn_core/mpi_comm_spawn_child.py
@@ -1,0 +1,35 @@
+
+
+
+class MPISimulation(object):
+    """The MPISimulation class.
+    Parameters
+    ----------
+    skip_mpi_import : bool | None
+        Skip importing MPI. Only useful for testing with pytest.
+
+    Attributes
+    ----------
+    comm : mpi4py.Comm object
+        The handle used for communicating among MPI processes
+    rank : int
+        The rank for each processor part of the MPI communicator
+    """
+    def __init__(self, skip_mpi_import=False):
+        self.skip_mpi_import = skip_mpi_import
+        if skip_mpi_import:
+            self.rank = 0
+        else:
+            from mpi4py import MPI
+
+            self.comm = MPI.COMM_WORLD
+            self.rank = self.comm.Get_rank()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        # skip Finalize() if we didn't import MPI on __init__
+        if hasattr(self, 'comm'):
+            from mpi4py import MPI
+            MPI.Finalize()

--- a/hnn_core/mpi_comm_spawn_child.py
+++ b/hnn_core/mpi_comm_spawn_child.py
@@ -1,8 +1,16 @@
+"""Script for running parallel simulations with MPI when called with mpiexec.
+This script is called directly from MPIBackend.simulate()
+"""
 
+# Authors: Blake Caldwell <blake_caldwell@brown.edu>
+#          Ryan Thorpe <ryvthorpe@gmail.com>
+
+from hnn_core.network_builder import _simulate_single_trial
 
 
 class MPISimulation(object):
     """The MPISimulation class.
+
     Parameters
     ----------
     skip_mpi_import : bool | None
@@ -22,6 +30,7 @@ class MPISimulation(object):
         else:
             from mpi4py import MPI
 
+            self.intercomm = MPI.Comm.Get_parent()
             self.comm = MPI.COMM_WORLD
             self.rank = self.comm.Get_rank()
 
@@ -31,5 +40,32 @@ class MPISimulation(object):
     def __exit__(self, type, value, traceback):
         # skip Finalize() if we didn't import MPI on __init__
         if hasattr(self, 'comm'):
-            from mpi4py import MPI
-            MPI.Finalize()
+            self.intercomm.Disconnect()
+
+    def _read_net(self):
+        """Read net and associated objects broadcasted to all ranks on stdin"""
+
+        return self.intercomm.bcast(None, root=0)
+
+    def run(self, net, tstop, dt, n_trials):
+        """Run MPI simulation(s) and write results to stderr"""
+
+        sim_data = []
+        for trial_idx in range(n_trials):
+            single_sim_data = _simulate_single_trial(net, tstop, dt, trial_idx)
+
+            # go ahead and append trial data for each rank, though
+            # only rank 0 has data that should be sent back to MPIBackend
+            sim_data.append(single_sim_data)
+
+        return sim_data
+
+
+if __name__ == '__main__':
+    """This file is called on command-line from nrniv"""
+
+    with MPISimulation() as mpi_sim:
+        net, tstop, dt, n_trials = mpi_sim._read_net()
+        sim_data = mpi_sim.run(net, tstop, dt, n_trials)
+        if mpi_sim.rank == 0:
+            mpi_sim.intercomm.send(sim_data, dest=0)

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -610,8 +610,12 @@ class MPIBackend(object):
         n_logical_cores = multiprocessing.cpu_count()
         if n_procs is None:
             self.n_procs = n_logical_cores
+        elif n_procs == 1:
+            print("Backend will use 1 core. Running simulation without MPI")
+            return
         else:
             self.n_procs = n_procs
+            print("MPI will run over %d processes" % (self.n_procs))
 
         # did user try to force running on more cores than available?
         oversubscribe = False
@@ -638,12 +642,6 @@ class MPIBackend(object):
             packages = ' and '.join(packages)
             warn(f'{packages} not installed. Will run on single processor')
             self.n_procs = 1
-
-        if self.n_procs == 1:
-            print("Backend will use 1 core. Running simulation without MPI")
-            return
-        else:
-            print("MPI will run over %d processes" % (self.n_procs))
 
         if mpi_comm_spawn:
             self.mpi_cmd = ''

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -670,10 +670,9 @@ class MPIBackend(object):
             self._intracomm = MPI.COMM_WORLD
             self._selfcomm = MPI.COMM_SELF
             if self._intracomm.Get_rank() != 0:
-                raise RuntimeError('MPI is attempting to spawn multiple '
-                                   'child subprocesses. Make sure only one '
-                                   'parent MPI process is running when '
-                                   '"mpi_comm_spawn" is True.')
+                raise RuntimeError('MPI is attempting to spawn multiple child '
+                                   'jobs. Make sure only one parent MPI job '
+                                   'is running when "mpi_comm_spawn" is True.')
 
             self.command = 'nrniv -python -mpi -nobanner ' + \
                 sys.executable + ' ' + \

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -588,8 +588,8 @@ class MPIBackend(object):
         The number of processes MPI will actually use (spread over cores). If 1
         is specified or mpi4py could not be loaded, the simulation will be run
         with the JoblibBackend
-    mpi_cmd : list of str
-        The mpi command with number of procs and options to be passed to Popen.
+    command : list of str | str
+        Command to run as subprocess (see subprocess.Popen documentation).
     spawn_intercomm : mpi4py.MPI.Intercomm | None
         The spawned intercommunicator instance if a new MPI subprocess was
         spawned. Otherwise, None.
@@ -644,19 +644,19 @@ class MPIBackend(object):
             self.n_procs = 1
 
         if mpi_comm_spawn:
-            self.mpi_cmd = ''
+            self.command = ''
         else:
-            self.mpi_cmd = mpi_cmd
+            self.command = mpi_cmd
 
             if hyperthreading:
-                self.mpi_cmd += ' --use-hwthread-cpus'
+                self.command += ' --use-hwthread-cpus'
 
             if oversubscribe:
-                self.mpi_cmd += ' --oversubscribe'
+                self.command += ' --oversubscribe'
 
-            self.mpi_cmd += ' -np ' + str(self.n_procs) + ' '
+            self.command += ' -np ' + str(self.n_procs) + ' '
 
-        self.mpi_cmd += 'nrniv -python -mpi -nobanner ' + \
+        self.command += 'nrniv -python -mpi -nobanner ' + \
             sys.executable + ' ' + \
             os.path.join(os.path.dirname(sys.modules[__name__].__file__),
                          'mpi_child.py')
@@ -666,7 +666,7 @@ class MPIBackend(object):
             use_posix = True
         else:
             use_posix = False
-        self.mpi_cmd = shlex.split(self.mpi_cmd, posix=use_posix)
+        self.command = shlex.split(self.command, posix=use_posix)
 
         self.mpi_comm_spawn = mpi_comm_spawn
         self.mpi_comm_spawn_info = mpi_comm_spawn_info
@@ -725,7 +725,7 @@ class MPIBackend(object):
         env = _get_mpi_env()
 
         self.proc, sim_data = run_subprocess(
-            command=self.mpi_cmd, obj=[net, tstop, dt, n_trials], timeout=30,
+            command=self.command, obj=[net, tstop, dt, n_trials], timeout=30,
             proc_queue=self.proc_queue, env=env, cwd=os.getcwd(),
             universal_newlines=True)
 

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -92,8 +92,8 @@ def _get_mpi_env():
     return my_env
 
 
-def spawn_subprocess(parent_comm, command, n_procs, info=None):
-    """Spawn child simulation processes from an existing MPI process"""
+def spawn_job(parent_comm, command, n_procs, info=None):
+    """Spawn child simulation job from an existing MPI communicator"""
 
     if info is None:
         subcomm = parent_comm.Spawn('nrniv', args=command,
@@ -589,12 +589,12 @@ class MPIBackend(object):
         Applicable only when mpi_comm_spawn is False (default): The name of the
         mpi launcher executable. Will use 'mpiexec' (openmpi) by default.
     mpi_comm_spawn : bool
-        Spawns new MPI subprocesses from an existing MPI process instead of
-        calling mpi_cmd. This allows for the MPI processes and associated
+        Spawns new MPI jobs from an existing MPI communicator instead of
+        calling mpi_cmd. This allows for the parent MPI job and associated
         hardware resources to be pre-instantiated e.g. on a computing cluster.
     mpi_comm_spawn_info : mpi4py.MPI.Info | None
         Appliable only when mpi_comm_spawn is True: an mpi4py.MPI.Info instance
-        that grants the user control over how MPI configures spawned processes.
+        that grants the user control over how openMPI configures spawned jobs.
 
     Attributes
     ----------
@@ -751,7 +751,7 @@ class MPIBackend(object):
         print("Running %d trials..." % (n_trials))
 
         if self.mpi_comm_spawn:
-            self._child_intercomm = spawn_subprocess(
+            self._child_intercomm = spawn_job(
                 parent_comm=self._selfcomm,
                 command=self.command,
                 n_procs=self.n_procs,


### PR DESCRIPTION
The goal here is to allow `MPIBackend` to spawn child jobs from an existing MPI job/communicator. A user could then run any simulation script (e.g., `plot_simulate_mpi_backend.py`) from a computing cluster with the following command and it will spawn as many sub-processes as are specified by `MPIBackend(n_procs=...)` to complete the simulation job:

```
$ mpiexec -np 1 --oversubscribe python -m mpi4py /path/to/script.py
```
I'm currently interested in this use-case for two reasons:

1.  It will allow a user to implement some more complex yet faster MPI configurations on a computing cluster where one can e.g. parallelize across both simulations and neurons, where currently only either scenario or the other is possible.
2. It solves (I think) some the security concerns with allowing a process to instantiate its own MPI parent job, which is what `MPIBackend` currently does.