### PR TITLE
[MRG] BUG: Fix edge case with non existing connections in `pick_connection()`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,6 +48,9 @@ Bug
 - Fix bug where :func:`~hnn_core.viz.plot_morphology` did not accurately
   reflect the shape of the cell being simulated, by `Nick Tolley`_ in :gh:`481`
 
+- Fix bug where :func:`~hnn_core.network.pick_connection` did not return an
+  empty list when searching non existing connections, by `Nick Tolley`_ in :gh:`515`
+
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -263,6 +263,9 @@ def pick_connection(net, src_gids=None, target_gids=None,
         # Intersection across parameters
         if conn_set and inner_set:
             conn_set = conn_set.intersection(inner_set)
+            # If at any point there's no matching elements, return empty
+            if not conn_set:
+                return list()
         else:
             conn_set = conn_set.union(inner_set)
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -424,8 +424,18 @@ def test_network():
     assert len(conn_idxs) == 0
     assert not pick_connection(net, src_gids='evprox1', loc='distal')
 
-    # Check condition where not connections match
+    # Check conditions where not connections match
     assert pick_connection(net, loc='distal', receptor='gabab') == list()
+    assert pick_connection(
+        net, src_gids='L2_pyramidal', receptor='gabab') == list()
+    assert pick_connection(
+        net, src_gids='L2_basket', receptor='ampa') == list()
+    assert pick_connection(
+        net, src_gids='L2_basket', target_gids='L2_basket',
+        loc='proximal', receptor='ampa') == list()
+    assert pick_connection(
+        net, src_gids='L2_pyramidal', target_gids='L2_basket',
+        loc='distal', receptor='gabab') == list()
 
     kwargs_bad = [
         ('src_gids', 0.0), ('src_gids', [0.0]),


### PR DESCRIPTION
Closes #514. Fixes logic in `pick_connection()` where certain edge cases don't return an empty list even when the searched connection doesn't exist.