### PR TITLE
[MRG] ADD support Apple Silicon (arm64) NEURON mechs

### DIFF
--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -150,7 +150,12 @@ def load_custom_mechanisms():
     if platform.system() == 'Windows':
         mech_fname = op.join(op.dirname(__file__), 'mod', 'nrnmech.dll')
     else:
-        mech_fname = op.join(op.dirname(__file__), 'mod', 'x86_64',
+        if platform.system() == 'Darwin' and 'arm64' in platform.platform():
+            cpu_arch = 'arm64'
+        else:  # x86 Mac or Linux
+            cpu_arch = 'x86_64'
+
+        mech_fname = op.join(op.dirname(__file__), 'mod', cpu_arch,
                              '.libs', 'libnrnmech.so')
     if not op.exists(mech_fname):
         raise FileNotFoundError(f'The file {mech_fname} could not be found')


### PR DESCRIPTION
This adds support for Apple Silicon ("M"-series, 64-bit ARM architecture). Tested on a system running 

- M1 Pro system with 8 cores (6 "performance" and 2 "efficiency" cores)
- [miniforge](https://github.com/conda-forge/miniforge) instead of vanilla `conda` (for the `arm` support)
- Python 3.10 (got picked up by `conda`, not sure by which dependency

(Almost) all tests pass locally. MPI example is working fine, but `test_parallel_backends.py` chokes when oversubscribing (will create a separate PR).

Support for Mx Macs in `hnn-core` might need to be flagged as 'experimental'?