### PR TITLE
[MRG] MAINT: Restrict voila version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ Optional dependencies
 GUI
 ~~~
 
-* ipywidgets
-* voila
+* ipywidgets (<=7.7.1)
+* voila (<=0.3.6)
 
 Parallel processing
 ~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
               'scipy'
           ],
           extras_require={
-              'gui': ['ipywidgets <=7.7.1', 'ipympl<0.9', 'voila']
+              'gui': ['ipywidgets <=7.7.1', 'ipympl<0.9', 'voila<=0.3.6']
           },
           packages=find_packages(),
           package_data={'hnn_core': [


### PR DESCRIPTION
Closes #585 

Restricts voila to versions <=0.3.6 to prevent javascript error when rendering GUI