### PR TITLE
[MRG] Fix legacy param reading for legacy_mode=False

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -75,6 +75,9 @@ Bug
 - Fix bug where :func:`~hnn_core.network.add_evoked_drive` failed when adding
   a drive with just NMDA weights, by `Nick Tolley`_ in :gh:`611`
 
+- Fix bug where :func:`~hnn_core.params.read_params` failed to create a network when
+  legacy mode is False, by `Nick Tolley`_ in :gh:`614`
+
 API
 ~~~
 - Optimization of the evoked drives can be conducted on any :class:`~hnn_core.Network`

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -145,6 +145,9 @@ def _add_drives_from_params(net):
                 synaptic_delays=specs['synaptic_delays'],
                 space_constant=specs['space_constant'])
         elif specs['type'] == 'poisson':
+            if (not net._legacy_mode) and specs[
+                    'dynamics']['tstop'] < specs['dynamics']['tstart']:
+                continue
             net.add_poisson_drive(
                 drive_name, tstart=specs['dynamics']['tstart'],
                 tstop=specs['dynamics']['tstop'],
@@ -165,6 +168,9 @@ def _add_drives_from_params(net):
                 synaptic_delays=specs['synaptic_delays'],
                 space_constant=specs['space_constant'])
         elif specs['type'] == 'bursty':
+            if (not net._legacy_mode) and specs[
+                    'dynamics']['tstop'] < specs['dynamics']['tstart']:
+                continue
             net.add_bursty_drive(
                 drive_name,
                 tstart=specs['dynamics']['tstart'],

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -8,7 +8,7 @@ from urllib.request import urlretrieve
 import pytest
 
 import hnn_core
-from hnn_core import read_params, Params
+from hnn_core import read_params, Params, jones_2009_model
 hnn_core_root = op.dirname(hnn_core.__file__)
 
 
@@ -16,6 +16,11 @@ def test_read_params():
     """Test reading of params object."""
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
+    # Smoke test that network loads params
+    _ = jones_2009_model(
+        params, add_drives_from_params=True, legacy_mode=False)
+    _ = jones_2009_model(
+        params, add_drives_from_params=True, legacy_mode=True)
     print(params)
     print(params['L2Pyr*'])
 


### PR DESCRIPTION
@rythorpe @jasmainak I think I figured out the issue with creating a network from a params file when `legacy_mode=False`. In the file there are "dummy drives" where the `tstart` comes after `tstop` so that the drive never occurs in the simulation.

I just added a conditional statement to skip over these drives when they come up, if you see a more elegant solution let me know!