### PR TITLE
[MRG] ENH: Added instance type check for plot_dipole function and also a test for it

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,9 +34,6 @@ Changelog
 
 - Add ability to return unweighted RMSE for each optimization iteration in :func:`~hnn_core.optimization.optimize_evoked`, by `Kaisu Lankinen`_ in :gh:`610`.
 
-- Add ability to check instance type of Dipole in :func:`~hnn_core.viz.plot_dipole`,
-  by `Rajat Partani`_in :gh:`606`.
-
 Bug
 ~~~
 - Fix bugs in drives API to enable: rate constant argument as float; evoked drive with
@@ -83,7 +80,7 @@ Bug
 
 - Fix bug where :func:`~hnn_core.viz.plot_dipole` failed to check the instance
   type of Dipole, by `Rajat Partani`_ in :gh:`606`
-
+  
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,6 +34,9 @@ Changelog
 
 - Add ability to return unweighted RMSE for each optimization iteration in :func:`~hnn_core.optimization.optimize_evoked`, by `Kaisu Lankinen`_ in :gh:`610`.
 
+- Add ability to check instance type of Dipole in :func:`~hnn_core.viz.plot_dipole`,
+  by `Rajat Partani`_in :gh:`606`.
+
 Bug
 ~~~
 - Fix bugs in drives API to enable: rate constant argument as float; evoked drive with

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -379,3 +379,4 @@ People who contributed to this release (in alphabetical order):
 .. _Stephanie R. Jones: https://github.com/stephanie-r-jones
 .. _Steven Brandt: https://github.com/spbrandt
 .. _Kaisu Lankinen: https://github.com/klankinen
+.. _Rajat Partani: https://github.com/raj1701

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -81,6 +81,9 @@ Bug
 - Fix bug where :func:`~hnn_core.params.read_params` failed to create a network when
   legacy mode is False, by `Nick Tolley`_ in :gh:`614`
 
+- Fix bug where :func:`~hnn_core.viz.plot_dipole` failed to check the instance
+  type of Dipole, by `Rajat Partani`_ in :gh:`606`
+
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -80,7 +80,7 @@ Bug
 
 - Fix bug where :func:`~hnn_core.viz.plot_dipole` failed to check the instance
   type of Dipole, by `Rajat Partani`_ in :gh:`606`
-  
+
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -43,9 +43,9 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     plot_dipole([dipole, dipole], show=False)
 
     # Test wrong argument to plot_dipole()
-    with pytest.raises(ValueError, match="dpl should be of "
-                       "type Dipole or list of Dipole, but is "
-                       "a list containing type <class 'int'>"):
+    with pytest.raises(TypeError, match="dpl must be an instance "
+                       "of Dipole, list of Dipole, got "
+                       "<class 'int'> instead"):
         plot_dipole([dipole, 10], show=False)
 
     # Test IO

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -45,6 +45,9 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     # Test wrong argument to plot_dipole()
     with pytest.raises(TypeError, match='dpl must be an instance of'):
         plot_dipole([dipole, 10], show=False)
+    with pytest.raises(AttributeError, match="'numpy.ndarray' object has no"
+                       " attribute 'append'"):
+        plot_dipole(np.array([dipole, dipole]), average=True, show=False)
 
     # Test IO
     dipole.write(dpl_out_fname)

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -43,10 +43,10 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     plot_dipole([dipole, dipole], show=False)
 
     # Test wrong argument to plot_dipole()
-    with pytest.raises(ValueError, match="Argument 1 should be of type dipole or list of dipoles, but 10 is a <class 'int'>"):
-        plot_dipole([dipole,10], show=False)
-
-
+    with pytest.raises(ValueError, match="Argument 1 should be of "
+                       "type dipole or list of dipoles, but 10 is "
+                       "a <class 'int'>"):
+        plot_dipole([dipole, 10], show=False)
 
     # Test IO
     dipole.write(dpl_out_fname)

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -42,6 +42,12 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     dipole.plot(show=False)
     plot_dipole([dipole, dipole], show=False)
 
+    # Test wrong argument to plot_dipole()
+    with pytest.raises(ValueError, match="Argument 1 should be of type dipole or list of dipoles, but 10 is a <class 'int'>"):
+        plot_dipole([dipole,10], show=False)
+
+
+
     # Test IO
     dipole.write(dpl_out_fname)
     dipole_read = read_dipole(dpl_out_fname)

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -43,7 +43,7 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     plot_dipole([dipole, dipole], show=False)
 
     # Test wrong argument to plot_dipole()
