### PR TITLE
[MRG] DOC: correct macOS pip install instructions for hnn-gui

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,10 @@ and it should not give any error messages.
 To install the GUI dependencies along with ``hnn-core``, a simple tweak to the above command is needed::
 
    $ pip install hnn_core[gui]
+   
+Note if you are zsh in macOS the command is::
+
+   $ pip install hnn_core'[gui]'
 
 To start the GUI, please do::
 


### PR DESCRIPTION
The brackets in zsh have an alternative use by default and require colons for the pip install