### PR TITLE
[MRG] BUG: Allow adding drives with just NMDA weights

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -70,6 +70,9 @@ Bug
 - Fix bug where :func:`~hnn_core.network.pick_connection` failed when searching
   for connections with a list of cell types, by `Nick Tolley`_ in :gh:`559`
 
+- Fix bug where :func:`~hnn_core.network.add_evoked_drive` failed when adding
+  a drive with just NMDA weights, by `Nick Tolley`_ in :gh:`611`
+
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -25,7 +25,7 @@ def _get_target_properties(weights_ampa, weights_nmda, synaptic_delays,
         weights_nmda = dict()
 
     weights_by_type = {cell_type: dict() for cell_type in
-                       (set(weights_ampa.keys()) | set(weights_ampa.keys()))}
+                       (set(weights_ampa.keys()) | set(weights_nmda.keys()))}
     for cell_type in weights_ampa:
         weights_by_type[cell_type].update({'ampa': weights_ampa[cell_type]})
     for cell_type in weights_nmda:

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -241,6 +241,14 @@ def test_add_drives():
             assert num_connections == \
                 np.around(len(net.gid_ranges[cell_type]) *
                           probability[cell_type]).astype(int)
+
+    # Test adding just the NMDA weights (no AMPA)
+    net.add_evoked_drive(
+        'evoked_nmda', mu=1.0, sigma=1.0, numspikes=1,
+        weights_nmda=weights_nmda,
+        location='distal', synaptic_delays=syn_delays, cell_specific=True,
+        probability=probability)
+
     # Round trip test to ensure drives API produces a functioning Network
     simulate_dipole(net, tstop=1)
 


### PR DESCRIPTION
Found by @wagdy88, adding an evoked drive with only NMDA weights threw an error. Solution was fixing a typo in `_get_target_properties()`