### PR TITLE
[MRG] NetworkPlot class to enable interactive visualizations and animations

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -82,6 +82,7 @@ Visualization (:py:mod:`hnn_core.viz`):
    plot_connectivity_matrix
    plot_laminar_lfp
    plot_laminar_csd
+   NetworkPlotter
 
 Parallel backends (:py:mod:`hnn_core.parallel_backends`):
 ---------------------------------------------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,7 +59,7 @@ Changelog
   json, by `George Dang`_ and `Rajat Partani`_ in :gh:`757`
 
 - Added :class:`~hnn_core/viz/NetworkPlotter` to visualize and animate network simulations,
-  by `Nick Tolley`_ in :gh:`649`
+  by `Nick Tolley`_ in :gh:`649`.
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -58,6 +58,9 @@ Changelog
 - Added feature to read/write :class:`~hnn_core.Network` configurations to
   json, by `George Dang`_ and `Rajat Partani`_ in :gh:`757`
 
+- Added :class:`~hnn_core/viz/NetworkPlotter` to visualize and animate network simulations,
+  by `Nick Tolley`_ in :gh:`649`
+
 Bug
 ~~~
 - Fix inconsistent connection mapping from drive gids to cell gids, by

--- a/examples/howto/plot_hnn_animation.py
+++ b/examples/howto/plot_hnn_animation.py
@@ -1,6 +1,6 @@
 """
 ================================
-XX. Modifying local connectivity
+06. Animating HNN simulations
 ================================
 
 This example demonstrates how to animate HNN simulations
@@ -10,28 +10,58 @@ This example demonstrates how to animate HNN simulations
 
 
 ###############################################################################
-from hnn_core import jones_2009_model, simulate_dipole
+# First, we'll import the necessary modules for instantiating a network and
+# running a simulation that we would like to animate.
+import os.path as op
+import hnn_core
+from hnn_core import jones_2009_model, simulate_dipole, read_params
 from hnn_core.network_models import add_erp_drives_to_jones_model
-from hnn_core.viz import NetworkPlot
-
-net = jones_2009_model()
-net.set_cell_positions(inplane_distance=300)
-add_erp_drives_to_jones_model(net)
-dpl = simulate_dipole(net, dt=0.5, tstop=170, record_vsec='all')
-
-net_plot = NetworkPlot(net)
 
 ###############################################################################
-from ipywidgets import interact, IntSlider
+# We begin by instantiating the network. For this example, we will reduce the
+# number of cells in the network to speed up the simulations.
+hnn_core_root = op.dirname(hnn_core.__file__)
+params_fname = op.join(hnn_core_root, 'param', 'default.json')
+params = read_params(params_fname)
+params.update({'N_pyr_x': 3, 'N_pyr_y': 3})
+net = jones_2009_model(params)
 
-def update_plot(t_idx, elev, azim):
-    net_plot.update_section_voltages(t_idx)
-    net_plot.elev = elev
-    net_plot.azim = azim
-    return net_plot.fig
+# Note that we move the cells further apart to allow better visualization of
+# the network (default inplane_distance=1.0 µm).
+net.set_cell_positions(inplane_distance=300)
 
-time_slider = IntSlider(min=0, max=len(net_plot.times), value=1, continuous_update=False)
-elev_slider = IntSlider(min=-100, max=100, value=10, continuous_update=False)
-azim_slider = IntSlider(min=-100, max=100, value=-100, continuous_update=False)
+###############################################################################
+# The :class:`hnn_core.viz.NetworkPlotter` class can be used to visualize
+# the 3D structure of the network.
+from hnn_core.viz import NetworkPlotter
 
-interact(update_plot, t_idx=time_slider, elev=elev_slider, azim=azim_slider)
+net_plot = NetworkPlotter(net)
+net_plot.fig
+
+###############################################################################
+# We can also visualize the network from another angle by adjusting the
+# azimuth and elevation parameters.
+net_plot.azim = 45
+net_plot.elev = 40
+net_plot.fig
+
+###############################################################################
+# Next we add event related potential (ERP) producing drives to the network
+# and run the simulation (see
+# :ref:`evoked example <sphx_glr_auto_examples_plot_simulate_evoked.py>`
+# for more details).
+# To visualize the membrane potential of cells in the
+# network, we need use `simulate_dipole(..., record_vsec='all')` which turns
+# on the recording of voltages in all sections of all cells in the network.
+add_erp_drives_to_jones_model(net)
+dpl = simulate_dipole(net, tstop=170, record_vsec='all')
+net_plot = NetworkPlotter(net)  # Reinitialize plotter with simulated network
+
+###############################################################################
+# Finally, we can animate the simulation using the `export_movie()` method. We
+# can adjust the xyz limits of the plot to better visualize the network.
+net_plot.xlim = (400, 1600)
+net_plot.ylim = (400, 1600)
+net_plot.zlim = (-500, 1600)
+net_plot.azim = 225
+net_plot.export_movie('animation_demo.gif', dpi=100, fps=30, interval=100)

--- a/examples/howto/plot_hnn_animation.py
+++ b/examples/howto/plot_hnn_animation.py
@@ -21,7 +21,7 @@ from hnn_core.network_models import add_erp_drives_to_jones_model
 ###############################################################################
 # We begin by instantiating the network. For this example, we will reduce the
 # number of cells in the network to speed up the simulations.
-net = jones_2009_model(add_drives_from_params=True, mesh_shape=(3, 3))
+net = jones_2009_model(mesh_shape=(3, 3))
 
 # Note that we move the cells further apart to allow better visualization of
 # the network (default inplane_distance=1.0 µm).

--- a/examples/howto/plot_hnn_animation.py
+++ b/examples/howto/plot_hnn_animation.py
@@ -13,6 +13,7 @@ This example demonstrates how to animate HNN simulations
 # First, we'll import the necessary modules for instantiating a network and
 # running a simulation that we would like to animate.
 import os.path as op
+
 import hnn_core
 from hnn_core import jones_2009_model, simulate_dipole, read_params
 from hnn_core.network_models import add_erp_drives_to_jones_model

--- a/examples/howto/plot_hnn_animation.py
+++ b/examples/howto/plot_hnn_animation.py
@@ -21,11 +21,7 @@ from hnn_core.network_models import add_erp_drives_to_jones_model
 ###############################################################################
 # We begin by instantiating the network. For this example, we will reduce the
 # number of cells in the network to speed up the simulations.
-hnn_core_root = op.dirname(hnn_core.__file__)
-params_fname = op.join(hnn_core_root, 'param', 'default.json')
-params = read_params(params_fname)
-params.update({'N_pyr_x': 3, 'N_pyr_y': 3})
-net = jones_2009_model(params)
+net = jones_2009_model(add_drives_from_params=True, mesh_shape=(3, 3))
 
 # Note that we move the cells further apart to allow better visualization of
 # the network (default inplane_distance=1.0 µm).

--- a/examples/howto/plot_hnn_animation.py
+++ b/examples/howto/plot_hnn_animation.py
@@ -1,0 +1,99 @@
+"""
+================================
+XX. Modifying local connectivity
+================================
+
+This example demonstrates how to animate HNN simulations
+"""
+
+# Author: Nick Tolley <nicholas_tolley@brown.edu>
+
+# sphinx_gallery_thumbnail_number = 2
+
+
+###############################################################################
+def plot_network(net, ax, t_idx, colormap):
+    """
+    colormap : str
+        The name of a matplotlib colormap. Default: 'viridis'
+    """
+
+    if ax is None:
+        ax = plt.axes(projection='3d')
+
+    xlim = (-200, 3100)
+    ylim = (-200, 3100)
+    # ylim = (-3000, 3100)
+
+    zlim = (-300, 2200)
+    #viridis = cm.get_cmap('viridis', 8)
+
+    for cell_type in net.cell_types:
+        gid_range = net.gid_ranges[cell_type]
+        for gid_idx, gid in enumerate(gid_range):
+            print(gid, end=' ')
+
+            cell = net.cell_types[cell_type]
+            # vsec = {sec_name: ((np.array(net.cell_response.vsec[0][gid][
+            #         sec_name]) - vmin) / (vmax - vmin)) for
+            #         sec_name in cell.sections.keys()}
+            # section_colors = {sec_name: viridis(vsec[sec_name][t_idx]) for
+            #                   sec_name in cell.sections.keys()}
+
+            section_colors = 'C0'
+
+            pos = net.pos_dict[cell_type][gid_idx]
+            pos = (float(pos[0]), float(pos[2]), float(pos[1]))
+            # plot_cell_morphology(
+            #     cell, ax=ax, show=False, pos=pos,
+            #     xlim=xlim, ylim=ylim, zlim=zlim, color=section_colors)
+            cell.plot_morphology(ax=ax, show=False, color=section_colors,
+                                 pos=pos, xlim=xlim, ylim=ylim, zlim=zlim)
+    # ax.view_init(10, -100)
+    ax.view_init(10, -500)
+
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
+    ax.set_zlim(zlim)
+    # ax.axis('on')
+
+    return ax
+
+def get_colors(net, t_idx, colormap):
+    color_list = list()
+    for cell_type in net.cell_types:
+        gid_range = net.gid_ranges[cell_type]
+        for gid_idx, gid in enumerate(gid_range):
+
+            cell = net.cell_types[cell_type]
+            vmin, vmax = -100, 50
+
+            for sec_name in cell.sections.keys():
+                vsec = (np.array(net.cell_response.vsec[0][gid][sec_name]) - vmin) / (vmax - vmin)
+                color_list.append(colormap(vsec[t_idx]))
+    return color_list
+
+                                
+
+def update_colors(ax, net, t_idx, colormap):
+    color_list = get_colors(net, t_idx, colormap)
+    lines = ax.get_lines()
+    for line, color in zip(lines, color_list):
+        line.set_color(color)
+    ax.view_init(10, -500)
+    
+
+net = jones_2009_model()
+net.set_cell_positions(inplane_distance=300)
+add_erp_drives_to_jones_model(net)
+dpl = simulate_dipole(net, dt=0.5, tstop=100, record_vsec='all')
+
+
+fig = plt.figure()
+ax = fig.add_subplot(projection='3d')
+plot_network(net, ax=ax, t_idx=None, colormap=None)
+
+colormap = colormaps['viridis']
+update_colors(ax, net, t_idx=100, colormap=colormap)
+ax.view_init(20, 100)
+fig

--- a/examples/howto/plot_hnn_animation.py
+++ b/examples/howto/plot_hnn_animation.py
@@ -8,92 +8,30 @@ This example demonstrates how to animate HNN simulations
 
 # Author: Nick Tolley <nicholas_tolley@brown.edu>
 
-# sphinx_gallery_thumbnail_number = 2
-
 
 ###############################################################################
-def plot_network(net, ax, t_idx, colormap):
-    """
-    colormap : str
-        The name of a matplotlib colormap. Default: 'viridis'
-    """
-
-    if ax is None:
-        ax = plt.axes(projection='3d')
-
-    xlim = (-200, 3100)
-    ylim = (-200, 3100)
-    # ylim = (-3000, 3100)
-
-    zlim = (-300, 2200)
-    #viridis = cm.get_cmap('viridis', 8)
-
-    for cell_type in net.cell_types:
-        gid_range = net.gid_ranges[cell_type]
-        for gid_idx, gid in enumerate(gid_range):
-            print(gid, end=' ')
-
-            cell = net.cell_types[cell_type]
-            # vsec = {sec_name: ((np.array(net.cell_response.vsec[0][gid][
-            #         sec_name]) - vmin) / (vmax - vmin)) for
-            #         sec_name in cell.sections.keys()}
-            # section_colors = {sec_name: viridis(vsec[sec_name][t_idx]) for
-            #                   sec_name in cell.sections.keys()}
-
-            section_colors = 'C0'
-
-            pos = net.pos_dict[cell_type][gid_idx]
-            pos = (float(pos[0]), float(pos[2]), float(pos[1]))
-            # plot_cell_morphology(
-            #     cell, ax=ax, show=False, pos=pos,
-            #     xlim=xlim, ylim=ylim, zlim=zlim, color=section_colors)
-            cell.plot_morphology(ax=ax, show=False, color=section_colors,
-                                 pos=pos, xlim=xlim, ylim=ylim, zlim=zlim)
-    # ax.view_init(10, -100)
-    ax.view_init(10, -500)
-
-    ax.set_xlim(xlim)
-    ax.set_ylim(ylim)
-    ax.set_zlim(zlim)
-    # ax.axis('on')
-
-    return ax
-
-def get_colors(net, t_idx, colormap):
-    color_list = list()
-    for cell_type in net.cell_types:
-        gid_range = net.gid_ranges[cell_type]
-        for gid_idx, gid in enumerate(gid_range):
-
-            cell = net.cell_types[cell_type]
-            vmin, vmax = -100, 50
-
-            for sec_name in cell.sections.keys():
-                vsec = (np.array(net.cell_response.vsec[0][gid][sec_name]) - vmin) / (vmax - vmin)
-                color_list.append(colormap(vsec[t_idx]))
-    return color_list
-
-                                
-
-def update_colors(ax, net, t_idx, colormap):
-    color_list = get_colors(net, t_idx, colormap)
-    lines = ax.get_lines()
-    for line, color in zip(lines, color_list):
-        line.set_color(color)
-    ax.view_init(10, -500)
-    
+from hnn_core import jones_2009_model, simulate_dipole
+from hnn_core.network_models import add_erp_drives_to_jones_model
+from hnn_core.viz import NetworkPlot
 
 net = jones_2009_model()
 net.set_cell_positions(inplane_distance=300)
 add_erp_drives_to_jones_model(net)
-dpl = simulate_dipole(net, dt=0.5, tstop=100, record_vsec='all')
+dpl = simulate_dipole(net, dt=0.5, tstop=170, record_vsec='all')
 
+net_plot = NetworkPlot(net)
 
-fig = plt.figure()
-ax = fig.add_subplot(projection='3d')
-plot_network(net, ax=ax, t_idx=None, colormap=None)
+###############################################################################
+from ipywidgets import interact, IntSlider
 
-colormap = colormaps['viridis']
-update_colors(ax, net, t_idx=100, colormap=colormap)
-ax.view_init(20, 100)
-fig
+def update_plot(t_idx, elev, azim):
+    net_plot.update_section_voltages(t_idx)
+    net_plot.elev = elev
+    net_plot.azim = azim
+    return net_plot.fig
+
+time_slider = IntSlider(min=0, max=len(net_plot.times), value=1, continuous_update=False)
+elev_slider = IntSlider(min=-100, max=100, value=10, continuous_update=False)
+azim_slider = IntSlider(min=-100, max=100, value=-100, continuous_update=False)
+
+interact(update_plot, t_idx=time_slider, elev=elev_slider, azim=azim_slider)

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -864,7 +864,7 @@ class Cell:
         return nc
 
     def plot_morphology(self, ax=None, color=None, pos=(0, 0, 0),
-                        xlim=(-250, 150), ylim=None, zlim=(-100, 1200),
+                        xlim=(-250, 150), ylim=(-100, 100), zlim=(-100, 1200),
                         show=True):
         """Plot the cell morphology.
 

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -882,6 +882,12 @@ class Cell:
         pos : tuple of int or float | None
             Position of cell soma. Must be a tuple of 3 elements for the
             (x, y, z) position of the soma in 3D space. Default: (0, 0, 0)
