### PR TITLE
[MRG] BUG: fix inconsistency in seeded simulation output

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,6 +20,9 @@ Changelog
 
 Bug
 ~~~
+- Fix random inconsistency in network spiking when seed is set by sorting target
+  and source gids in :meth:`~hnn_core.Network.add_connection`, by 
+  `Ryan Thorpe`_ in :gh:`642`.
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,8 +20,7 @@ Changelog
 
 Bug
 ~~~
-- Fix random inconsistency in network spiking when seed is set by sorting target
-  and source gids in :meth:`~hnn_core.Network.add_connection`, by 
+- Fix inconsistent connection mapping from drive gids to cell gids, by
   `Ryan Thorpe`_ in :gh:`642`.
 
 API

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,6 +29,9 @@ API
   now support hdf5 format for read/write Cell response object, by
   `Rajat Partani`_ in :gh:`644`
 
+- Connection `'src_gids'` and `'target_gids'` are now stored as set objects
+  instead of lists, by `Ryan Thorpe`_ in :gh:`642`.
+
 .. _0.3:
 
 0.3

--- a/examples/howto/plot_connectivity.py
+++ b/examples/howto/plot_connectivity.py
@@ -49,7 +49,7 @@ print(net_erp.connectivity[conn_idx])
 plot_connectivity_matrix(net_erp, conn_idx)
 
 # Note here that `'src_gids'` is a `set` object
-# The `.pop()` method can be used to remove a random element
+# The `.pop()` method can be used to sample a random element
 src_gid = net_erp.connectivity[conn_idx]['src_gids'].copy().pop()
 fig = plot_cell_connectivity(net_erp, conn_idx, src_gid)
 

--- a/examples/howto/plot_connectivity.py
+++ b/examples/howto/plot_connectivity.py
@@ -48,8 +48,7 @@ conn_idx = conn_indices[0]
 print(net_erp.connectivity[conn_idx])
 plot_connectivity_matrix(net_erp, conn_idx)
 
-gid_idx = 11
-src_gid = net_erp.connectivity[conn_idx]['src_gids'][gid_idx]
+src_gid = net_erp.connectivity[conn_idx]['src_gids'].copy().pop()
 fig = plot_cell_connectivity(net_erp, conn_idx, src_gid)
 
 ###############################################################################
@@ -81,7 +80,7 @@ def get_network(probability=1.0):
     for target in ['L5_pyramidal', 'L2_basket']:
         net.add_connection(src, target, location, receptor,
                            delay, weight, lamtha, probability=probability,
-			   conn_seed=conn_seed)
+                           conn_seed=conn_seed)
 
     # Basket cell connections
     location, receptor = 'soma', 'gabaa'
@@ -90,7 +89,7 @@ def get_network(probability=1.0):
     for target in ['L5_pyramidal', 'L2_basket']:
         net.add_connection(src, target, location, receptor,
                            delay, weight, lamtha, probability=probability,
-			   conn_seed=conn_seed)
+                           conn_seed=conn_seed)
     return net
 
 
@@ -125,7 +124,7 @@ plot_connectivity_matrix(net_sparse, conn_idx)
 ###############################################################################
 # Note that the sparsity is in addition to the weight decay with distance
 # from the source cell.
-src_gid = net_sparse.connectivity[conn_idx]['src_gids'][5]
+src_gid = net_sparse.connectivity[conn_idx]['src_gids'].copy().pop()
 plot_cell_connectivity(net_sparse, conn_idx, src_gid=src_gid)
 
 ###############################################################################

--- a/examples/howto/plot_connectivity.py
+++ b/examples/howto/plot_connectivity.py
@@ -48,6 +48,8 @@ conn_idx = conn_indices[0]
 print(net_erp.connectivity[conn_idx])
 plot_connectivity_matrix(net_erp, conn_idx)
 
