### PR TITLE
WIP: Set legacy mode to false by default

### DIFF
--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -12,7 +12,7 @@ from .externals.mne import _validate_type
 
 
 def jones_2009_model(params=None, add_drives_from_params=False,
-                     legacy_mode=True):
+                     legacy_mode=False):
     """Instantiate the network model described in
     Jones et al. J. of Neurophys. 2009 [1]_
 
@@ -27,7 +27,7 @@ def jones_2009_model(params=None, add_drives_from_params=False,
         for backward-compatibility with HNN GUI, and will be deprecated in a
         future release. Default: False
     legacy_mode : bool
-        Set to True by default to enable matching HNN GUI output when drives
+        Set to False by default. Enables matching HNN GUI output when drives
         are added suitably. Will be deprecated in a future release.
 
     Returns
@@ -174,7 +174,7 @@ def jones_2009_model(params=None, add_drives_from_params=False,
 
 
 def law_2021_model(params=None, add_drives_from_params=False,
-                   legacy_mode=True):
+                   legacy_mode=False):
     """Instantiate the expansion of Jones 2009 model to study beta
     modulated ERPs as described in
     Law et al. Cereb. Cortex 2021 [1]_
@@ -261,7 +261,7 @@ def law_2021_model(params=None, add_drives_from_params=False,
 # Remove params argument after updating examples
 # (only relevant for Jones 2009 model)
 def calcium_model(params=None, add_drives_from_params=False,
-                  legacy_mode=True):
+                  legacy_mode=False):
     """Instantiate the Jones 2009 model with improved calcium dynamics in
     L5 pyramidal neurons. For more details on changes to calcium dynamics
     see Kohl et al. Brain Topragr 2022 [1]_

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -40,10 +40,9 @@ def test_network_models():
     add_erp_drives_to_jones_model(net_default)
     for drive_name in ['evdist1', 'evprox1', 'evprox2']:
         assert drive_name in net_default.external_drives.keys()
-    # 15 drive connections are added as follows: evdist1: 3 ampa + 3 nmda,
-    # evprox1: 4 ampa, evprox2: 4 ampa, and 1 extra zero-weighted ampa
-    # evdist1->L5_basket connection is added to comply with legacy_mode
-    assert len(net_default.connectivity) == n_conn + 15
+    # 14 drive connections are added as follows: evdist1: 3 ampa + 3 nmda,
+    # evprox1: 4 ampa, evprox2: 4 ampa
+    assert len(net_default.connectivity) == n_conn + 14
 
     # Ensure distant dependent calcium gbar
     net_calcium = calcium_model()


### PR DESCRIPTION
Changes all network models to use `legacy_mode=False` by default. Some minor changes in tests/examples were necessary but overall a pretty small change.