-    with pytest.raises(ValueError, match="Argument 1 should be of "
+    with pytest.raises(ValueError, match="Arg 1 should be of "
                        "type dipole or list of dipoles, but 10 is "
                        "a <class 'int'>"):
         plot_dipole([dipole, 10], show=False)

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -43,9 +43,7 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     plot_dipole([dipole, dipole], show=False)
 
     # Test wrong argument to plot_dipole()
-    with pytest.raises(TypeError, match="dpl must be an instance "
-                       "of Dipole, list of Dipole, got "
-                       "<class 'int'> instead"):
+    with pytest.raises(TypeError, match='dpl must be an instance of'):
         plot_dipole([dipole, 10], show=False)
 
     # Test IO

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -43,8 +43,8 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     plot_dipole([dipole, dipole], show=False)
 
     # Test wrong argument to plot_dipole()
-    with pytest.raises(ValueError, match="Arg 1 should be of "
-                       "type dipole or list of dipoles, but 10 is "
+    with pytest.raises(ValueError, match="dpl should be of "
+                       "type Dipole or list of Dipole, but 10 is "
                        "a <class 'int'>"):
         plot_dipole([dipole, 10], show=False)
 

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -44,7 +44,7 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
 
     # Test wrong argument to plot_dipole()
     with pytest.raises(ValueError, match="dpl should be of "
-                       "type Dipole or list of Dipole, but 10 is "
+                       "type Dipole, but 10 is "
                        "a <class 'int'>"):
         plot_dipole([dipole, 10], show=False)
 

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -44,8 +44,8 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
 
     # Test wrong argument to plot_dipole()
     with pytest.raises(ValueError, match="dpl should be of "
-                       "type Dipole, but 10 is "
-                       "a <class 'int'>"):
+                       "type Dipole or list of Dipole, but is "
+                       "a list containing type <class 'int'>"):
         plot_dipole([dipole, 10], show=False)
 
     # Test IO

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -273,13 +273,14 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
     elif isinstance(dpl, list):
         for single_dpl in dpl:
             if not isinstance(single_dpl, Dipole):
-                raise ValueError('dpl should be of type Dipole, '
-                                 f'but {single_dpl } is a {type(single_dpl )}')
+                raise ValueError('dpl should be of type Dipole or list of '
+                                 'Dipole, but is a list containing '
+                                 f'type {type(single_dpl )}')
         if average:
             dpl = dpl + [average_dipoles(dpl)]
     else:
         raise ValueError('dpl should be of type Dipole, '
-                         f'but {dpl } is a {type(dpl )}')
+                         f'but is a type {type(dpl )}')
 
     scale_applied = dpl[0].scale_applied
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -273,17 +273,10 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
     elif average:
         dpl = dpl + [average_dipoles(dpl)]
 
-    if type(dpl) == list:
-        for single_dpl in dpl:
-            if not isinstance(single_dpl, Dipole):
-                raise ValueError('Argument 1 should be of type '
-                                 'dipole or list of dipoles, '
-                                 f'but {single_dpl} is a {type(single_dpl)}')
-    else:
-        if not isinstance(dpl, Dipole):
-            raise ValueError('Argument 1 should be of '
-                             'type dipole or list of dipoles, '
-                             f'but {dpl} is a {type(dpl)}')
+    for single_dpl in dpl:
+        if not isinstance(single_dpl, Dipole):
+            raise ValueError('Arg 1 should be of type dipole or list of dipol'
+                             'es, 'f'but {single_dpl} is a {type(single_dpl)}')
 
     scale_applied = dpl[0].scale_applied
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -275,8 +275,8 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
 
     for single_dpl in dpl:
         if not isinstance(single_dpl, Dipole):
-            raise ValueError('Arg 1 should be of type dipole or list of dipol'
-                             'es, 'f'but {single_dpl} is a {type(single_dpl)}')
+            raise ValueError('dpl should be of type Dipole or list of Dipole, '
+                             f'but {single_dpl} is a {type(single_dpl)}')
 
     scale_applied = dpl[0].scale_applied
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -273,6 +273,15 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
     elif average:
         dpl = dpl + [average_dipoles(dpl)]
 
+    if type(dpl) == list:
+        for single_dpl in dpl:
+            if not isinstance(single_dpl, Dipole):
+                raise ValueError('Argument 1 should be of type dipole or list of dipoles, '
+                                f'but {single_dpl} is a {type(single_dpl)}')
+    elif not isinstance(dpl, Dipole):
+        raise ValueError('Argument 1 should be of type dipole or list of dipoles, '
+                            f'but {dpl} is a {type(dpl)}')
+
     scale_applied = dpl[0].scale_applied
 
     assert len(layers) == len(axes), "ax and layer should have the same size"

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -276,11 +276,14 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
     if type(dpl) == list:
         for single_dpl in dpl:
             if not isinstance(single_dpl, Dipole):
