### PR TITLE
[MRG] MAINT: Fix gui tests

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -826,15 +826,12 @@ class HNNGUI:
             content += line
 
         uploaded_value = {
-            params_name: {
-                'metadata': {
-                    'name': params_name,
-                    'type': 'application/json',
-                    'size': len(content),
-                },
-                'content': content
-            }
+            'name': params_name,
+            'type': 'application/json',
+            'size': len(content),
+            'content': content
         }
+
         self.load_button.set_trait('value', uploaded_value)
 
     def _simulate_left_tab_click(self, tab_title):
@@ -1333,10 +1330,9 @@ def on_upload_change(change, params, tstop, dt, log_out, drive_boxes,
     if len(change['owner'].value) == 0:
         return
 
-    # params_fname = change['owner'].metadata[0]['name']
-    params_fname = list(change['owner'].value.keys())[0]
-    file_uploaded = change['owner'].value
-    param_data = list(file_uploaded.values())[0]['content']
+    params_fname = change['new']['name']
+    file_uploaded = change['new']
+    param_data = change['new']['content']
     param_data = codecs.decode(param_data, encoding="utf-8")
 
     if load_info['prev_param_data'] == param_data:

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -657,13 +657,11 @@ class HNNGUI:
         # accordians to group local-connectivity by cell type
         connectivity_boxes = [
             VBox(slider) for slider in self.connectivity_widgets]
-        connectivity_names = [
+        connectivity_names = (
             'Layer 2/3 Pyramidal', 'Layer 5 Pyramidal', 'Layer 2 Basket',
-            'Layer 5 Basket'
-        ]
-        cell_connectivity = Accordion(children=connectivity_boxes)
-        for idx, connectivity_name in enumerate(connectivity_names):
-            cell_connectivity.set_title(idx, connectivity_name)
+            'Layer 5 Basket')
+        cell_connectivity = Accordion(children=connectivity_boxes,
+                                      titles=connectivity_names)
 
         drive_selections = VBox([
             self.widget_drive_type_selection, self.widget_location_selection,
@@ -680,14 +678,12 @@ class HNNGUI:
         ])
 
         # Tabs for left pane
-        left_tab = Tab()
+        titles = ('Simulation', 'Cell connectivity', 'Drives', 'Analysis')
+        left_tab = Tab(titles=titles)
         left_tab.children = [
             simulation_box, self._connectivity_out, drives_options,
             analysis_options,
         ]
-        titles = ['Simulation', 'Cell connectivity', 'Drives', 'Analysis']
-        for idx, title in enumerate(titles):
-            left_tab.set_title(idx, title)
 
         self.app_layout = AppLayout(
             header=self._header,
@@ -1215,14 +1211,15 @@ def add_drive_widget(drive_type, drive_boxes, drive_widgets, drives_out,
             drive_widgets.append(drive)
 
         if render:
+            titles = [f"{drive['name']} ({drive['location']})" for
+                      drive in drive_widgets]
+
             accordion = Accordion(
                 children=drive_boxes,
                 selected_index=len(drive_boxes) -
                 1 if expand_last_drive else None,
-            )
-            for idx, drive in enumerate(drive_widgets):
-                accordion.set_title(idx,
-                                    f"{drive['name']} ({drive['location']})")
+                titles=tuple(titles))
+
             display(accordion)
 
 
@@ -1238,7 +1235,7 @@ def add_connectivity_tab(net, connectivity_out,
     while len(connectivity_sliders) > 0:
         connectivity_sliders.pop()
 
-    connectivity_names = []
+    connectivity_names = list()
     for src_gids in cell_types:
         for target_gids in cell_types:
             for location in locations:
@@ -1274,9 +1271,8 @@ def add_connectivity_tab(net, connectivity_out,
                         _get_connectivity_widgets(receptor_related_conn))
 
     connectivity_boxes = [VBox(slider) for slider in connectivity_sliders]
-    cell_connectivity = Accordion(children=connectivity_boxes)
-    for idx, connectivity_name in enumerate(connectivity_names):
-        cell_connectivity.set_title(idx, connectivity_name)
+    cell_connectivity = Accordion(children=connectivity_boxes,
+                                  titles=tuple(connectivity_names))
 
     with connectivity_out:
         display(cell_connectivity)

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -838,8 +838,8 @@ class HNNGUI:
 
     def _simulate_left_tab_click(self, tab_title):
         tab_index = None
-        for idx in self.app_layout.left_sidebar._titles.keys():
-            if tab_title == self.app_layout.left_sidebar._titles[idx]:
+        for idx, tab_title in enumerate(self.app_layout.left_sidebar.titles):
+            if tab_title == self.app_layout.left_sidebar.titles[idx]:
                 tab_index = int(idx)
                 break
         if tab_index is None:

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -660,7 +660,7 @@ class HNNGUI:
         connectivity_names = (
             'Layer 2/3 Pyramidal', 'Layer 5 Pyramidal', 'Layer 2 Basket',
             'Layer 5 Basket')
-        cell_connectivity = Accordion(children=connectivity_boxes,
+        cell_connectivity = Accordion(children=connectivity_boxes, # noqa
                                       titles=connectivity_names)
 
         drive_selections = VBox([

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1331,7 +1331,6 @@ def on_upload_change(change, params, tstop, dt, log_out, drive_boxes,
         return
 
     params_fname = change['new']['name']
-    file_uploaded = change['new']
     param_data = change['new']['content']
     param_data = codecs.decode(param_data, encoding="utf-8")
 

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -12,6 +12,7 @@ import sys
 import urllib.parse
 import urllib.request
 from collections import defaultdict
+from datetime import datetime
 
 import hnn_core
 import matplotlib.pyplot as plt
@@ -825,12 +826,13 @@ class HNNGUI:
         for line in data:
             content += line
 
-        uploaded_value = {
+        uploaded_value = [{
             'name': params_name,
             'type': 'application/json',
             'size': len(content),
-            'content': content
-        }
+            'content': content,
+            'last_modified': datetime.utcnow()
+        }]
 
         self.load_button.set_trait('value', uploaded_value)
 
@@ -1330,8 +1332,8 @@ def on_upload_change(change, params, tstop, dt, log_out, drive_boxes,
     if len(change['owner'].value) == 0:
         return
 
-    params_fname = change['new']['name']
-    param_data = change['new']['content']
+    params_fname = change['new'][0]['name']
+    param_data = change['new'][0]['content']
     param_data = codecs.decode(param_data, encoding="utf-8")
 
     if load_info['prev_param_data'] == param_data:

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
               'scipy'
           ],
           extras_require={
-              'gui': ['ipywidgets <=7.7.1', 'voila']
+              'gui': ['ipywidgets >=8.0.0', 'voila']
           },
           packages=find_packages(),
           package_data={'hnn_core': [

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
               'scipy'
           ],
           extras_require={
-              'gui': ['ipywidgets', 'voila']
+              'gui': ['ipywidgets <=7.7.1', 'voila']
           },
           packages=find_packages(),
           package_data={'hnn_core': [


### PR DESCRIPTION
Closes #552. Glad to see it wasn't our fault! From what I can tell the last `ipywidgets` update broke the `.set_title()` functionality for widgets. Probably related to [this](https://github.com/jupyter-widgets/ipywidgets/pull/3477) This is resolved by instantiating the widgets with all the titles at the outset using a `tuple`. 

Not totally sure I understand the problem yet, but in any case these changes resolve the errors associated with titles and works for both versions.