### PR TITLE
[MRG] MAINT: improve parallel backend and runtime messages

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,7 +15,7 @@ Changelog
 - Add option to select drives using argument 'which_drives' in
   :func:`~hnn_core.optimization.optimize_evoked`, by `Mohamed A. Sherif`_ in :gh:`478`.
 
-- Changed ``conn_seed`` default to ``None`` (from ``3``) in :func:`~hnn_core.network.add_connection`, 
+- Changed ``conn_seed`` default to ``None`` (from ``3``) in :func:`~hnn_core.network.add_connection`,
   by `Mattan Pelah`_ in :gh:`492`.
 
 - Add interface to modify attributes of sections in
@@ -23,6 +23,9 @@ Changelog
 
  - Add ability to target specific sections when adding drives or connections,
    by `Nick Tolley`_ in :gh:`419`
+
+- Runtime output messages now specify the trial with which each simulation time
+  checkpoint belongs too, by `Ryan Thorpe`_ in :gh:`546`.
 
 Bug
 ~~~
@@ -56,14 +59,14 @@ Bug
 
 - Fix bug in :class:`~hnn_core.MPIBackend` that caused an MPI runtime error
   (``RuntimeError: MPI simulation failed. Return code: 143``), when running a
-  simulation with an oversubscribed MPI session on a reduced network, by 
+  simulation with an oversubscribed MPI session on a reduced network, by
   `Ryan Thorpe`_ in :gh:`545`.
 
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`
   template model by passing a :class:`~hnn_core.Network` instance directly into
-  :func:`~hnn_core.optimization.optimize_evoked`. Simulations run during 
+  :func:`~hnn_core.optimization.optimize_evoked`. Simulations run during
   optimization can now consist of multiple trials over which the simulated
   dipole is averaged, by `Ryan Thorpe`_ in :gh:`446`.
 
@@ -77,7 +80,7 @@ API
 
 Notable Changes
 ---------------
-- Local field potentials can now be recorded during simulations 
+- Local field potentials can now be recorded during simulations
   :ref:`[Example] <sphx_glr_auto_examples_howto_plot_record_extracellular_potentials.py>`
 
 - Ability to optimize parameters to reproduce event related potentials from real data
@@ -143,7 +146,7 @@ Changelog
 
 - Add method for setting in-plane cell distances and layer separation in the network :func:`~hnn_core.Network.set_cell_positions`, by `Christopher Bailey`_ in `#370 <https://github.com/jonescompneurolab/hnn-core/pull/370>`_
 
-- External drives API now accepts probability argument for targetting subsets of cells, 
+- External drives API now accepts probability argument for targetting subsets of cells,
   by `Nick Tolley`_ in :gh:`416`
 
 Bug
@@ -336,5 +339,5 @@ People who contributed to this release (in alphabetical order):
 .. _Nick Tolley: https://github.com/ntolley
 .. _Ryan Thorpe: https://github.com/rythorpe
 .. _Samika Kanekar: https://github.com/samikane
-.. _Sarah Pugliese: https://bcs.mit.edu/directory/sarah-pugliese 
+.. _Sarah Pugliese: https://bcs.mit.edu/directory/sarah-pugliese
 .. _Stephanie R. Jones: https://github.com/stephanie-r-jones

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -123,13 +123,13 @@ def average_dipoles(dpls):
 
     Parameters
     ----------
-    dpls: list of Dipole objects
+    dpls : list of Dipole objects
         Contains list of dipole objects, each with a `data` member containing
         'L2', 'L5' and 'agg' components
 
     Returns
     -------
-    dpl: instance of Dipole
+    dpl : instance of Dipole
         A new dipole object with each component of `dpl.data` representing the
         average over the same components in the input list
     """
@@ -167,15 +167,15 @@ def _rmse(dpl, exp_dpl, tstart=0.0, tstop=0.0, weights=None):
     """ Calculates RMSE between data in dpl and exp_dpl
     Parameters
     ----------
-    dpl: instance of Dipole
+    dpl : instance of Dipole
         A dipole object with simulated data
-    exp_dpl: instance of Dipole
+    exp_dpl : instance of Dipole
         A dipole object with experimental data
-    tstart | None: float
+    tstart : None | float
         Time at beginning of range over which to calculate RMSE
-    tstop | None: float
+    tstop : None | float
         Time at end of range over which to calculate RMSE
-    weights | None: array
+    weights : None | array
         An array of weights to be applied to each point in
         simulated dpl. Must have length >= dpl.data
         If None, weights will be replaced with 1's for typical RMSE
@@ -183,7 +183,7 @@ def _rmse(dpl, exp_dpl, tstart=0.0, tstop=0.0, weights=None):
 
     Returns
     -------
