### PR TITLE
[MRG] BUG: fix elusive MPI runtime error in tests

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -54,10 +54,10 @@ Bug
 - Fix bug where :func:`~hnn_core.network.pick_connection` did not return an
   empty list when searching non existing connections, by `Nick Tolley`_ in :gh:`515`
 
-- Fix bug in :meth:`~hnn_core.NetworkBuilder.aggregate_data` where continuous 
-  data types (e.g., current dipole) were not guaranteed to have congruent array 
-  sizes across cells distributed over different MPI threads, by `Ryan Thorpe`_ 
-  in :gh:`545`.
+- Fix bug in :class:`~hnn_core.MPIBackend` that caused an MPI runtime error
+  (``RuntimeError: MPI simulation failed. Return code: 143``), when running a
+  simulation with an oversubscribed MPI session on a reduced network, by 
+  `Ryan Thorpe`_ in :gh:`545`.
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -54,6 +54,11 @@ Bug
 - Fix bug where :func:`~hnn_core.network.pick_connection` did not return an
   empty list when searching non existing connections, by `Nick Tolley`_ in :gh:`515`
 
+- Fix bug in :meth:`~hnn_core.NetworkBuilder.aggregate_data` where continuous 
+  data types (e.g., current dipole) were not guaranteed to have congruent array 
+  sizes across cells distributed over different MPI threads, by `Ryan Thorpe`_ 
+  in :gh:`545`.
+
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`

--- a/examples/howto/plot_simulate_mpi_backend.py
+++ b/examples/howto/plot_simulate_mpi_backend.py
@@ -47,7 +47,7 @@ net.add_bursty_drive(
 # ``openmpi``, which must be installed on the system
 from hnn_core import MPIBackend
 
-with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
+with MPIBackend(n_procs=18, mpi_cmd='mpiexec'):
     dpls = simulate_dipole(net, tstop=310., n_trials=1)
 
 trial_idx = 0

--- a/examples/howto/plot_simulate_mpi_backend.py
+++ b/examples/howto/plot_simulate_mpi_backend.py
@@ -47,7 +47,7 @@ net.add_bursty_drive(
 # ``openmpi``, which must be installed on the system
 from hnn_core import MPIBackend
 
-with MPIBackend(n_procs=18, mpi_cmd='mpiexec'):
+with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
     dpls = simulate_dipole(net, tstop=310., n_trials=1)
 
 trial_idx = 0

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -377,7 +377,7 @@ class Network(object):
 
         # contents of pos_dict determines all downstream inferences of
         # cell counts, real and artificial
-        self._n_cells = 0  # currently only used for tests
+        self._n_cells = 0  # used in tests and MPIBackend checks
         self.pos_dict = dict()
         self.cell_types = dict()
 

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -371,6 +371,7 @@ class NetworkBuilder(object):
         # round robin assignment of cell gids
         for gid in range(self._rank, self.net._n_cells, n_hosts):
             self._gid_list.append(gid)
+        print(f'# of GIDs on this host: {len(self._gid_list)}')
 
         for drive in self.net.external_drives.values():
             if drive['cell_specific']:

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -705,7 +705,13 @@ class MPIBackend(object):
                                                     postproc=postproc)
 
         print("Running %d trials..." % (n_trials))
-        dpls = []
+
+        if self.n_procs > net._n_cells:
+            raise ValueError(f'More MPI processes were assigned than there '
+                             f'are cells in the network. Please decrease '
+                             f'the number of parallel processes (got n_procs='
+                             f'{self.n_procs}) over which you will '
+                             f'distribute the {net._n_cells} network neurons.')
 
         env = _get_mpi_env()
 

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -175,6 +175,7 @@ class TestParallelBackends():
         net = jones_2009_model(params, add_drives_from_params=True)
 
         oversubscribed = round(cpu_count() * 1.5)
+        oversubscribed = 12
         with MPIBackend(n_procs=oversubscribed) as backend:
             assert backend.n_procs == oversubscribed
             simulate_dipole(net, tstop=40)

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -58,11 +58,9 @@ def test_gid_assignment():
     all_gids.sort()
 
     n_hosts = 3
-    tstop = 20.
-    dt = 0.025
     all_gids_instantiated = list()
     for rank in range(n_hosts):
-        net_builder = NetworkBuilder(net, tstop=tstop, dt=dt)
+        net_builder = NetworkBuilder(net)
         net_builder._gid_list = list()
         net_builder._gid_assign(rank=rank, n_hosts=n_hosts)
         all_gids_instantiated.extend(net_builder._gid_list)
@@ -176,7 +174,7 @@ class TestParallelBackends():
                        'N_trials': 2})
         net = jones_2009_model(params, add_drives_from_params=True)
 
-        oversubscribed = round(cpu_count() * 1.5)
+        oversubscribed = round(cpu_count() * 3.0)
         with MPIBackend(n_procs=oversubscribed) as backend:
             assert backend.n_procs == oversubscribed
             simulate_dipole(net, tstop=40)

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -174,7 +174,7 @@ class TestParallelBackends():
                        'N_trials': 2})
         net = jones_2009_model(params, add_drives_from_params=True)
 
-        oversubscribed = round(cpu_count() * 3.0)
+        oversubscribed = round(cpu_count() * 1.5)
         with MPIBackend(n_procs=oversubscribed) as backend:
             assert backend.n_procs == oversubscribed
             simulate_dipole(net, tstop=40)

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -58,9 +58,11 @@ def test_gid_assignment():
     all_gids.sort()
 
     n_hosts = 3
+    tstop = 20.
+    dt = 0.025
     all_gids_instantiated = list()
     for rank in range(n_hosts):
-        net_builder = NetworkBuilder(net)
+        net_builder = NetworkBuilder(net, tstop=tstop, dt=dt)
         net_builder._gid_list = list()
         net_builder._gid_assign(rank=rank, n_hosts=n_hosts)
         all_gids_instantiated.extend(net_builder._gid_list)
@@ -175,7 +177,6 @@ class TestParallelBackends():
         net = jones_2009_model(params, add_drives_from_params=True)
 
         oversubscribed = round(cpu_count() * 1.5)
-        oversubscribed = 12
         with MPIBackend(n_procs=oversubscribed) as backend:
             assert backend.n_procs == oversubscribed
             simulate_dipole(net, tstop=40)


### PR DESCRIPTION
closes #406 

Finally figured it out. Our `MPIBackend` unit tests use a reduced network model to speed things up. This revealed a rare edge case that only shows up on machines with a large number of logical cores, where more MPI threads were created than there were neurons contributing to the dipole. When `NetworkBuilder().aggregate_data()` then tried to add up and reduce its NEURON data instances across both intra-rank and inter-rank neurons, it hung due to to a mismatch between `h.Vector()` sizes.