### PR TITLE
[MRG] BUG: Allow `pick_connection()` to accept list of cell types

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -62,6 +62,9 @@ Bug
   simulation with an oversubscribed MPI session on a reduced network, by
   `Ryan Thorpe`_ in :gh:`545`.
 
+- Fix bug where :func:`~hnn_core.network.pick_connection` failed when searching
+  for connections with a list of cell types, by `Nick Tolley`_ in :gh:`559`
+
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`

--- a/hnn_core/check.py
+++ b/hnn_core/check.py
@@ -6,7 +6,7 @@ from .params import _long_name
 from .externals.mne import _validate_type, _check_option
 
 
-def _check_gids(gids, gid_ranges, valid_cells, arg_name):
+def _check_gids(gids, gid_ranges, valid_cells, arg_name, same_type=True):
     """Format different gid specifications into list of gids"""
     _validate_type(gids, (int, list, range, str, None), arg_name,
                    'int list, range, str, or None')
@@ -20,6 +20,9 @@ def _check_gids(gids, gid_ranges, valid_cells, arg_name):
         _check_option(arg_name, gids, valid_cells)
         gids = gid_ranges[_long_name(gids)]
 
+    if all(isinstance(gid, str) for gid in gids):
+        gids = [gid for cell_type in gids for gid in gid_ranges[cell_type]]
+
     cell_type = _gid_to_type(gids[0], gid_ranges)
     for gid in gids:
         _validate_type(gid, int, arg_name)
@@ -27,7 +30,7 @@ def _check_gids(gids, gid_ranges, valid_cells, arg_name):
         if gid_type is None:
             raise AssertionError(
                 f'{arg_name} {gid} not in net.gid_ranges')
-        if gid_type != cell_type:
+        if same_type and gid_type != cell_type:
             raise AssertionError(f'All {arg_name} must be of the same type')
 
     return gids

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -209,9 +209,9 @@ def pick_connection(net, src_gids=None, target_gids=None,
     valid_srcs = list(net.gid_ranges.keys())  # includes drives as srcs
     valid_targets = list(net.cell_types.keys())
     src_gids = _check_gids(src_gids, net.gid_ranges,
-                           valid_srcs, 'src_gids')
+                           valid_srcs, 'src_gids', same_type=False)
     target_gids = _check_gids(target_gids, net.gid_ranges,
-                              valid_targets, 'target_gids')
+                              valid_targets, 'target_gids', same_type=False)
 
     _validate_type(loc, (str, list, None), 'loc', 'str, list, or None')
     _validate_type(receptor, (str, list, None), 'receptor',

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -445,17 +445,21 @@ def test_network():
 
     # Test searching a list of src or target types
     cell_type_list = ['L2_basket', 'L5_basket']
-    gid_list = np.array(list(net.gid_ranges['L2_basket']) + list(
+    true_gid_set = set(list(net.gid_ranges['L2_basket']) + list(
         net.gid_ranges['L5_basket']))
     indices = pick_connection(net, src_gids=cell_type_list)
+    pick_gid_list = list()
     for conn_idx in indices:
-        assert np.all(np.in1d(
-            net.connectivity[conn_idx]['src_gids'], gid_list))
+        pick_gid_list.extend(
+            net.connectivity[conn_idx]['src_gids'])
+    assert true_gid_set == set(pick_gid_list)
 
     indices = pick_connection(net, target_gids=['L2_basket', 'L5_basket'])
+    pick_gid_list = list()
     for conn_idx in indices:
-        assert np.all(np.in1d(
-            net.connectivity[conn_idx]['target_gids'], gid_list))
+        pick_gid_list.extend(
+            net.connectivity[conn_idx]['target_gids'])
+    assert true_gid_set == set(pick_gid_list)
 
     # Check that a given gid isn't present in any connection profile that
     # pick_connection can't identify

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -419,7 +419,6 @@ def test_network():
     kwargs_good = [
         ('src_gids', 0),
         ('src_gids', 'L2_pyramidal'),
-        ('src_gids', 'L2_pyramidal'),
         ('src_gids', range(2)),
         ('src_gids', None),
         ('target_gids', 35),

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -419,6 +419,7 @@ def test_network():
     kwargs_good = [
         ('src_gids', 0),
         ('src_gids', 'L2_pyramidal'),
+        ('src_gids', ['L2_pyramidal'])
         ('src_gids', range(2)),
         ('src_gids', None),
         ('target_gids', 35),
@@ -443,6 +444,20 @@ def test_network():
             else:
                 assert np.any(np.in1d([item], net.connectivity[conn_idx][arg]))
 
+    # Test searching a list of src or target types
+    cell_type_list = ['L2_basket', 'L5_basket']
+    gid_list = np.array(list(net.gid_ranges['L2_basket']) + list(
+        net.gid_ranges['L5_basket']))
+    indices = pick_connection(net, src_gids=cell_type_list)
+    for conn_idx in indices:
+        assert np.all(np.in1d(
+            net.connectivity[conn_idx]['src_gids'], gid_list))
+
+    indices = pick_connection(net, target_gids=['L2_basket', 'L5_basket'])
+    for conn_idx in indices:
+        assert np.all(np.in1d(
+            net.connectivity[conn_idx]['src_gids'], gid_list))
+
     # Check that a given gid isn't present in any connection profile that
     # pick_connection can't identify
     conn_idxs = pick_connection(net, src_gids=0)
@@ -456,7 +471,7 @@ def test_network():
     assert len(conn_idxs) == 0
     assert not pick_connection(net, src_gids='evprox1', loc='distal')
 
-    # Check conditions where not connections match
+    # Check conditions where no connections match
     assert pick_connection(net, loc='distal', receptor='gabab') == list()
     assert pick_connection(
         net, src_gids='L2_pyramidal', receptor='gabab') == list()

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -419,7 +419,7 @@ def test_network():
     kwargs_good = [
         ('src_gids', 0),
         ('src_gids', 'L2_pyramidal'),
-        ('src_gids', ['L2_pyramidal'])
+        ('src_gids', 'L2_pyramidal'),
         ('src_gids', range(2)),
         ('src_gids', None),
         ('target_gids', 35),
@@ -456,7 +456,7 @@ def test_network():
     indices = pick_connection(net, target_gids=['L2_basket', 'L5_basket'])
     for conn_idx in indices:
         assert np.all(np.in1d(
-            net.connectivity[conn_idx]['src_gids'], gid_list))
+            net.connectivity[conn_idx]['target_gids'], gid_list))
 
     # Check that a given gid isn't present in any connection profile that
     # pick_connection can't identify


### PR DESCRIPTION
Highly specific but unfortunate oversight. Currently `pick_connection()` fails when attempting to search connection indices when specifying the src or target gids as a list of cell types. Minimal reproducible example:
```py
from hnn_core import jones_2009_model, pick_connection
net = jones_2009_model()
pick_connection(net, src_gids=['L2_basket', 'L5_basket'])
```

The code fails because `pick_connection()` verifies string inputs using `_check_gids()`. There is a condition in `_check_gids()` that ensures all of the gids are of the same type, this is important for `net.add_connection`, but makes the use above fail.

I've just added the boolean flag `_check_gids(same_type=True)` to allow switching between these conditions.