### PR TITLE
[MRG] MAINT: Close figures in unit tests

### DIFF
--- a/hnn_core/tests/test_cell_response.py
+++ b/hnn_core/tests/test_cell_response.py
@@ -10,6 +10,7 @@ from hnn_core import CellResponse, read_spikes
 
 def test_cell_response(tmpdir):
     """Test CellResponse object."""
+    import matplotlib.pyplot as plt
 
     # Round-trip test
     spike_times = [[2.3456, 7.89], [4.2812, 93.2]]
@@ -162,3 +163,4 @@ def test_cell_response(tmpdir):
                       'L5_pyramidal': range(4, 6), 'L5_basket': range(6, 8)}
         cell_response = read_spikes(tmpdir.join('spk_*.txt'),
                                     gid_ranges=gid_ranges)
+    plt.close('all')

--- a/hnn_core/tests/test_cell_response.py
+++ b/hnn_core/tests/test_cell_response.py
@@ -2,6 +2,7 @@
 
 from glob import glob
 
+import matplotlib.pyplot as plt
 import pytest
 import numpy as np
 
@@ -10,8 +11,6 @@ from hnn_core import CellResponse, read_spikes
 
 def test_cell_response(tmpdir):
     """Test CellResponse object."""
-    import matplotlib.pyplot as plt
-
     # Round-trip test
     spike_times = [[2.3456, 7.89], [4.2812, 93.2]]
     spike_gids = [[1, 3], [5, 7]]

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -18,6 +18,8 @@ matplotlib.use('agg')
 
 def test_dipole(tmpdir, run_hnn_core_fixture):
     """Test dipole object."""
+    import matplotlib.pyplot as plt
+
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     dpl_out_fname = tmpdir.join('dpl1.txt')
@@ -108,9 +110,13 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
                            net._params['dipole_scalefctr'])
     assert_allclose(dpls_raw[0].data['agg'], dpls[0].data['agg'])
 
+    plt.close('all')
+
 
 def test_dipole_simulation():
     """Test data produced from simulate_dipole() call."""
+    import matplotlib.pyplot as plt
+
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
@@ -144,6 +150,7 @@ def test_dipole_simulation():
 
         # Smoke test for raster plot with no spikes
         net.cell_response.plot_spikes_raster()
+    plt.close('all')
 
 
 @requires_mpi4py

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -2,6 +2,7 @@ import os.path as op
 from urllib.request import urlretrieve
 
 import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -18,8 +19,6 @@ matplotlib.use('agg')
 
 def test_dipole(tmpdir, run_hnn_core_fixture):
     """Test dipole object."""
-    import matplotlib.pyplot as plt
-
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     dpl_out_fname = tmpdir.join('dpl1.txt')
@@ -115,8 +114,6 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
 
 def test_dipole_simulation():
     """Test data produced from simulate_dipole() call."""
-    import matplotlib.pyplot as plt
-
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -13,6 +13,8 @@ from hnn_core.extracellular import (ExtracellularArray, calculate_csd2d,
                                     _get_laminar_z_coords)
 from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
 
+import matplotlib.pyplot as plt
+
 
 hnn_core_root = op.dirname(hnn_core.__file__)
 params_fname = op.join(hnn_core_root, 'param', 'default.json')
@@ -161,8 +163,6 @@ def test_transfer_resistance():
 @requires_mpi4py
 @requires_psutil
 def test_extracellular_backends(run_hnn_core_fixture):
