### PR TITLE
[MRG] Added read/write methods and tests for cell response

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,6 +20,9 @@ Bug
 
 API
 ~~~
+- :func:`~hnn_core.CellResponse.write` and :func:`~hnn_core.Cell_response.read_spikes`
+  now support hdf5 format for read/write Cell response object, by
+  by `Rajat Partani`_ in :gh:`644`
 
 .. _0.3:
 
@@ -408,10 +411,10 @@ People who contributed to this release (in alphabetical order):
 .. _Mostafa Khalil: https://github.com/mkhalil8
 .. _Nick Tolley: https://github.com/ntolley
 .. _Orsolya Beatrix Kolozsvari: http://github.com/orbekolo/
+.. _Rajat Partani: https://github.com/raj1701
 .. _Ryan Thorpe: https://github.com/rythorpe
 .. _Samika Kanekar: https://github.com/samikane
 .. _Sarah Pugliese: https://bcs.mit.edu/directory/sarah-pugliese
 .. _Stephanie R. Jones: https://github.com/stephanie-r-jones
 .. _Steven Brandt: https://github.com/spbrandt
 .. _Kaisu Lankinen: https://github.com/klankinen
-.. _Rajat Partani: https://github.com/raj1701

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,7 +22,7 @@ API
 ~~~
 - :func:`~hnn_core.CellResponse.write` and :func:`~hnn_core.Cell_response.read_spikes`
   now support hdf5 format for read/write Cell response object, by
-  by `Rajat Partani`_ in :gh:`644`
+  `Rajat Partani`_ in :gh:`644`
 
 .. _0.3:
 

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -3,7 +3,7 @@ from .params import Params, read_params
 from .network import Network, pick_connection
 from .network_models import jones_2009_model, law_2021_model, calcium_model
 from .cell import Cell
-from .cell_response import CellResponse, read_spikes, read_spikes_hdf5
+from .cell_response import CellResponse, read_spikes
 from .cells_default import pyramidal, basket
 from .parallel_backends import MPIBackend, JoblibBackend
 

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -3,7 +3,7 @@ from .params import Params, read_params
 from .network import Network, pick_connection
 from .network_models import jones_2009_model, law_2021_model, calcium_model
 from .cell import Cell
-from .cell_response import CellResponse, read_spikes
+from .cell_response import CellResponse, read_spikes, read_spikes_hdf5
 from .cells_default import pyramidal, basket
 from .parallel_backends import MPIBackend, JoblibBackend
 

--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -406,7 +406,10 @@ class CellResponse(object):
         data['vsec'] = self.vsec
         data['isec'] = self.isec
         data['times'] = self.times
-        write_hdf5(fname, data, overwrite=True)
+        # h5py cannot handle np.array(None)
+        if data['times'].shape == np.array(None).shape:
+            data['times'] = list()
+        write_hdf5(fname, data, overwrite=True, use_json=True)
 
     def _write_txt(self, fname):
         """Write spiking activity per trial to a collection of files.
@@ -558,6 +561,9 @@ def _read_spikes_hdf5(fname):
     cell_response = CellResponse(spike_times=data['spike_times'],
                                  spike_gids=data['spike_gids'],
                                  spike_types=data['spike_types'])
+
+    if data['times'] == list():
+        data['times'] = np.array(None)
 
     return cell_response
 

--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -6,6 +6,8 @@
 
 from glob import glob
 import numpy as np
+import os
+from h5io import write_hdf5, read_hdf5
 
 from .viz import plot_spikes_hist, plot_spikes_raster
 
@@ -423,6 +425,33 @@ class CellResponse(object):
                         int(self._spike_gids[trial_idx][spike_idx]),
                         self._spike_types[trial_idx][spike_idx]))
 
+    def write_hdf5(self, fname):
+        """Write spiking activity to a hdf5 file.
+
+        Parameters
+        ----------
+        fname : str
+            String format (e.g., 'spk.hdf5') of the
+            path to the output spike file.
+
+        Outputs
+        -------
+        A hdf5 file containing the cell response object
+        """
+        fname = str(fname)
+        # Hardcoded fname for test purposes
+        # Write code to check available file names
+        # upon discussion of the file name and location
+        print(f'Writing file {fname}')
+        data = {}
+        data['spike_times'] = self.spike_times
+        data['spike_gids'] = self.spike_gids
+        data['spike_types'] = self.spike_types
+        data['vsec'] = self.vsec
+        data['isec'] = self.isec
+        data['times'] = self.times
+        write_hdf5(fname, data, overwrite=True)
+
 
 def read_spikes(fname, gid_ranges=None):
     """Read spiking activity from a collection of spike trial files.