-    err: float
+    err : float
         Weighted RMSE between data in dpl and exp_dpl
     """
     from scipy import signal

--- a/hnn_core/mpi_child.py
+++ b/hnn_core/mpi_child.py
@@ -125,7 +125,7 @@ class MPISimulation(object):
 
         from hnn_core.network_builder import _simulate_single_trial
 
-        sim_data = []
+        sim_data = list()
         for trial_idx in range(n_trials):
             single_sim_data = _simulate_single_trial(net, tstop, dt, trial_idx)
 

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -45,14 +45,10 @@ def _simulate_single_trial(net, tstop, dt, trial_idx):
     h.load_file("stdrun.hoc")
 
     rank = _get_rank()
-    nhosts = _get_nhosts()
 
     # Now let's simulate the dipole
 
     _PC.barrier()  # sync for output to screen
-    if rank == 0:
-        print("running trial %d on %d cores" %
-              (trial_idx + 1, nhosts))
 
     # Set tstop before instantiating any classes
     h.tstop = tstop
@@ -69,7 +65,7 @@ def _simulate_single_trial(net, tstop, dt, trial_idx):
     h.finitialize()
 
     def simulation_time():
-        print('Simulation time: {0} ms...'.format(round(h.t, 2)))
+        print(f'Trial {trial_idx + 1}: {round(h.t, 2)} ms...')
 
     if rank == 0:
         for tt in range(0, int(h.tstop), 10):

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -37,7 +37,7 @@ def _gather_trial_data(sim_data, net, n_trials, postproc):
     To be called after simulate(). Returns list of Dipoles, one for each trial,
     and saves spiking info in net (instance of Network).
     """
-    dpls = []
+    dpls = list()
 
     # Create array of equally sampled time points for simulating currents
     cell_type_names = list(net.cell_types.keys())
@@ -688,12 +688,12 @@ class MPIBackend(object):
             The integration time step of h.CVode (ms)
         n_trials : int
             Number of trials to simulate.
-        postproc: bool
+        postproc : bool
             If False, no postprocessing applied to the dipole
 
         Returns
         -------
-        dpl: list of Dipole
+        dpl : list of Dipole
             The Dipole results from each simulation trial
         """
 
@@ -703,8 +703,6 @@ class MPIBackend(object):
                                                     dt=dt,
                                                     n_trials=n_trials,
                                                     postproc=postproc)
-
-        print("Running %d trials..." % (n_trials))
 
         if self.n_procs > net._n_cells:
             raise ValueError(f'More MPI processes were assigned than there '

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -552,7 +552,7 @@ class JoblibBackend(object):
             The Dipole results from each simulation trial
         """
 
-        print(f"Joblib will run {n_trials} in parallel by "
+        print(f"Joblib will run {n_trials} trial(s) in parallel by "
               f"distributing trials over {self.n_jobs} jobs.")
         parallel, myfunc = self._parallel_func(_simulate_single_trial)
         sim_data = parallel(myfunc(net, tstop, dt, trial_idx) for
@@ -708,7 +708,7 @@ class MPIBackend(object):
                              f'{self.n_procs}) over which you will '
                              f'distribute the {net._n_cells} network neurons.')
 
-        print(f"MPI will run {n_trials} sequentially by "
+        print(f"MPI will run {n_trials} trial(s) sequentially by "
               f"distributing network neurons over {self.n_procs} processes.")
 
         env = _get_mpi_env()

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -701,7 +701,8 @@ class MPIBackend(object):
                                                     dt=dt,
                                                     n_trials=n_trials,
                                                     postproc=postproc)
-        elif self.n_procs > net._n_cells:
+
+        if self.n_procs > net._n_cells:
             raise ValueError(f'More MPI processes were assigned than there '
                              f'are cells in the network. Please decrease '
                              f'the number of parallel processes (got n_procs='

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -127,7 +127,7 @@ def test_child_run():
             sim_data = mpi_sim.run(net_reduced, tstop=tstop, dt=0.025,
                                    n_trials=n_trials)
             stdout = buf.getvalue()
-        assert "Simulation time:" in stdout
+        assert "Trial 1: 0.03 ms..." in stdout
 
         with io.StringIO() as buf_err, redirect_stderr(buf_err):
             mpi_sim._write_data_stderr(sim_data)


### PR DESCRIPTION
This is just a quick follow-up to #545 where I found it hard to trace how far a simulation had progressed before failing due to where/how the print messages were placed in `parallel_backend.py` and `network_builder.py`. I also took the liberty of fixing a few nitpicky typos in some docstrings.