-    import matplotlib.pyplot as plt
-
     """Test extracellular outputs across backends."""
     # calculation of CSD requires >=4 electrode contacts
     electrode_array = {'arr1': [(2, 2, 400), (2, 2, 600), (2, 2, 800),
@@ -199,7 +199,7 @@ def test_extracellular_backends(run_hnn_core_fixture):
     joblib_net.rec_arrays['arr1'].plot_lfp(show=False)
     joblib_net.rec_arrays['arr1'].plot_csd(show=False)
 
-    plt.close()
+    plt.close('all')
 
 
 def test_rec_array_calculation():

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -161,6 +161,8 @@ def test_transfer_resistance():
 @requires_mpi4py
 @requires_psutil
 def test_extracellular_backends(run_hnn_core_fixture):
+    import matplotlib.pyplot as plt
+
     """Test extracellular outputs across backends."""
     # calculation of CSD requires >=4 electrode contacts
     electrode_array = {'arr1': [(2, 2, 400), (2, 2, 600), (2, 2, 800),
@@ -196,6 +198,8 @@ def test_extracellular_backends(run_hnn_core_fixture):
     # check plotting works
     joblib_net.rec_arrays['arr1'].plot_lfp(show=False)
     joblib_net.rec_arrays['arr1'].plot_csd(show=False)
+
+    plt.close()
 
 
 def test_rec_array_calculation():

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1,5 +1,6 @@
 # Authors: Huzi Cheng <hzcheng15@icloud.com>
 import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from hnn_core import Dipole, Network, Params
@@ -16,8 +17,6 @@ matplotlib.use('agg')
 
 def test_gui_load_params():
     """Test if gui loads default parameters properly"""
-    import matplotlib.pyplot as plt
-
     gui = HNNGUI()
 
     assert isinstance(gui.params, Params)
@@ -29,8 +28,6 @@ def test_gui_load_params():
 
 def test_gui_upload_params():
     """Test if gui handles uploaded parameters correctly"""
-    import matplotlib.pyplot as plt
-
     gui = HNNGUI()
     _ = gui.compose()
 
@@ -77,8 +74,6 @@ def test_gui_upload_params():
 
 def test_gui_change_connectivity():
     """Test if GUI properly changes cell connectivity parameters."""
-    import matplotlib.pyplot as plt
-
     gui = HNNGUI()
     _ = gui.compose()
 
@@ -119,8 +114,6 @@ def test_gui_change_connectivity():
 
 def test_gui_add_drives():
     """Test if gui add different type of drives."""
-    import matplotlib.pyplot as plt
-
     gui = HNNGUI()
     _ = gui.compose()
 
@@ -142,8 +135,6 @@ def test_gui_add_drives():
 
 def test_gui_init_network():
     """Test if gui initializes network properly"""
-    import matplotlib.pyplot as plt
-
     gui = HNNGUI()
     _ = gui.compose()
     # now the default parameter has been loaded.
@@ -163,8 +154,6 @@ def test_gui_init_network():
 @requires_psutil
 def test_gui_run_simulation_mpi():
     """Test if run button triggers simulation with MPIBackend."""
-    import matplotlib.pyplot as plt
-
     gui = HNNGUI()
     _ = gui.compose()
     gui.params['N_pyr_x'] = 3
@@ -182,8 +171,6 @@ def test_gui_run_simulation_mpi():
 
 
 def test_gui_run_simulations():
-    import matplotlib.pyplot as plt
-
     """Test if run button triggers multiple simulations correctly."""
     gui = HNNGUI()
     app_layout = gui.compose()
@@ -249,8 +236,6 @@ def test_gui_run_simulations():
 
 def test_gui_take_screenshots():
     """Test if the GUI correctly generates screenshots."""
-    import matplotlib.pyplot as plt
-
     gui = HNNGUI()
     gui.compose(return_layout=False)
     screenshot = gui.capture(render=False)
@@ -263,8 +248,6 @@ def test_gui_take_screenshots():
 
 def test_gui_add_figure():
     """Test if the GUI adds/deletes figs properly."""
-    import matplotlib.pyplot as plt
-
     gui = HNNGUI()
     _ = gui.compose()
     gui.params['N_pyr_x'] = 3
@@ -313,8 +296,6 @@ def test_gui_add_figure():
 
 def test_gui_edit_figure():
     """Test if the GUI adds/deletes figs properly."""
-    import matplotlib.pyplot as plt
-
     gui = HNNGUI()
     _ = gui.compose()
     gui.params['N_pyr_x'] = 3
@@ -341,8 +322,6 @@ def test_gui_edit_figure():
 
 def test_gui_figure_overlay():
     """Test if the GUI adds/deletes figs properly."""
-    import matplotlib.pyplot as plt
-
     gui = HNNGUI()
     _ = gui.compose()
     gui.params['N_pyr_x'] = 3
@@ -373,7 +352,6 @@ def test_gui_figure_overlay():
 
 
 def test_gui_adaptive_spectrogram():
-    import matplotlib.pyplot as plt
     gui = HNNGUI()
     gui.compose()
     gui.params['N_pyr_x'] = 3

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -72,6 +72,7 @@ def test_gui_upload_params():
     assert gui.drive_widgets[-1]['tstop'].value == 0.
     plt.close('all')
 
+
 def test_gui_change_connectivity():
     """Test if GUI properly changes cell connectivity parameters."""
     gui = HNNGUI()

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -16,16 +16,21 @@ matplotlib.use('agg')
 
 def test_gui_load_params():
     """Test if gui loads default parameters properly"""
+    import matplotlib.pyplot as plt
+
     gui = HNNGUI()
 
     assert isinstance(gui.params, Params)
 
     print(gui.params)
     print(gui.params['L2Pyr*'])
+    plt.close('all')
 
 
 def test_gui_upload_params():
     """Test if gui handles uploaded parameters correctly"""
+    import matplotlib.pyplot as plt
+
     gui = HNNGUI()
     _ = gui.compose()
 
@@ -68,10 +73,12 @@ def test_gui_upload_params():
     gui._simulate_upload_drives(file1_url)
     assert gui.connectivity_widgets[0][0].children[1].value == 0.01
     assert gui.drive_widgets[-1]['tstop'].value == 0.
-
+    plt.close('all')
 
 def test_gui_change_connectivity():
     """Test if GUI properly changes cell connectivity parameters."""
+    import matplotlib.pyplot as plt
+
     gui = HNNGUI()
     _ = gui.compose()
 
@@ -107,10 +114,13 @@ def test_gui_change_connectivity():
                 # test if the new value is reflected in the network
                 assert _single_simulation['net'].connectivity[conn_idx][
                     'nc_dict']['A_weight'] == w_val
+    plt.close('all')
 
 
 def test_gui_add_drives():
     """Test if gui add different type of drives."""
+    import matplotlib.pyplot as plt
+
     gui = HNNGUI()
     _ = gui.compose()
 
@@ -127,10 +137,13 @@ def test_gui_add_drives():
             assert gui.drive_widgets[0]['type'] == val_drive_type
             assert gui.drive_widgets[0]['location'] == val_location
             assert val_drive_type in gui.drive_widgets[0]['name']
+    plt.close('all')
 
 
 def test_gui_init_network():
     """Test if gui initializes network properly"""
+    import matplotlib.pyplot as plt
+
     gui = HNNGUI()
     _ = gui.compose()
     # now the default parameter has been loaded.
@@ -139,6 +152,7 @@ def test_gui_init_network():
     _init_network_from_widgets(gui.params, gui.widget_dt, gui.widget_tstop,
                                _single_simulation, gui.drive_widgets,
                                gui.connectivity_widgets)
+    plt.close('all')
 
     # copied from test_network.py
     assert np.isclose(_single_simulation['net']._inplane_distance, 1.)
@@ -149,6 +163,8 @@ def test_gui_init_network():
 @requires_psutil
 def test_gui_run_simulation_mpi():
     """Test if run button triggers simulation with MPIBackend."""
+    import matplotlib.pyplot as plt
+
     gui = HNNGUI()
     _ = gui.compose()
     gui.params['N_pyr_x'] = 3
@@ -162,9 +178,12 @@ def test_gui_run_simulation_mpi():
     assert isinstance(gui.simulation_data[default_name]["net"], Network)
     assert isinstance(dpls, list)
     assert all([isinstance(dpl, Dipole) for dpl in dpls])
+    plt.close('all')
 
 
 def test_gui_run_simulations():
+    import matplotlib.pyplot as plt
+
     """Test if run button triggers multiple simulations correctly."""
     gui = HNNGUI()
     app_layout = gui.compose()
@@ -225,10 +244,13 @@ def test_gui_run_simulations():
     assert len(gui.simulation_data) == 1
     assert gui._simulation_status_bar.value == \
         gui._simulation_status_contents['failed']
+    plt.close('all')
 
 
 def test_gui_take_screenshots():
     """Test if the GUI correctly generates screenshots."""
+    import matplotlib.pyplot as plt
+
     gui = HNNGUI()
     gui.compose(return_layout=False)
     screenshot = gui.capture(render=False)
@@ -236,10 +258,13 @@ def test_gui_take_screenshots():
     gui._simulate_left_tab_click("External drives")
     screenshot1 = gui.capture(render=False)
     assert screenshot._repr_html_() != screenshot1._repr_html_()
+    plt.close('all')
 
 
 def test_gui_add_figure():
     """Test if the GUI adds/deletes figs properly."""
+    import matplotlib.pyplot as plt
+
     gui = HNNGUI()
     _ = gui.compose()
     gui.params['N_pyr_x'] = 3
@@ -283,10 +308,13 @@ def test_gui_add_figure():
     ]
     correct_remaining_titles = [_idx2figname(idx) for idx in (1, 3, 4)]
     assert remaining_titles1 == remaining_titles2 == correct_remaining_titles
+    plt.close('all')
 
 
 def test_gui_edit_figure():
     """Test if the GUI adds/deletes figs properly."""
+    import matplotlib.pyplot as plt
+
     gui = HNNGUI()
     _ = gui.compose()
     gui.params['N_pyr_x'] = 3
@@ -308,10 +336,13 @@ def test_gui_edit_figure():
         axes_config = axes_config_tabs.children[-1].children[1]
         simulation_selection = axes_config.children[0].children[0]
         assert simulation_selection.options == tuple(sim_names[:n_figs])
+    plt.close('all')
 
 
 def test_gui_figure_overlay():
     """Test if the GUI adds/deletes figs properly."""
+    import matplotlib.pyplot as plt
+
     gui = HNNGUI()
     _ = gui.compose()
     gui.params['N_pyr_x'] = 3
@@ -338,9 +369,11 @@ def test_gui_figure_overlay():
                 assert add_plot_button.disabled is True
                 clear_ax_button.click()
                 assert add_plot_button.disabled is False
+    plt.close('all')
 
 
 def test_gui_adaptive_spectrogram():
+    import matplotlib.pyplot as plt
     gui = HNNGUI()
     gui.compose()
     gui.params['N_pyr_x'] = 3
@@ -364,3 +397,4 @@ def test_gui_adaptive_spectrogram():
     assert any(['_cbar-ax-' in attr
                 for attr in dir(gui.viz_manager.figs[figid])]) is False
     assert len(gui.viz_manager.figs[1].axes) == 2
+    plt.close('all')

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -2,6 +2,7 @@ from functools import partial
 import os.path as op
 
 import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -24,8 +25,6 @@ def _fake_click(fig, ax, point, button=1):
 
 def test_network_visualization():
     """Test network visualisations."""
-    import matplotlib.pyplot as plt
-
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
@@ -82,8 +81,6 @@ def test_network_visualization():
 
 def test_dipole_visualization():
     """Test dipole visualisations."""
-    import matplotlib.pyplot as plt
-
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -24,6 +24,8 @@ def _fake_click(fig, ax, point, button=1):
 
 def test_network_visualization():
     """Test network visualisations."""
+    import matplotlib.pyplot as plt
+
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
@@ -59,6 +61,8 @@ def test_network_visualization():
     with pytest.raises(ValueError, match='src_gid -1 not a valid cell ID'):
         plot_cell_connectivity(net, conn_idx, src_gid=-1)
 
+    plt.close('all')
+
     # test interactive clicking updates the position of src_cell in plot
     del net.connectivity[-1]
     conn_idx = 15
@@ -73,6 +77,7 @@ def test_network_visualization():
     _fake_click(fig, ax_src, [pos[0], pos[1]])
     pos_in_plot = ax_target.collections[2].get_offsets().data[0]
     assert_allclose(pos[:2], pos_in_plot)
+    plt.close('all')
 
 
 def test_dipole_visualization():
@@ -112,6 +117,7 @@ def test_dipole_visualization():
 
     # test plotting multiple dipoles with average
     fig = plot_dipole(dpls, average=True, show=False)
+    plt.close('all')
 
     # test plotting dipoles with multiple layers
     fig, ax = plt.subplots()
@@ -124,6 +130,8 @@ def test_dipole_visualization():
                       show=False,
                       ax=[axes[0], axes[1], axes[2]],
                       layer=['L2', 'L5', 'agg'])
+
+    plt.close('all')
 
     with pytest.raises(AssertionError,
                        match="ax and layer should have the same size"):
@@ -156,3 +164,5 @@ def test_dipole_visualization():
         net.cell_response.plot_spikes_hist(trial_idx='blah')
     net.cell_response.plot_spikes_hist(trial_idx=0, show=False)
     net.cell_response.plot_spikes_hist(trial_idx=[0, 1], show=False)
+
+    plt.close('all')


### PR DESCRIPTION
Closes #540 
Adds `plt.close('all')` at the end of unit tests that create plots