+# Note here that `'src_gids'` is a `set` object
+# The `.pop()` method can be used to remove a random element
 src_gid = net_erp.connectivity[conn_idx]['src_gids'].copy().pop()
 fig = plot_cell_connectivity(net_erp, conn_idx, src_gid)
 

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -264,7 +264,7 @@ def _drive_cell_event_times(drive_type, dynamics, tstop, target_type='any',
     elif len(matches) > 1:
         raise ValueError('Ambiguous external drive: %s' % drive_type)
 
-    event_times = list()
+    event_times = np.array([])
     if drive_type == 'poisson':
         if target_type == 'any':
             rate_constant = dynamics['rate_constant']

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -299,11 +299,10 @@ def _drive_cell_event_times(drive_type, dynamics, tstop, target_type='any',
     # brute force remove non-zero times. Might result in fewer vals
     # than desired
     # values MUST be sorted for VecStim()!
-    if len(event_times) > 0:
-        event_times = event_times[np.logical_and(event_times > 0,
-                                                 event_times <= tstop)]
-        event_times.sort()
-        event_times = event_times.tolist()
+    event_times = event_times[np.logical_and(event_times > 0,
+                                             event_times <= tstop)]
+    event_times.sort()
+    event_times = event_times.tolist()
 
     return event_times
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -873,6 +873,10 @@ class Network(object):
         if not target_populations.issubset(set(self.cell_types.keys())):
             raise ValueError('Allowed drive target cell types are: ',
                              f'{self.cell_types.keys()}')
+        
+        # enforce the same order as in self.cell_types
+        target_populations = [cell_type for cell_type in self.cell_types.keys()
+                              if cell_type in target_populations]
 
         # Ensure location exists for all target cells
         cell_sections = [set(self.cell_types[cell_type].sections.keys()) for
@@ -938,8 +942,7 @@ class Network(object):
         # seed_increment increased by 1 for each target cell type,
         # added to conn_seed to ensure statistical independence of random
         # connections when probability < 1.0
-        for seed_increment, target_cell_type in enumerate(
-                sorted(target_populations)):
+        for seed_increment, target_cell_type in enumerate(target_populations):
             target_gids = list(self.gid_ranges[target_cell_type])
             delays = delays_by_type[target_cell_type]
             probability = probability_by_type[target_cell_type]
@@ -978,8 +981,6 @@ class Network(object):
                     if receptor_idx > 0:
                         self.connectivity[-1]['src_gids'] = \
                             self.connectivity[-2]['src_gids']
-
-            seed_increment += 1
 
     def _reset_drives(self):
         # reset every time called again, e.g., from dipole.py or in self.copy()
@@ -1194,7 +1195,7 @@ class Network(object):
                 raise AssertionError(
                     'All target_gids must be of the same type')
         conn['target_type'] = target_type
-        conn['target_gids'] = sorted(target_set)
+        conn['target_gids'] = target_set
         conn['num_targets'] = len(target_set)
 
         if len(target_gids) != len(src_gids):
@@ -1209,7 +1210,7 @@ class Network(object):
             gid_pairs[src_gid] = target_src_pair
 
         conn['src_type'] = self.gid_to_type(src_gids[0])
-        conn['src_gids'] = sorted(set(src_gids))
+        conn['src_gids'] = set(src_gids)
         conn['num_srcs'] = len(src_gids)
 
         conn['gid_pairs'] = gid_pairs

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1020,9 +1020,9 @@ class Network(object):
                         # population) and create event times
                         conn_idxs = pick_connection(self,
                                                     src_gids=drive_cell_gid)
-                        target_types = np.unique([self.connectivity[conn_idx]
-                                                 ['target_type'] for conn_idx
-                                                 in conn_idxs])
+                        target_types = set([self.connectivity[conn_idx]
+                                            ['target_type'] for conn_idx in
+                                            conn_idxs])
                         for target_type in target_types:
                             event_times.append(_drive_cell_event_times(
                                 drive['type'],
@@ -1194,7 +1194,7 @@ class Network(object):
                 raise AssertionError(
                     'All target_gids must be of the same type')
         conn['target_type'] = target_type
-        conn['target_gids'] = sorted(set(target_set))
+        conn['target_gids'] = sorted(target_set)
         conn['num_targets'] = len(target_set)
 
         if len(target_gids) != len(src_gids):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -873,8 +873,9 @@ class Network(object):
         if not target_populations.issubset(set(self.cell_types.keys())):
             raise ValueError('Allowed drive target cell types are: ',
                              f'{self.cell_types.keys()}')
-        
-        # enforce the same order as in self.cell_types
+
+        # enforce the same order as in self.cell_types - necessary for
+        # consistent source gid assignment
         target_populations = [cell_type for cell_type in self.cell_types.keys()
                               if cell_type in target_populations]
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1361,10 +1361,10 @@ class _Connectivity(dict):
         Number of unique source gids.
     num_targets : int
         Number of unique target gids.
-    src_gids : list of int
-        List of unique source gids in connection.
-    target_gids : list of int
-        List of unique target gids in connection.
+    src_gids : set of int
+        Set of unique source gids in connection.
+    target_gids : set of int
+        Set of unique target gids in connection.
     loc : str
         Location of synapse on target cell. Must be
         'proximal', 'distal', or 'soma'. Note that inhibitory synapses

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -377,15 +377,15 @@ class NetworkBuilder(object):
                 # assigned to this rank
                 for src_gid in self.net.gid_ranges[drive['name']]:
                     conn_idxs = pick_connection(self.net, src_gids=src_gid)
-                    target_gids = list()
+                    target_gids = set()
                     for conn_idx in conn_idxs:
                         gid_pairs = self.net.connectivity[
                             conn_idx]['gid_pairs']
                         if src_gid in gid_pairs:
-                            target_gids += (self.net.connectivity[conn_idx]
-                                            ['gid_pairs'][src_gid])
-
-                    for target_gid in set(target_gids):
+                            target_gids.update(self.net.connectivity[conn_idx]
+                                               ['gid_pairs'][src_gid])
+                    # sort to ensure consistency
+                    for target_gid in sorted(target_gids):
                         if (target_gid in self._gid_list and
                                 src_gid not in self._gid_list):
                             self._gid_list.append(src_gid)

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -384,8 +384,8 @@ class NetworkBuilder(object):
                         if src_gid in gid_pairs:
                             target_gids.update(self.net.connectivity[conn_idx]
                                                ['gid_pairs'][src_gid])
-                    # sort to ensure consistency
-                    for target_gid in sorted(target_gids):
+
+                    for target_gid in target_gids:
                         if (target_gid in self._gid_list and
                                 src_gid not in self._gid_list):
                             self._gid_list.append(src_gid)

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -701,6 +701,7 @@ def test_network_connectivity():
     kwargs_good = [
         ('src_gids', 0),
         ('src_gids', 'L2_pyramidal'),
+        ('src_gids', range(2)),
         ('src_gids', None),
         ('target_gids', 35),
         ('target_gids', range(2)),

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -720,19 +720,19 @@ def test_network_connectivity():
         for conn_idx in indices:
             if isinstance(item, range):
                 # arg specifies a subset of item gids (within range)
-                net.connectivity[conn_idx][arg] <= set(item)
+                net.connectivity[conn_idx][arg].issubset(item)
             elif isinstance(item, str):
                 if arg in {'src_gids', 'target_gids'}:
                     # arg specifies a subset of item gids (within gid_ranges)
-                    assert (net.connectivity[conn_idx][arg] <=
-                            set(net.gid_ranges[item]))
+                    assert net.connectivity[conn_idx][arg].issubset(
+                        net.gid_ranges[item])
                 else:
                     # arg and item specify equivalent string descriptors for
                     # this connection type
                     assert net.connectivity[conn_idx][arg] == item
             else:
                 # arg specifies a superset of item gids
-                assert set(net.connectivity[conn_idx][arg]) >= {item}
+                assert set(net.connectivity[conn_idx][arg]).issuperset({item})
 
     # Test searching a list of src or target types
     src_cell_type_list = ['L2_basket', 'L5_basket']

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -272,7 +272,7 @@ def test_network_drives():
         src_set = set()
         for conn_idx in conn_idxs:
             src_set.update(net.connectivity[conn_idx]['src_gids'])
-        drive_src_list.extend(sorted(list(src_set)))
+        drive_src_list.extend(sorted(src_set))
     assert np.array_equal(drive_src_list, sorted(drive_src_list))
 
     # Check drive dict structure for each external drive

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -688,7 +688,6 @@ def test_network_connectivity():
     kwargs_good = [
         ('src_gids', 0),
         ('src_gids', 'L2_pyramidal'),
-        ('src_gids', range(2)),
         ('src_gids', None),
         ('target_gids', 35),
         ('target_gids', range(2)),
@@ -704,13 +703,23 @@ def test_network_connectivity():
         indices = pick_connection(**kwargs)
         for conn_idx in indices:
             if (arg == 'src_gids' or arg == 'target_gids') and \
-                    isinstance(item, str):
-                assert np.all(np.in1d(net.connectivity[conn_idx][arg],
-                              net.gid_ranges[item]))
+               isinstance(item, str):
+                # item and arg specify equivalent sets
+                assert not net.connectivity[conn_idx][arg].difference(
+                    net.gid_ranges[item])
             elif item is None:
                 pass
             else:
-                assert np.any(np.in1d([item], net.connectivity[conn_idx][arg]))
+                # item and arg specify sets with a non-empty intersection
+                if isinstance(item, range):
+                    set_1 = set(item)
+                else:
+                    set_1 = {item}
+                if isinstance(net.connectivity[conn_idx][arg], str):
+                    set_2 = {net.connectivity[conn_idx][arg]}
+                else:
+                    set_2 = set(net.connectivity[conn_idx][arg])
+                assert set_1.intersection(set_2)
 
     # Test searching a list of src or target types
     src_cell_type_list = ['L2_basket', 'L5_basket']

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -262,6 +262,19 @@ def test_network_drives():
         n_drive_cells = net.external_drives[dn]['n_drive_cells']
         assert len(net.gid_ranges[dn]) == n_drive_cells
 
+    # Source gids should be assigned in order according to net.cell_types
+    # For a cell-specific drive, connections are made between disjoint sets of
+    # source gids by target type
+    drive_src_list = list()
+    for target_type in net.cell_types:
+        conn_idxs = pick_connection(net, src_gids='evprox1',
+                                    target_gids=target_type)
+        src_set = set()
+        for conn_idx in conn_idxs:
+            src_set.update(net.connectivity[conn_idx]['src_gids'])
+        drive_src_list.extend(sorted(list(src_set)))
+    assert np.array_equal(drive_src_list, sorted(drive_src_list))
+
     # Check drive dict structure for each external drive
     for drive_idx, drive in enumerate(net.external_drives.values()):
         # Check that connectivity sources correspond to gid_ranges
@@ -701,25 +714,24 @@ def test_network_connectivity():
         kwargs = kwargs_default.copy()
         kwargs[arg] = item
         indices = pick_connection(**kwargs)
+        if item is None:
+            assert len(indices) == 0
         for conn_idx in indices:
-            if (arg == 'src_gids' or arg == 'target_gids') and \
-               isinstance(item, str):
-                # item and arg specify equivalent sets
-                assert not net.connectivity[conn_idx][arg].difference(
-                    net.gid_ranges[item])
-            elif item is None:
-                pass
+            if isinstance(item, range):
+                # arg specifies a subset of item gids (within range)
+                net.connectivity[conn_idx][arg] <= set(item)
+            elif isinstance(item, str):
+                if arg in {'src_gids', 'target_gids'}:
+                    # arg specifies a subset of item gids (within gid_ranges)
+                    assert (net.connectivity[conn_idx][arg] <=
+                            set(net.gid_ranges[item]))
+                else:
+                    # arg and item specify equivalent string descriptors for
+                    # this connection type
+                    assert net.connectivity[conn_idx][arg] == item
             else:
-                # item and arg specify sets with a non-empty intersection
-                if isinstance(item, range):
-                    set_1 = set(item)
-                else:
-                    set_1 = {item}
-                if isinstance(net.connectivity[conn_idx][arg], str):
-                    set_2 = {net.connectivity[conn_idx][arg]}
-                else:
-                    set_2 = set(net.connectivity[conn_idx][arg])
-                assert set_1.intersection(set_2)
+                # arg specifies a superset of item gids
+                assert set(net.connectivity[conn_idx][arg]) >= {item}
 
     # Test searching a list of src or target types
     src_cell_type_list = ['L2_basket', 'L5_basket']


### PR DESCRIPTION
fixes #641 

I'm pretty sure the root of the bug was due to inconsistent ordering when looping over unordered [`set`](https://docs.python.org/3/library/stdtypes.html#set) elements. There are multiple places in `Network` and `NetworkBuilder` where `set` instances were used to populate ordered lists that influence the mapping of artificial cell gids -> network gids (i.e., even though the seeding behavior and drive spike times were perfectly consistent). My general strategy here was to remove ambiguity whenever possible, so there are some more maintenance-oriented modifications that simplify, convert, or make explicit certain ordered objects.