+        xlim : tuple of int | tuple of float
+            x limits of plot window. Default (-250, 150)
+        ylim : tuple of int | tuple of float
+            y limits of plot window. Default (-100, 100)
+        zlim : tuple of int | tuple of float
+            z limits of plot window. Default (-100, 1200)
         show : bool
             If True, show the plot
 

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -863,7 +863,7 @@ class Cell:
 
         return nc
 
-    def plot_morphology(self, ax=None, color=None, show=True):
+    def plot_morphology(self, ax=None, color=None, pos=(0, 0, 0), show=True):
         """Plot the cell morphology.
 
         Parameters
@@ -875,8 +875,11 @@ class Cell:
             color indicated by str. If dict, colors of individual sections
             can be specified. Must have a key for every section in cell as
             defined in the `Cell.sections` attribute.
-        | Ex: ``{'apical_trunk': 'r', 'soma': 'b', ...}``
 
+        | Ex: ``{'apical_trunk': 'r', 'soma': 'b', ...}``
+        pos : tuple of int or float | None
+            Position of cell soma. Must be a tuple of 3 elements for the
+            (x, y, z) position of the soma in 3D space. Default: (0, 0, 0)
         show : bool
             If True, show the plot
 
@@ -885,7 +888,8 @@ class Cell:
         axes : instance of Axes3D
             The matplotlib 3D axis handle.
         """
