### PR TITLE
[MRG] attempt to fix MPI support on Apple Silicon

### DIFF
--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -24,7 +24,7 @@ _BACKEND = None
 
 
 def _thread_handler(event, out, queue):
-    while not event.isSet():
+    while not event.is_set():
         line = out.readline()
         if line == '':
             break

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -29,7 +29,7 @@ def _terminate_mpibackend(event, backend):
     sleep(0.1)
 
     # run terminate until it is successful
-    while not event.isSet():
+    while not event.is_set():
         backend.terminate()
         sleep(0.01)
 


### PR DESCRIPTION
This is a continuation of #538 (first commit is identical, can be rebased trivially), where I try to figure out why the oversubscribe-test fails in `test_parallel_backends`.

The second commit is part of the solution: fixes `TestParallelBackends.test_terminate_mpibackend`, which fails with 

```python
        expected_string = "Child process failed unexpectedly"
>       assert expected_string in record[0].message.args[0]
E       AssertionError: assert 'Child process failed unexpectedly' in 'isSet() is deprecated, use is_set() instead'
```

However, the second one is more thorny (in `TestParallelBackends.test_run_mpibackend_oversubscribed`):

```python
command = ['mpiexec', '--use-hwthread-cpus', '--oversubscribe', '-np', '12', 'nrniv', ...]

...

        if not proc.returncode == 0:
            # simulation failed with a numeric return code
>           raise RuntimeError("MPI simulation failed. Return code: %d" %
                               proc.returncode)
E           RuntimeError: MPI simulation failed. Return code: 143

parallel_backends.py:233: RuntimeError

...
====================================================== short test summary info ======================================================
FAILED tests/test_parallel_backends.py::TestParallelBackends::test_run_mpibackend_oversubscribed - RuntimeError: MPI simulation fa...
======================================== 1 failed, 9 passed, 2 warnings in 84.02s (0:01:24) =========================================
```

I have a pretty strong suspicion that MPI is having troubles with the M1 Pro's 6 'performance' and 2 'efficiency' cores, and/or with the lack of logical CPUs (hyperthreading). The test asks MPI to run on 12 (logical) cores. I haven't been able to pin down the problem yet...

**NB** All other MPI-related tests pass!