-                raise ValueError('Argument 1 should be of type dipole or list of dipoles, '
-                                f'but {single_dpl} is a {type(single_dpl)}')
-    elif not isinstance(dpl, Dipole):
-        raise ValueError('Argument 1 should be of type dipole or list of dipoles, '
-                            f'but {dpl} is a {type(dpl)}')
+                raise ValueError('Argument 1 should be of type '
+                                 'dipole or list of dipoles, '
+                                 f'but {single_dpl} is a {type(single_dpl)}')
+    else:
+        if not isinstance(dpl, Dipole):
+            raise ValueError('Argument 1 should be of '
+                             'type dipole or list of dipoles, '
+                             f'but {dpl} is a {type(dpl)}')
 
     scale_applied = dpl[0].scale_applied
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -272,15 +272,11 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
         dpl = [dpl]
     elif isinstance(dpl, list):
         for single_dpl in dpl:
-            if not isinstance(single_dpl, Dipole):
-                raise ValueError('dpl should be of type Dipole or list of '
-                                 'Dipole, but is a list containing '
-                                 f'type {type(single_dpl)}')
+            _validate_type(single_dpl, Dipole, 'dpl', 'Dipole, list of Dipole')
         if average:
             dpl = dpl + [average_dipoles(dpl)]
     else:
-        raise ValueError('dpl should be of type Dipole or list of Dipole, '
-                         f'but is a type {type(dpl)}')
+        _validate_type(dpl, Dipole, 'dpl', 'Dipole, list of Dipole')
 
     scale_applied = dpl[0].scale_applied
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -270,13 +270,16 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
 
     if isinstance(dpl, Dipole):
         dpl = [dpl]
-    elif average:
-        dpl = dpl + [average_dipoles(dpl)]
-
-    for single_dpl in dpl:
-        if not isinstance(single_dpl, Dipole):
-            raise ValueError('dpl should be of type Dipole or list of Dipole, '
-                             f'but {single_dpl} is a {type(single_dpl)}')
+    elif isinstance(dpl, list):
+        for single_dpl in dpl:
+            if not isinstance(single_dpl, Dipole):
+                raise ValueError('dpl should be of type Dipole, '
+                                 f'but {single_dpl } is a {type(single_dpl )}')
+        if average:
+            dpl = dpl + [average_dipoles(dpl)]
+    else:
+        raise ValueError('dpl should be of type Dipole, '
+                         f'but {dpl } is a {type(dpl )}')
 
     scale_applied = dpl[0].scale_applied
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -274,7 +274,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
         _validate_type(this_dpl, Dipole, 'dpl', 'Dipole, list of Dipole')
 
     if average:
-        dpl = dpl + [average_dipoles(dpl)]
+        dpl.append(average_dipoles(dpl))
 
     scale_applied = dpl[0].scale_applied
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -270,13 +270,11 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
 
     if isinstance(dpl, Dipole):
         dpl = [dpl]
-    elif isinstance(dpl, list):
-        for single_dpl in dpl:
-            _validate_type(single_dpl, Dipole, 'dpl', 'Dipole, list of Dipole')
-        if average:
-            dpl = dpl + [average_dipoles(dpl)]
-    else:
-        _validate_type(dpl, Dipole, 'dpl', 'Dipole, list of Dipole')
+    for this_dpl in dpl:
+        _validate_type(this_dpl, Dipole, 'dpl', 'Dipole, list of Dipole')
+
+    if average:
+        dpl = dpl + [average_dipoles(dpl)]
 
     scale_applied = dpl[0].scale_applied
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -275,12 +275,12 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
             if not isinstance(single_dpl, Dipole):
                 raise ValueError('dpl should be of type Dipole or list of '
                                  'Dipole, but is a list containing '
-                                 f'type {type(single_dpl )}')
+                                 f'type {type(single_dpl)}')
         if average:
             dpl = dpl + [average_dipoles(dpl)]
     else:
-        raise ValueError('dpl should be of type Dipole, '
-                         f'but is a type {type(dpl )}')
+        raise ValueError('dpl should be of type Dipole or list of Dipole, '
+                         f'but is a type {type(dpl)}')
 
     scale_applied = dpl[0].scale_applied
 


### PR DESCRIPTION
Closes #511 
I made changes in plot_dipole function in viz.py to type of argument 1. Iteration is used when a list of dipoles is passed. I have included a test in test_dipole.py where [dipole, integer] is passed as an argument to plot_dipole() and the appropriate error message is checked using pytest.