-        return plot_cell_morphology(self, ax=ax, color=color, show=show)
+        return plot_cell_morphology(self, ax=ax, color=color, pos=pos,
+                                    show=show)
 
     def _update_section_end_pts_L(self, node, dpt):
         if self.cell_tree is None:

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -863,7 +863,9 @@ class Cell:
 
         return nc
 
-    def plot_morphology(self, ax=None, color=None, pos=(0, 0, 0), show=True):
+    def plot_morphology(self, ax=None, color=None, pos=(0, 0, 0),
+                        xlim=(-250, 150), ylim=None, zlim=(-100, 1200),
+                        show=True):
         """Plot the cell morphology.
 
         Parameters
@@ -889,7 +891,7 @@ class Cell:
             The matplotlib 3D axis handle.
         """
         return plot_cell_morphology(self, ax=ax, color=color, pos=pos,
-                                    show=show)
+                                    xlim=xlim, ylim=ylim, zlim=zlim, show=show)
 
     def _update_section_end_pts_L(self, node, dpt):
         if self.cell_tree is None:

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -233,26 +233,11 @@ def test_network_plotter_init(setup_net):
     """Test init keywords of NetworkPlotter class."""
     net = setup_net
     # test NetworkPlotter class
-    with pytest.raises(TypeError, match='xlim must be'):
-        _ = NetworkPlotter(net, xlim='blah')
-    with pytest.raises(TypeError, match='ylim must be'):
-        _ = NetworkPlotter(net, ylim='blah')
-    with pytest.raises(TypeError, match='zlim must be'):
-        _ = NetworkPlotter(net, zlim='blah')
-    with pytest.raises(TypeError, match='elev must be'):
-        _ = NetworkPlotter(net, elev='blah')
-    with pytest.raises(TypeError, match='azim must be'):
-        _ = NetworkPlotter(net, azim='blah')
-    with pytest.raises(TypeError, match='vmin must be'):
-        _ = NetworkPlotter(net, vmin='blah')
-    with pytest.raises(TypeError, match='vmax must be'):
-        _ = NetworkPlotter(net, vmax='blah')
-    with pytest.raises(TypeError, match='trial_idx must be'):
-        _ = NetworkPlotter(net, trial_idx=1.0)
-    with pytest.raises(TypeError, match='time_idx must be'):
-        _ = NetworkPlotter(net, time_idx=1.0)
-    with pytest.raises(TypeError, match='colorbar must be'):
-        _ = NetworkPlotter(net, colorbar='blah')
+    args = ['xlim', 'ylim', 'zlim', 'elev', 'azim', 'vmin', 'vmax',
+            'trial_idx', 'time_idx', 'colorbar']
+    for arg in args:
+        with pytest.raises(TypeError, match=f'{arg} must be'):
+            net_plot = NetworkPlotter(net, **{arg: 'blah'})
 
     net_plot = NetworkPlotter(net)
 

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -265,7 +265,8 @@ def test_dipole_visualization():
 
     # Simulate with record_vsec='all' to test voltage plotting
     net = jones_2009_model(params)
-    _ = simulate_dipole(net, dt=0.5, tstop=10, record_vsec='all')
+    _ = simulate_dipole(net, dt=0.5, tstop=10, n_trials=2,
+                        record_vsec='all')
     net_plot = NetworkPlotter(net)
 
     assert net_plot.vsec_array.shape == (159, 21)