@@ -475,4 +504,38 @@ def read_spikes(fname, gid_ranges=None):
     if gid_ranges is not None:
         cell_response.update_types(gid_ranges)
 
+    return cell_response
+
+
+def read_spikes_hdf5(fname, gid_ranges=None):
+    """Read spiking activity from a hdf5 file.
+
+    Parameters
+    ----------
+    fname : str
+        Path to the hdf5 file (e.g., '<pathname>/spk.hdf5') to be read.
+    gid_ranges : dict of lists or range objects | None
+        Dictionary with keys 'evprox1', 'evdist1' etc.
+        containing the range of Cell or input IDs of different
+        cell or input types. If None, data object should contain
+        spike type.
+
+    Returns
+    ----------
+    cell_response : CellResponse
+        An instance of the CellResponse object.
+    """
+
+    # A check to ensure file exists
+    if not os.path.exists(fname):
+        raise NameError("File not found at path %s" % (fname,))
+    data = read_hdf5(fname)
+    # Write checks to ensure data object contain all required
+    # attributes
+    print(data)
+    cell_response = CellResponse(spike_times=data['spike_times'],
+                                 spike_gids=data['spike_gids'],
+                                 spike_types=data['spike_types'])
+    if gid_ranges is not None:
+        cell_response.update_types(gid_ranges)
     return cell_response

--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -86,6 +86,8 @@ class CellResponse(object):
             spike_gids = list()
         if spike_types is None:
             spike_types = list()
+        if times is None:
+            times = list()
 
         if cell_type_names is None:
             cell_type_names = ['L2_basket', 'L2_pyramidal',
@@ -406,9 +408,6 @@ class CellResponse(object):
         data['vsec'] = self.vsec
         data['isec'] = self.isec
         data['times'] = self.times
-        # h5py cannot handle np.array(None)
-        if data['times'].shape == np.array(None).shape:
-            data['times'] = list()
         write_hdf5(fname, data, overwrite=True, use_json=True)
 
     def _write_txt(self, fname):
@@ -461,7 +460,7 @@ class CellResponse(object):
 
         Parameters
         ----------
-        fname : str/Path object
+        fname : str | Path object
             String format (e.g., 'spk_%d.txt' or 'spk_{0}.txt' or spk.hdf5)
             of the path to the output spike file(s).
 
@@ -504,7 +503,7 @@ def _read_spikes_txt(fname, gid_ranges=None):
         a 3rd column for spike type.
 
     Returns
-    ----------
+    -------
     cell_response : CellResponse
         An instance of the CellResponse object.
     """
@@ -552,7 +551,7 @@ def _read_spikes_hdf5(fname):
         Path to the hdf5 file (e.g., '<pathname>/spk.hdf5') to be read.
 
     Returns
-    ----------
+    -------
     cell_response : CellResponse
         An instance of the CellResponse object.
     """
@@ -562,9 +561,6 @@ def _read_spikes_hdf5(fname):
                                  spike_gids=data['spike_gids'],
                                  spike_types=data['spike_types'])
 
-    if data['times'] == list():
-        data['times'] = np.array(None)
-
     return cell_response
 
 
@@ -573,7 +569,7 @@ def read_spikes(fname, gid_ranges=None):
 
     Parameters
     ----------
-    fname : str/Path object
+    fname : str | Path object
         Path to the hdf5 or txt file (e.g., '<pathname>/spk.hdf5' or
         '<pathname>/spk_*.txt') to be read.
     gid_ranges : dict of lists or range objects | None
@@ -583,7 +579,7 @@ def read_spikes(fname, gid_ranges=None):
         spike type. (Not applicable for hdf5 files)
 
     Returns
