### PR TITLE
[MRG] ENH: Custom section colors in Cell.plot_morphology

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,6 +12,8 @@ Current
 
 Changelog
 ~~~~~~~~~
+- Add ability to customize plot colors for each cell section in
+  :func:`~hnn_core.Cell.plot_morphology`, by `Nick Tolley`_ in :gh:`646`
 
 Bug
 ~~~

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -655,13 +655,20 @@ class Cell:
 
         return nc
 
-    def plot_morphology(self, ax=None, cell_types=None, show=True):
+    def plot_morphology(self, ax=None, color=None, show=True):
         """Plot the cell morphology.
 
         Parameters
         ----------
         ax : instance of Axes3D
             Matplotlib 3D axis
+        color : str | dict | None
+            Color of cell. If str, entire cell plotted with
+            color indicated by str. If dict, colors of individual sections
+            can be specified. Must have a key for every section in cell as
+            defined in the `Cell.sections` attribute.
+        | Ex: ``{'apical_trunk': 'r', 'soma': 'b', ...}``
+
         show : bool
             If True, show the plot
 
@@ -670,7 +677,7 @@ class Cell:
         axes : instance of Axes3D
             The matplotlib 3D axis handle.
         """
-        return plot_cell_morphology(self, ax=ax, show=show)
+        return plot_cell_morphology(self, ax=ax, color=color, show=show)
 
     def _update_end_pts(self):
         """"Create cell and copy coordinates to Section.end_pts"""

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -60,6 +60,16 @@ def test_network_visualization():
     with pytest.raises(ValueError, match='src_gid -1 not a valid cell ID'):
         plot_cell_connectivity(net, conn_idx, src_gid=-1)
 
+    # Test morphology plotting
+    for cell_type in net.cell_types.values():
+        cell_type.plot_morphology()
+        cell_type.plot_morphology(color='r')
+
+        sections = list(cell_type.sections.keys())
+        section_color = {sect_name: f'C{idx}' for
+                         idx, sect_name in enumerate(sections)}
+        cell_type.plot_morphology(color=section_color)
+
     plt.close('all')
 
     # test interactive clicking updates the position of src_cell in plot

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -70,6 +70,12 @@ def test_network_visualization():
                          idx, sect_name in enumerate(sections)}
         cell_type.plot_morphology(color=section_color)
 
+    cell_type = net.cell_response
+    with pytest.raises(ValueError):
+        cell_type.plot_morphology(color='z')
+    with pytest.raises(TypeError, match='color must be'):
+        cell_type.plot_morphology(color=123)
+
     plt.close('all')
 
     # test interactive clicking updates the position of src_cell in plot

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -70,9 +70,11 @@ def test_network_visualization():
                          idx, sect_name in enumerate(sections)}
         cell_type.plot_morphology(color=section_color)
 
-    cell_type = net.cell_response
+    cell_type = net.cell_types['L2_basket']
     with pytest.raises(ValueError):
         cell_type.plot_morphology(color='z')
+    with pytest.raises(ValueError):
+        cell_type.plot_morphology(color={'soma': 'z'})
     with pytest.raises(TypeError, match='color must be'):
         cell_type.plot_morphology(color=123)
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -810,7 +810,7 @@ def _linewidth_from_data_units(ax, linewidth):
     return linewidth * (length / value_range)
 
 
-def plot_cell_morphology(cell, ax, show=True):
+def plot_cell_morphology(cell, ax, color=None, show=True):
     """Plot the cell morphology.
 
     Parameters
@@ -821,6 +821,13 @@ def plot_cell_morphology(cell, ax, show=True):
         Matplotlib 3D axis
     show : bool
         If True, show the plot
+    color : str | dict | None
+        Color of cell. If str, entire cell plotted with
+        color indicated by str. If dict, colors of individual sections
+        can be specified. Must have a key for every section in cell as
+        defined in the `Cell.sections` attribute.
+
+        | Ex: ``{'apical_trunk': 'r', 'soma': 'b', ...}``
 
     Returns
     -------
@@ -833,6 +840,13 @@ def plot_cell_morphology(cell, ax, show=True):
     if ax is None:
         plt.figure()
         ax = plt.axes(projection='3d')
+
+    if color is None:
+        section_colors = {section: 'b' for section in cell.sections.keys()}
+    if isinstance(color, str):
+        section_colors = {section: color for section in cell.sections.keys()}
+    if isinstance(color, dict):
+        section_colors = color
 
     # Cell is in XZ plane
     ax.set_xlim((cell.pos[1] - 250, cell.pos[1] + 150))
@@ -849,7 +863,8 @@ def plot_cell_morphology(cell, ax, show=True):
             xs.append(pt[0] + dx)
             ys.append(pt[1] + dz)
             zs.append(pt[2] + dy)
-        ax.plot(xs, ys, zs, 'b-', linewidth=linewidth)
+        ax.plot(xs, ys, zs, 'b-', linewidth=linewidth,
+                color=section_colors[sec_name])
     ax.view_init(0, -90)
     ax.axis('off')
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -841,6 +841,8 @@ def plot_cell_morphology(cell, ax, color=None, show=True):
         plt.figure()
         ax = plt.axes(projection='3d')
 
+    _validate_type(color, (str, dict, None), 'color')
+
     if color is None:
         section_colors = {section: 'b' for section in cell.sections.keys()}
     if isinstance(color, str):
@@ -863,7 +865,7 @@ def plot_cell_morphology(cell, ax, color=None, show=True):
             xs.append(pt[0] + dx)
             ys.append(pt[1] + dz)
             zs.append(pt[2] + dy)
-        ax.plot(xs, ys, zs, 'b-', linewidth=linewidth,
+        ax.plot(xs, ys, zs, '-', linewidth=linewidth,
                 color=section_colors[sec_name])
     ax.view_init(0, -90)
     ax.axis('off')


### PR DESCRIPTION
I'd like to make a few additions to the visualization functions that will make animating HNN simulations more straight forward. The main change is allowing a custom color for each cell section in `Cell.plot_morphology` like so:

```py
from hnn_core import jones_2009_model
net = jones_2009_model()
sections = list(net.cell_types['L5_pyramidal'].sections.keys())
section_color = {sect_name: f'C{idx}' for idx, sect_name in enumerate(sections)}
net.cell_types['L5_pyramidal'].plot_morphology(color=section_color)
```
![image](https://github.com/jonescompneurolab/hnn-core/assets/55253912/74fe8ec8-1132-459f-88b6-5b3a0f56f864)

The other addition will be a `plot_network_morphology` function (alternate name suggestions are appreciated!) that simply calls `Cell.plot_morphology` and places the cells in their appropriate 3D position.

With these two functions the code to make animations is pretty slim and could be added as an example to the main website. Let me know what you guys think! @rythorpe @jasmainak @chenghuzi 