@@ -300,7 +301,7 @@ def test_dipole_visualization():
     net_plot.azim = 10
     net_plot.vmin = 0
     net_plot.vmax = 100
-    net_plot.trial_idx = 0
+    net_plot.trial_idx = 1
     net_plot.time_idx = 5
     net_plot.bgcolor = 'white'
     net_plot.voltage_colormap = 'jet'
@@ -313,7 +314,7 @@ def test_dipole_visualization():
     assert net_plot.azim == 10
     assert net_plot.vmin == 0
     assert net_plot.vmax == 100
-    assert net_plot.trial_idx == 0
+    assert net_plot.trial_idx == 1
     assert net_plot.time_idx == 5
 
     assert net_plot.bgcolor == 'white'

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -3,6 +3,8 @@ import os.path as op
 import matplotlib
 from matplotlib import backend_bases
 import matplotlib.pyplot as plt
+from matplotlib.colorbar import Colorbar
+
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -240,6 +242,8 @@ def test_dipole_visualization():
         _ = NetworkPlotter(net, trial_idx=1.0)
     with pytest.raises(TypeError, match='time_idx must be'):
         _ = NetworkPlotter(net, time_idx=1.0)
+    with pytest.raises(TypeError, match='colorbar must be'):
+        _ = NetworkPlotter(net, colorbar='blah')
 
     net = jones_2009_model(params)
     net_plot = NetworkPlotter(net)
@@ -272,6 +276,7 @@ def test_dipole_visualization():
     assert net_plot.vsec_array.shape == (159, 21)
     assert net_plot.color_array.shape == (159, 21, 4)
     assert net_plot._vsec_recorded is True
+    assert isinstance(net_plot._cbar, Colorbar)
 
     # Type check errors
     with pytest.raises(TypeError, match='xlim must be'):
@@ -292,6 +297,8 @@ def test_dipole_visualization():
         net_plot.trial_idx = 1.0
     with pytest.raises(TypeError, match='time_idx must be'):
         net_plot.time_idx = 1.0
+    with pytest.raises(TypeError, match='colorbar must be'):
+        net_plot.colorbar = 'blah'
 
     # Check that the setters work
     net_plot.xlim = (-100, 100)
@@ -305,6 +312,10 @@ def test_dipole_visualization():
     net_plot.time_idx = 5
     net_plot.bgcolor = 'white'
     net_plot.voltage_colormap = 'jet'
+
+    net_plot.colorbar = False
+    # check later that net._cbar is None
+    assert net_plot._cbar is None
 
     # Check that the getters work
     assert net_plot.xlim == (-100, 100)

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -9,8 +9,9 @@ import pytest
 
 import hnn_core
 from hnn_core import read_params, jones_2009_model
-from hnn_core.viz import plot_cells, plot_dipole, plot_psd, plot_tfr_morlet
-from hnn_core.viz import plot_connectivity_matrix, plot_cell_connectivity
+from hnn_core.viz import (plot_cells, plot_dipole, plot_psd, plot_tfr_morlet,
+                          plot_connectivity_matrix, plot_cell_connectivity,
+                          NetworkPlotter)
 from hnn_core.dipole import simulate_dipole
 
 matplotlib.use('agg')
@@ -132,7 +133,7 @@ def test_dipole_visualization():
         weights_ampa=weights_ampa, synaptic_delays=syn_delays,
         event_seed=14)
 
-    dpls = simulate_dipole(net, tstop=100., n_trials=2)
+    dpls = simulate_dipole(net, tstop=100., n_trials=2, record_vsec='all')
     fig = dpls[0].plot()  # plot the first dipole alone
     axes = fig.get_axes()[0]
     dpls[0].copy().smooth(window_len=10).plot(ax=axes)  # add smoothed versions
@@ -219,5 +220,45 @@ def test_dipole_visualization():
                                                   'beta_dist': 'g'})
     with pytest.raises(ValueError, match="'beta_dist' must be"):
         net.cell_response.plot_spikes_hist(color={'beta_prox': 'r'})
+
+    # test NetworkPlotter class
+    with pytest.raises(TypeError, match='xlim must be'):
+        _ = NetworkPlotter(net, xlim='blah')
+    with pytest.raises(TypeError, match='ylim must be'):
+        _ = NetworkPlotter(net, ylim='blah')
+    with pytest.raises(TypeError, match='zlim must be'):
+        _ = NetworkPlotter(net, zlim='blah')
+    with pytest.raises(TypeError, match='elev must be'):
+        _ = NetworkPlotter(net, elev='blah')
+    with pytest.raises(TypeError, match='azim must be'):
+        _ = NetworkPlotter(net, azim='blah')
+    with pytest.raises(TypeError, match='vmin must be'):
+        _ = NetworkPlotter(net, vmin='blah')
+    with pytest.raises(TypeError, match='vmax must be'):
+        _ = NetworkPlotter(net, vmax='blah')
+    with pytest.raises(TypeError, match='trial_idx must be'):
+        _ = NetworkPlotter(net, trial_idx=1.0)
+    with pytest.raises(TypeError, match='time_idx must be'):
+        _ = NetworkPlotter(net, time_idx=1.0)
+
+    net_plot = NetworkPlotter(net)
+    with pytest.raises(TypeError, match='xlim must be'):
+        net_plot.xlim = 'blah'
+    with pytest.raises(TypeError, match='ylim must be'):
+        net_plot.ylim = 'blah'
+    with pytest.raises(TypeError, match='zlim must be'):
+        net_plot.zlim = 'blah'
+    with pytest.raises(TypeError, match='elev must be'):
+        net_plot.elev = 'blah'
+    with pytest.raises(TypeError, match='azim must be'):
+        net_plot.azim = 'blah'
+    with pytest.raises(TypeError, match='vmin must be'):
+        net_plot.vmin = 'blah'
+    with pytest.raises(TypeError, match='vmax must be'):
+        net_plot.vmax = 'blah'
+    with pytest.raises(TypeError, match='trial_idx must be'):
+        net_plot.trial_idx = 1.0
+    with pytest.raises(TypeError, match='time_idx must be'):
+        net_plot.time_idx = 1.0
 
     plt.close('all')

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -329,14 +329,20 @@ def test_network_plotter_setter(setup_net):
     plt.close('all')
 
 
-def test_network_plotter_export(setup_net):
+def test_network_plotter_export(tmp_path, setup_net):
     """Test NetworkPlotter class export methods."""
     net = setup_net
     _ = simulate_dipole(net, dt=0.5, tstop=10, n_trials=1,
                         record_vsec='all')
     net_plot = NetworkPlotter(net)
 