-    ----------
+    -------
     cell_response : CellResponse
         An instance of the CellResponse object.
     """

--- a/hnn_core/tests/test_cell_response.py
+++ b/hnn_core/tests/test_cell_response.py
@@ -29,7 +29,7 @@ def test_cell_response(tmpdir):
     # Testing writing using txt files
     with pytest.warns(DeprecationWarning,
                       match="Writing cell response to txt files is "
-                      "deprecated."):
+                      "deprecated"):
         cell_response.write(tmpdir.join('spk_%d.txt'))
 
     # Testing reading from txt files
@@ -40,15 +40,12 @@ def test_cell_response(tmpdir):
 
     # Testing when overwrite is False and same filename is used
     with pytest.raises(FileExistsError,
-                       match="File already exists at path %s. Rename the "
-                             "file or set overwrite=True."
-                             % (tmpdir.join('spk.hdf5'),)):
+                       match="File already exists at path "):
         cell_response.write(tmpdir.join('spk.hdf5'), overwrite=False)
 
     # Testing for wrong extension provided
     with pytest.raises(NameError,
-                       match="File extension should be either txt or hdf5, "
-                             "but the given extension is xls"):
+                       match="File extension should be either txt or hdf5"):
         cell_response.write(tmpdir.join('spk.xls'))
 
     # Test read using hdf5
@@ -56,8 +53,7 @@ def test_cell_response(tmpdir):
 
     # Testing File Not Found Error
     with pytest.raises(FileNotFoundError,
-                       match="File not found at "
-                       "path %s." % (tmpdir.join('spk1.hdf5'),)):
+                       match="File not found at "):
         assert cell_response == read_spikes(tmpdir.join('spk1.hdf5'))
 
     assert ("CellResponse | 2 simulation trials" in repr(cell_response))

--- a/hnn_core/tests/test_cell_response.py
+++ b/hnn_core/tests/test_cell_response.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import pytest
 import numpy as np
 
-from hnn_core import CellResponse, read_spikes
+from hnn_core import CellResponse, read_spikes, read_spikes_hdf5
 
 
 def test_cell_response(tmpdir):
@@ -27,6 +27,12 @@ def test_cell_response(tmpdir):
     cell_response.plot_spikes_hist(show=False)
     cell_response.write(tmpdir.join('spk_%d.txt'))
     assert cell_response == read_spikes(tmpdir.join('spk_*.txt'))
+
+    # Write using hdf5
+    cell_response.write_hdf5(tmpdir.join('spk.hdf5'))
+    # Test read using hdf5
+    assert cell_response == read_spikes_hdf5(tmpdir.join('spk.hdf5'))
+
     assert ("CellResponse | 2 simulation trials" in repr(cell_response))
 
     # reset clears all recorded variables, but leaves simulation time intact

--- a/hnn_core/tests/test_cell_response.py
+++ b/hnn_core/tests/test_cell_response.py
@@ -51,10 +51,14 @@ def test_cell_response(tmpdir):
     # Test read using hdf5
     assert cell_response == read_spikes(tmpdir.join('spk.hdf5'))
 
+    # Smoke test for visualization functions upon reading hdf5 file
+    cell_response_hdf5 = read_spikes(tmpdir.join('spk.hdf5'))
+    cell_response_hdf5.plot_spikes_hist(show=False)
+
     # Testing File Not Found Error
     with pytest.raises(FileNotFoundError,
                        match="File not found at "):
-        assert cell_response == read_spikes(tmpdir.join('spk1.hdf5'))
+        read_spikes(tmpdir.join('spk1.hdf5'))
 
     assert ("CellResponse | 2 simulation trials" in repr(cell_response))
 
@@ -76,6 +80,10 @@ def test_cell_response(tmpdir):
     empty_spike.write(tmpdir.join('empty_spk.txt'))
     empty_spike.write(tmpdir.join('empty_spk_{0}.txt'))
     assert empty_spike == read_spikes(tmpdir.join('empty_spk_*.txt'))
+
+    # Test recovery of empty spike file using hdf5
+    empty_spike.write(tmpdir.join('empty_spk.hdf5'))
+    assert empty_spike == read_spikes(tmpdir.join('empty_spk.hdf5'))
 
     assert ("CellResponse | 2 simulation trials" in repr(empty_spike))
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,8 @@ if __name__ == "__main__":
               'numpy >=1.14',
               'NEURON >=7.7; platform_system != "Windows"',
               'matplotlib>=3.5.3',
-              'scipy'
+              'scipy',
+              'h5io'
           ],
           extras_require={
               'gui': ['ipywidgets <=7.7.1', 'ipympl<0.9', 'voila<=0.3.6']


### PR DESCRIPTION
- Wrote a method `write_hdf5()` for `cell_response`
- Wrote a method `read_spikes_hdf5()` to read a hdf5 file and instantiate a `cell_response` object
- A small test for checking the working for read\write method

`pip install h5io --upgrade` required for using h5io