+    # Check no file is already written
+    path_out = tmp_path / 'demo.gif'
+    assert not path_out.is_file()
+
     # Test animation export and voltage plotting
-    net_plot.export_movie('demo.gif', dpi=200, decim=100, writer='pillow')
+    net_plot.export_movie(path_out, dpi=200, decim=100, writer='pillow')
+
+    assert path_out.is_file()
 
     plt.close('all')

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -245,7 +245,7 @@ def test_dipole_visualization():
     with pytest.raises(TypeError, match='colorbar must be'):
         _ = NetworkPlotter(net, colorbar='blah')
 
-    net = jones_2009_model(params)
+    net = jones_2009_model(params, mesh_shape=(3, 3))
     net_plot = NetworkPlotter(net)
 
     assert net_plot.vsec_array.shape == (159, 1)
@@ -268,7 +268,7 @@ def test_dipole_visualization():
         net_plot.export_movie('demo.gif', dpi=200)
 
     # Simulate with record_vsec='all' to test voltage plotting
-    net = jones_2009_model(params)
+    net = jones_2009_model(params, mesh_shape=(3, 3))
     _ = simulate_dipole(net, dt=0.5, tstop=10, n_trials=2,
                         record_vsec='all')
     net_plot = NetworkPlotter(net)

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -84,6 +84,13 @@ def test_network_visualization():
     with pytest.raises(TypeError,
                        match="'ax' to be an instance of Axes3D, but got Axes"):
         plot_cells(net, ax=axes, show=False)
+    cell_type.plot_morphology(pos=(1.0, 2.0, 3.0))
+    with pytest.raises(TypeError, match='pos must be'):
+        cell_type.plot_morphology(pos=123)
+    with pytest.raises(ValueError, match='pos must be a tuple of 3 elements'):
+        cell_type.plot_morphology(pos=(1, 2, 3, 4))
+    with pytest.raises(TypeError, match='pos\\[idx\\] must be'):
+        cell_type.plot_morphology(pos=(1, '2', 3))
 
     plt.close('all')
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -1240,3 +1240,93 @@ def plot_laminar_csd(times, data, contact_labels, ax=None, colorbar=True,
     plt_show(show)
 
     return ax.get_figure()
+
+
+class NetworkPlot:
+    """Helper class to visualize full
+       morphology of HNN model.
+
+    Parameters
+    ----------
+    net : Instance of Network object
+        The Network object
+
+    colormap_name : str
+        Name of colormap used to visualize membrane potential
+
+    Attributes
+    ----------
+
+    """
+    def __init__(self, net, ax=None, vmin=-100, vmax=50, default_color='b',
+                 voltage_colormap='viridis', elev=10, azim=-500,
+                 xlim=(-200, 3100), ylim=(-200, 300), zlim=(-300, 2200),
+                 trial_idx=0):
+        import matplotlib.pyplot as plt
+        from matplotlib import colormaps
+
+        self.net = net
+
+        self.vmin = vmin
+        self.vmax = vmax
+
+        self.default_color = default_color
+        self.voltage_colormap = voltage_colormap
+        self.colormap = colormaps[voltage_colormap]
+
+        # Axes limits and view positions
+        self.xlim = xlim
+        self.ylim = ylim
+        self.zlim = zlim
+        self.elev = elev
+        self.azim = azim
+
+        self.trial_idx = trial_idx
+
+        # Get voltage data and corresponding colors
+        self.vsec_array = self.get_voltages()
+        self.color_array = self.colormap(self.vsec_array)
+
+        # Create figure
+        if ax is None:
+            self.fig = plt.figure()
+            self.ax = self.fig.add_subplot(projection='3d')
+        else:
+            self.fig=None
+        self.init_network_plot()
+
+    def get_voltages(self):
+        vsec_list = list()
+        for cell_type in self.net.cell_types:
+            gid_range = self.net.gid_ranges[cell_type]
+            for gid in gid_range:
+
+                cell = self.net.cell_types[cell_type]
+
+                for sec_name in cell.sections.keys():
+                    vsec = np.array(self.net.cell_response.vsec[self.trial_idx][gid][sec_name])
+                    vsec_list.append(vsec)
+        
+        vsec_array = np.vstack(vsec_list)
+        vsec_array = (vsec_array - self.vmin) / (self.vmax - self.vmin)
+        return np.vstack(vsec_list)
+    
+    def update_section_voltages(self, lines, color_list):
+        return
+    
+    def plot_voltage(self, t_idx):
+        return
+    
+    def init_network_plot(self):
+        for cell_type in self.net.cell_types:
+            gid_range = self.net.gid_ranges[cell_type]
+            for gid_idx, gid in enumerate(gid_range):
+
+                cell = self.net.cell_types[cell_type]
+
+                pos = self.net.pos_dict[cell_type][gid_idx]
+                pos = (float(pos[0]), float(pos[2]), float(pos[1]))
+
+                cell.plot_morphology(ax=self.ax, show=False, color=self.default_color,
+                                     pos=pos, xlim=self.xlim, ylim=self.ylim, zlim=self.zlim)
+

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -1337,7 +1337,7 @@ class NetworkPlot:
 
         vsec_array = np.vstack(vsec_list)
         vsec_array = (vsec_array - self.vmin) / (self.vmax - self.vmin)
-        return np.vstack(vsec_list)
+        return vsec_array
 
     def update_section_voltages(self, t_idx):
         color_list = self.color_array[:, t_idx]
@@ -1364,6 +1364,15 @@ class NetworkPlot:
         self.ax.set_zlim(self._zlim)
 
         self.ax.view_init(self._elev, self._azim)
+
+    def export_movie(self, fname, dpi=300):
+        import matplotlib.animation as animation
+        ani = animation.FuncAnimation(
+            self.fig, self.set_time_idx, len(self.times) - 1, interval=30)
+
+        writer = animation.writers['ffmpeg'](fps=30)
+        ani.save(fname, writer=writer, dpi=dpi)
+        return ani
 
     # Axis limits
     @property
@@ -1452,6 +1461,10 @@ class NetworkPlot:
     def time_idx(self, time_idx):
         self._time_idx = time_idx
         self.update_section_voltages(self._time_idx)
+
+    # Necessary for making animations
+    def set_time_idx(self, time_idx):
+        self.time_idx = time_idx
 
     # Background color and voltage colormaps
     @property

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -1365,12 +1365,18 @@ class NetworkPlot:
 
         self.ax.view_init(self._elev, self._azim)
 
-    def export_movie(self, fname, dpi=300):
+    def export_movie(self, fname, fps=30, dpi=300, decim=10,
+                     interval=30, frame_start=0, frame_stop=None,
+                     writer='ffmpeg'):
         import matplotlib.animation as animation
-        ani = animation.FuncAnimation(
-            self.fig, self.set_time_idx, len(self.times) - 1, interval=30)
+        if frame_stop is None:
+            frame_stop = len(self.times) - 1
 
-        writer = animation.writers['ffmpeg'](fps=30)
+        frames = np.arange(frame_start, frame_stop, decim)
+        ani = animation.FuncAnimation(
+            self.fig, self.set_time_idx, frames, interval=interval)
+
+        writer = animation.writers[writer](fps=fps)
         ani.save(fname, writer=writer, dpi=dpi)
         return ani
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -921,11 +921,11 @@ def plot_cell_morphology(
     for sec_name, section in cell.sections.items():
         linewidth = _linewidth_from_data_units(ax, section.diam)
         end_pts = section.end_pts
+        dx = pos[0] - cell.sections['soma'].end_pts[0][0]
+        dy = pos[1] - cell.sections['soma'].end_pts[0][1]
+        dz = pos[2] - cell.sections['soma'].end_pts[0][2]
         xs, ys, zs = list(), list(), list()
         for pt in end_pts:
-            dx = pos[0] - cell.sections['soma'].end_pts[0][0]
-            dy = pos[1] - cell.sections['soma'].end_pts[0][1]
-            dz = pos[2] - cell.sections['soma'].end_pts[0][2]
             xs.append(pt[0] + dx)
             ys.append(pt[1] + dz)
             zs.append(pt[2] + dy)

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -876,6 +876,14 @@ def plot_cell_morphology(
     pos : tuple of int or float | None
         Position of cell soma. Must be a tuple of 3 elements for the
         (x, y, z) position of the soma in 3D space. Default: (0, 0, 0)
+    xlim : tuple of int | tuple of float
+        x limits of plot window. Default (-250, 150)
+    ylim : tuple of int | tuple of float
+        y limits of plot window. Default (-100, 100)
+    zlim : tuple of int | tuple of float
+        z limits of plot window. Default (-100, 1200)
+    show : bool
+        If True, show the plot
 
     Returns
     -------
@@ -1549,6 +1557,7 @@ class NetworkPlotter:
         self._trial_idx = trial_idx
         self.vsec_array = self._get_voltages()
         self.color_array = self._colormap(self.vsec_array)
+        self._update_section_voltages(self._time_idx)
 
     @property
     def time_idx(self):

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -1298,7 +1298,6 @@ class NetworkPlotter:
             else:
                 self._vsec_recorded = False
         else:
-            self._is_simulated = False
             self._vsec_recorded = False
             self.times = None
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -853,8 +853,9 @@ def _linewidth_from_data_units(ax, linewidth):
     return linewidth * (length / value_range)
 
 
-def plot_cell_morphology(cell, ax, color=None, pos=(0, 0, 0), xlim=(-250, 150),
-                         ylim=None, zlim=(-100, 1200), show=True):
+def plot_cell_morphology(
+        cell, ax, color=None, pos=(0, 0, 0), xlim=(-250, 150),
+        ylim=(-100, 100), zlim=(-100, 1200), show=True):
     """Plot the cell morphology.
 
     Parameters
@@ -905,9 +906,9 @@ def plot_cell_morphology(cell, ax, color=None, pos=(0, 0, 0), xlim=(-250, 150),
             _validate_type(pos_idx, (float, int), 'pos[idx]')
 
     # Cell is in XZ plane
-    ax.set_xlim((pos[0] - xlim[0], pos[0] + xlim[1]))
-    ax.set_ylim((pos[1] - ylim[0], pos[1] + ylim[1]))
-    ax.set_zlim((pos[2] - zlim[0], pos[2] + zlim[1]))
+    ax.set_xlim((pos[0] + xlim[0], pos[0] + xlim[1]))
+    ax.set_zlim((pos[1] + zlim[0], pos[1] + zlim[1]))
+    ax.set_ylim((pos[2] + ylim[0], pos[2] + ylim[1]))
 
     for sec_name, section in cell.sections.items():
         linewidth = _linewidth_from_data_units(ax, section.diam)

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -1330,6 +1330,7 @@ class NetworkPlotter:
             self.ax = self.fig.add_subplot(projection='3d')
             self.ax.set_facecolor(self._bg_color)
         else:
+            self.ax = ax
             self.fig = None
         self._init_network_plot()
         self._update_axes()

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -853,7 +853,7 @@ def _linewidth_from_data_units(ax, linewidth):
     return linewidth * (length / value_range)
 
 
-def plot_cell_morphology(cell, ax, color=None, show=True):
+def plot_cell_morphology(cell, ax, color=None, pos=(0, 0, 0), show=True):
     """Plot the cell morphology.
 
     Parameters
@@ -871,6 +871,9 @@ def plot_cell_morphology(cell, ax, color=None, show=True):
         defined in the `Cell.sections` attribute.
 
         | Ex: ``{'apical_trunk': 'r', 'soma': 'b', ...}``
+    pos : tuple of int or float | None
+        Position of cell soma. Must be a tuple of 3 elements for the
+        (x, y, z) position of the soma in 3D space. Default: (0, 0, 0)
 
     Returns
     -------
@@ -893,18 +896,25 @@ def plot_cell_morphology(cell, ax, color=None, show=True):
     if isinstance(color, dict):
         section_colors = color
 
+    _validate_type(pos, tuple, 'pos')
+    if isinstance(pos, tuple):
+        if len(pos) != 3:
+            raise ValueError('pos must be a tuple of 3 elements')
+        for pos_idx in pos:
+            _validate_type(pos_idx, (float, int), 'pos[idx]')
+
     # Cell is in XZ plane
-    ax.set_xlim((cell.pos[1] - 250, cell.pos[1] + 150))
-    ax.set_zlim((cell.pos[2] - 100, cell.pos[2] + 1200))
+    # ax.set_xlim((pos[1] - 250, pos[1] + 150))
+    # ax.set_zlim((pos[2] - 100, pos[2] + 1200))
 
     for sec_name, section in cell.sections.items():
         linewidth = _linewidth_from_data_units(ax, section.diam)
         end_pts = section.end_pts
         xs, ys, zs = list(), list(), list()
         for pt in end_pts:
-            dx = cell.pos[0] - cell.sections['soma'].end_pts[0][0]
-            dy = cell.pos[1] - cell.sections['soma'].end_pts[0][1]
-            dz = cell.pos[2] - cell.sections['soma'].end_pts[0][2]
+            dx = pos[0] - cell.sections['soma'].end_pts[0][0]
+            dy = pos[1] - cell.sections['soma'].end_pts[0][1]
+            dz = pos[2] - cell.sections['soma'].end_pts[0][2]
             xs.append(pt[0] + dx)
             ys.append(pt[1] + dz)
             zs.append(pt[2] + dy)

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -1504,7 +1504,7 @@ class NetworkPlotter:
 
     @time_idx.setter
     def time_idx(self, time_idx):
-        _validate_type(time_idx, int, 'time_idx')
+        _validate_type(time_idx, (int, np.integer), 'time_idx')
         self._time_idx = time_idx
         self.update_section_voltages(self._time_idx)
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -1503,7 +1503,7 @@ class NetworkPlotter:
         self._zlim = zlim
         self.ax.set_zlim(self._zlim)
 
-    # Eleevation and azimuth of 3D viewpoint
+    # Elevation and azimuth of 3D viewpoint
     @property
     def elev(self):
         return self._elev

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -1366,7 +1366,7 @@ class NetworkPlotter:
         vsec_array = (vsec_array - self.vmin) / (self.vmax - self.vmin)
         return vsec_array
 
-    def update_section_voltages(self, t_idx):
+    def _update_section_voltages(self, t_idx):
         if not self._vsec_recorded:
             raise RuntimeError("Network must be simulated with"
                                "`simulate_dipole(record_vsec='all')` before"
@@ -1398,7 +1398,7 @@ class NetworkPlotter:
 
     def export_movie(self, fname, fps=30, dpi=300, decim=10,
                      interval=30, frame_start=0, frame_stop=None,
-                     writer='ffmpeg'):
+                     writer='pillow'):
         """Export movie of network activity
         fname : str
             Filename of exported movie
@@ -1416,13 +1416,16 @@ class NetworkPlotter:
             Index of last frame, default: None
             If None, entire simulation is animated
         writer : str
-            Movie writer, default: 'ffmpeg'
+            Movie writer, default: 'pillow'.
+            Alternative movie writers can be found at
+            https://matplotlib.org/stable/api/animation_api.html
         """
         import matplotlib.animation as animation
 
         if not self._vsec_recorded:
-            raise RuntimeError('Network must be simulated before'
-                               'plotting voltages.')
+            raise RuntimeError("Network must be simulated with"
+                               "`simulate_dipole(record_vsec='all')` before"
+                               "plotting voltages.")
         if frame_stop is None:
             frame_stop = len(self.times) - 1
 
@@ -1529,7 +1532,7 @@ class NetworkPlotter:
     def time_idx(self, time_idx):
         _validate_type(time_idx, (int, np.integer), 'time_idx')
         self._time_idx = time_idx
-        self.update_section_voltages(self._time_idx)
+        self._update_section_voltages(self._time_idx)
 
     # Callable update function for making animations
     def _set_time_idx(self, time_idx):

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -1243,7 +1243,7 @@ def plot_laminar_csd(times, data, contact_labels, ax=None, colorbar=True,
     return ax.get_figure()
 
 
-class NetworkPlot:
+class NetworkPlotter:
     """Helper class to visualize full
        morphology of HNN model.
 
@@ -1289,6 +1289,8 @@ class NetworkPlot:
         self.net = net
         self.times = net.cell_response.times
 
+        _validate_type(vmin, (int, float), 'vmin')
+        _validate_type(vmax, (int, float), 'vmax')
         self._vmin = vmin
         self._vmax = vmax
 
@@ -1299,11 +1301,21 @@ class NetworkPlot:
         self.colormap = colormaps[voltage_colormap]
 
         # Axes limits and view positions
+        _validate_type(xlim, tuple, 'xlim')
+        _validate_type(ylim, tuple, 'ylim')
+        _validate_type(zlim, tuple, 'zlim')
+        _validate_type(elev, (int, float), 'elev')
+        _validate_type(azim, (int, float), 'azim')
+
         self._xlim = xlim
         self._ylim = ylim
         self._zlim = zlim
         self._elev = elev
         self._azim = azim
+
+        # Trial and time indices
+        _validate_type(trial_idx, int, 'trial_idx')
+        _validate_type(time_idx, int, 'time_idx')
 
         self._trial_idx = trial_idx
         self._time_idx = time_idx
@@ -1387,6 +1399,7 @@ class NetworkPlot:
 
     @xlim.setter
     def xlim(self, xlim):
+        _validate_type(xlim, tuple, 'xlim')
         self._xlim = xlim
         self.ax.set_xlim(self._xlim)
 
@@ -1396,6 +1409,7 @@ class NetworkPlot:
 
     @ylim.setter
     def ylim(self, ylim):
+        _validate_type(ylim, tuple, 'ylim')
         self._ylim = ylim
         self.ax.set_ylim(self._ylim)
 
@@ -1405,6 +1419,7 @@ class NetworkPlot:
 
     @zlim.setter
     def zlim(self, zlim):
+        _validate_type(zlim, tuple, 'zlim')
         self._zlim = zlim
         self.ax.set_zlim(self._zlim)
 
@@ -1415,6 +1430,7 @@ class NetworkPlot:
 
     @elev.setter
     def elev(self, elev):
+        _validate_type(elev, (int, float), 'elev')
         self._elev = elev
         self.ax.view_init(self._elev, self._azim)
 
@@ -1424,6 +1440,7 @@ class NetworkPlot:
 
     @azim.setter
     def azim(self, azim):
+        _validate_type(azim, (int, float), 'azim')
         self._azim = azim
         self.ax.view_init(self._elev, self._azim)
 
@@ -1434,6 +1451,7 @@ class NetworkPlot:
 
     @vmin.setter
     def vmin(self, vmin):
+        _validate_type(vmin, (int, float), 'vmin')
         self._vmin = vmin
         self.vsec_array = self.get_voltages()
         self.color_array = self.colormap(self.vsec_array)
@@ -1444,6 +1462,7 @@ class NetworkPlot:
 
     @vmax.setter
     def vmax(self, vmax):
+        _validate_type(vmax, (int, float), 'vmax')
         self._vmax = vmax
         self.vsec_array = self.get_voltages()
         self.color_array = self.colormap(self.vsec_array)
@@ -1455,6 +1474,7 @@ class NetworkPlot:
 
     @trial_idx.setter
     def trial_idx(self, trial_idx):
+        _validate_type(trial_idx, int, 'trial_idx')
         self._trial_idx = trial_idx
         self.vsec_array = self.get_voltages()
         self.color_array = self.colormap(self.vsec_array)
@@ -1465,6 +1485,7 @@ class NetworkPlot:
 
     @time_idx.setter
     def time_idx(self, time_idx):
+        _validate_type(time_idx, int, 'time_idx')
         self._time_idx = time_idx
         self.update_section_voltages(self._time_idx)
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -1321,7 +1321,7 @@ class NetworkPlotter:
         self._time_idx = time_idx
 
         # Get voltage data and corresponding colors
-        self.vsec_array = self.get_voltages()
+        self.vsec_array = self._get_voltages()
         self.color_array = self.colormap(self.vsec_array)
 
         # Create figure
@@ -1331,10 +1331,10 @@ class NetworkPlotter:
             self.ax.set_facecolor(self._bg_color)
         else:
             self.fig = None
-        self.init_network_plot()
+        self._init_network_plot()
         self._update_axes()
 
-    def get_voltages(self):
+    def _get_voltages(self):
         vsec_list = list()
         for cell_type in self.net.cell_types:
             gid_range = self.net.gid_ranges[cell_type]
@@ -1356,7 +1356,7 @@ class NetworkPlotter:
         for line, color in zip(self.ax.lines, color_list):
             line.set_color(color)
 
-    def init_network_plot(self):
+    def _init_network_plot(self):
         for cell_type in self.net.cell_types:
             gid_range = self.net.gid_ranges[cell_type]
             for gid_idx, gid in enumerate(gid_range):
@@ -1380,13 +1380,32 @@ class NetworkPlotter:
     def export_movie(self, fname, fps=30, dpi=300, decim=10,
                      interval=30, frame_start=0, frame_stop=None,
                      writer='ffmpeg'):
+        """Export movie of network activity
+        fname : str
+            Filename of exported movie
+        fps : int
+            Frames per second, default: 30
+        dpi : int
+            Dots per inch, default: 300
+        decim : int
+            Decimation factor for frames, default: 10
+        interval : int
+            Delay between frames, default: 30
+        frame_start : int
+            Index of first frame, default: 0
+        frame_stop : int | None
+            Index of last frame, default: None
+            If None, entire simulation is animated
+        writer : str
+            Movie writer, default: 'ffmpeg'
+        """
         import matplotlib.animation as animation
         if frame_stop is None:
             frame_stop = len(self.times) - 1
 
         frames = np.arange(frame_start, frame_stop, decim)
         ani = animation.FuncAnimation(
-            self.fig, self.set_time_idx, frames, interval=interval)
+            self.fig, self._set_time_idx, frames, interval=interval)
 
         writer = animation.writers[writer](fps=fps)
         ani.save(fname, writer=writer, dpi=dpi)
@@ -1453,7 +1472,7 @@ class NetworkPlotter:
     def vmin(self, vmin):
         _validate_type(vmin, (int, float), 'vmin')
         self._vmin = vmin
-        self.vsec_array = self.get_voltages()
+        self.vsec_array = self._get_voltages()
         self.color_array = self.colormap(self.vsec_array)
 
     @property
@@ -1464,7 +1483,7 @@ class NetworkPlotter:
     def vmax(self, vmax):
         _validate_type(vmax, (int, float), 'vmax')
         self._vmax = vmax
-        self.vsec_array = self.get_voltages()
+        self.vsec_array = self._get_voltages()
         self.color_array = self.colormap(self.vsec_array)
 
     # Time and trial indices
@@ -1476,7 +1495,7 @@ class NetworkPlotter:
     def trial_idx(self, trial_idx):
         _validate_type(trial_idx, int, 'trial_idx')
         self._trial_idx = trial_idx
-        self.vsec_array = self.get_voltages()
+        self.vsec_array = self._get_voltages()
         self.color_array = self.colormap(self.vsec_array)
 
     @property
@@ -1489,8 +1508,8 @@ class NetworkPlotter:
         self._time_idx = time_idx
         self.update_section_voltages(self._time_idx)
 
-    # Necessary for making animations
-    def set_time_idx(self, time_idx):
+    # Callable update function for making animations
+    def _set_time_idx(self, time_idx):
         self.time_idx = time_idx
 
     # Background color and voltage colormaps

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -853,7 +853,8 @@ def _linewidth_from_data_units(ax, linewidth):
     return linewidth * (length / value_range)
 
 
-def plot_cell_morphology(cell, ax, color=None, pos=(0, 0, 0), show=True):
+def plot_cell_morphology(cell, ax, color=None, pos=(0, 0, 0), xlim=(-250, 150),
+                         ylim=None, zlim=(-100, 1200), show=True):
     """Plot the cell morphology.
 
     Parameters
@@ -904,8 +905,9 @@ def plot_cell_morphology(cell, ax, color=None, pos=(0, 0, 0), show=True):
             _validate_type(pos_idx, (float, int), 'pos[idx]')
 
     # Cell is in XZ plane
-    # ax.set_xlim((pos[1] - 250, pos[1] + 150))
-    # ax.set_zlim((pos[2] - 100, pos[2] + 1200))
+    ax.set_xlim((pos[0] - xlim[0], pos[0] + xlim[1]))
+    ax.set_ylim((pos[1] - ylim[0], pos[1] + ylim[1]))
+    ax.set_zlim((pos[2] - zlim[0], pos[2] + zlim[1]))
 
     for sec_name, section in cell.sections.items():
         linewidth = _linewidth_from_data_units(ax, section.diam)


### PR DESCRIPTION
Here's my first pass at creating a viz class that can be used to quickly render the full 3D network, as well as membrane potentials of individual sections. This is meant to be largely generic and flexible so that it can be co-opted for other purposes. I think the most interesting applications at the moment would be:

- Quickly generating animations of HNN simulations
- Embedding the 3D plot into the current ipywidgets GUI

The current strategy for the class is to do all of the heavy lifting at the initialization (namely creating the 3D object, and mapping the voltage recordings to the appropriate colors). For a quick demo, the code below can be run on my laptop on a single core in approximately 20 sec:
```py
from hnn_core import jones_2009_model, simulate_dipole
from hnn_core.network_models import add_erp_drives_to_jones_model
from hnn_core.viz import NetworkPlot

net = jones_2009_model()
net.set_cell_positions(inplane_distance=300)
add_erp_drives_to_jones_model(net)
dpl = simulate_dipole(net, dt=0.5, tstop=170, record_vsec='all')

net_plot = NetworkPlot(net)
```
![image](https://github.com/jonescompneurolab/hnn-core/assets/55253912/207ef159-ff77-4740-8664-9e9e24eb659a)

If you want to play around with visualizing the voltages, you can try the following code block:
```py
from ipywidgets import interact, IntSlider

def update_plot(t_idx, elev, azim):
    net_plot.update_section_voltages(t_idx)
    net_plot.elev = elev
    net_plot.azim = azim
    return net_plot.fig

time_slider = IntSlider(min=0, max=len(net_plot.times), value=1, continuous_update=False)
elev_slider = IntSlider(min=-100,max=100, value=10, continuous_update=False)
azim_slider = IntSlider(min=-100,max=100, value=-100, continuous_update=False)

interact(update_plot, t_idx=time_slider, elev=elev_slider, azim=azim_slider)
```
![image](https://github.com/jonescompneurolab/hnn-core/assets/55253912/0f3f20e7-7d9a-4c0b-81ee-d32369811016)

