### PR TITLE
[MRG] BUG: objective function in optimization.py should return a scalar

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,9 @@ Bug
 - Fix inconsistent connection mapping from drive gids to cell gids, by
   `Ryan Thorpe`_ in :gh:`642`.
 
+- Objective function called by :func:`~hnn_core/optimization/optimize_evoked`
+  now returns a scalar instead of tuple, by `Ryan Thorpe`_ in :gh:`670`.
+
 API
 ~~~
 - :func:`~hnn_core.CellResponse.write` and :func:`~hnn_core.Cell_response.read_spikes`

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -358,7 +358,7 @@ def _optrun(drive_params_updated, drive_params_static, net, tstop, dt,
 
     opt_params['optiter'] += 1
 
-    return avg_rmse, avg_rmse_unweighted  # nlopt expects error
+    return avg_rmse
 
 
 def _run_optimization(maxiter, param_ranges, optrun):

--- a/hnn_core/optimization.py
+++ b/hnn_core/optimization.py
@@ -279,8 +279,6 @@ def _optrun(drive_params_updated, drive_params_static, net, tstop, dt,
     -------
     avg_rmse: float
         Weighted RMSE between data in dpl and exp_dpl
-    avg_rmse_unweighted : float
-        Unweighted RMSE between data in dpl and exp_dpl
     """
     print("Optimization step %d, iteration %d" % (opt_params['cur_step'] + 1,
                                                   opt_params['optiter'] + 1))

--- a/hnn_core/tests/test_cell_response.py
+++ b/hnn_core/tests/test_cell_response.py
@@ -9,7 +9,7 @@ import numpy as np
 from hnn_core import CellResponse, read_spikes
 
 
-def test_cell_response(tmpdir):
+def test_cell_response(tmp_path):
     """Test CellResponse object."""
     # Round-trip test
     spike_times = [[2.3456, 7.89], [4.2812, 93.2]]
@@ -30,13 +30,13 @@ def test_cell_response(tmpdir):
     with pytest.warns(DeprecationWarning,
                       match="Writing cell response to txt files is "
                       "deprecated"):
-        cell_response.write(tmpdir.join('spk_%d.txt'))
+        cell_response.write(tmp_path.join('spk_%d.txt'))
 
     # Testing reading from txt files
     with pytest.warns(DeprecationWarning,
                       match="Reading cell response from txt files is "
                       "deprecated"):
-        assert cell_response == read_spikes(tmpdir.join('spk_*.txt'))
+        assert cell_response == read_spikes(tmp_path.join('spk_*.txt'))
 
     assert ("CellResponse | 2 simulation trials" in repr(cell_response))
 
@@ -54,10 +54,10 @@ def test_cell_response(tmpdir):
     # Test recovery of empty spike files
     empty_spike = CellResponse(spike_times=[[], []], spike_gids=[[], []],
                                spike_types=[[], []])
-    empty_spike.write(tmpdir.join('empty_spk_%d.txt'))
-    empty_spike.write(tmpdir.join('empty_spk.txt'))
-    empty_spike.write(tmpdir.join('empty_spk_{0}.txt'))
-    assert empty_spike == read_spikes(tmpdir.join('empty_spk_*.txt'))
+    empty_spike.write(tmp_path.join('empty_spk_%d.txt'))
+    empty_spike.write(tmp_path.join('empty_spk.txt'))
+    empty_spike.write(tmp_path.join('empty_spk_{0}.txt'))
+    assert empty_spike == read_spikes(tmp_path.join('empty_spk_*.txt'))
 
     assert ("CellResponse | 2 simulation trials" in repr(empty_spike))
 
@@ -154,23 +154,23 @@ def test_cell_response(tmpdir):
         'L2_basket': [[test_rate], [0.0]]}
 
     # Write spike file with no 'types' column
-    for fname in sorted(glob(str(tmpdir.join('spk_*.txt')))):
+    for fname in sorted(glob(str(tmp_path.join('spk_*.txt')))):
         times_gids_only = np.loadtxt(fname, dtype=str)[:, (0, 1)]
         np.savetxt(fname, times_gids_only, delimiter='\t', fmt='%s')
 
     # Check that spike_types are updated according to gid_ranges
-    cell_response = read_spikes(tmpdir.join('spk_*.txt'),
+    cell_response = read_spikes(tmp_path.join('spk_*.txt'),
                                 gid_ranges=gid_ranges)
     assert cell_response.spike_types == spike_types
 
     # Check for gid_ranges errors
     with pytest.raises(ValueError, match="gid_ranges must be provided if "
                        "spike types are unspecified in the file "):
-        cell_response = read_spikes(tmpdir.join('spk_*.txt'))
+        cell_response = read_spikes(tmp_path.join('spk_*.txt'))
     with pytest.raises(ValueError, match="gid_ranges should contain only "
                        "disjoint sets of gid values"):
         gid_ranges = {'L2_pyramidal': range(3), 'L2_basket': range(2, 4),
                       'L5_pyramidal': range(4, 6), 'L5_basket': range(6, 8)}
-        cell_response = read_spikes(tmpdir.join('spk_*.txt'),
+        cell_response = read_spikes(tmp_path.join('spk_*.txt'),
                                     gid_ranges=gid_ranges)
     plt.close('all')

--- a/hnn_core/tests/test_cell_response.py
+++ b/hnn_core/tests/test_cell_response.py
@@ -30,13 +30,13 @@ def test_cell_response(tmp_path):
     with pytest.warns(DeprecationWarning,
                       match="Writing cell response to txt files is "
                       "deprecated"):
-        cell_response.write(tmp_path.join('spk_%d.txt'))
+        cell_response.write(tmp_path / 'spk_%d.txt')
 
     # Testing reading from txt files
     with pytest.warns(DeprecationWarning,
                       match="Reading cell response from txt files is "
                       "deprecated"):
-        assert cell_response == read_spikes(tmp_path.join('spk_*.txt'))
+        assert cell_response == read_spikes(tmp_path / 'spk_*.txt')
 
     assert ("CellResponse | 2 simulation trials" in repr(cell_response))
 
@@ -54,10 +54,10 @@ def test_cell_response(tmp_path):
     # Test recovery of empty spike files
     empty_spike = CellResponse(spike_times=[[], []], spike_gids=[[], []],
                                spike_types=[[], []])
-    empty_spike.write(tmp_path.join('empty_spk_%d.txt'))
-    empty_spike.write(tmp_path.join('empty_spk.txt'))
-    empty_spike.write(tmp_path.join('empty_spk_{0}.txt'))
-    assert empty_spike == read_spikes(tmp_path.join('empty_spk_*.txt'))
+    empty_spike.write(tmp_path / 'empty_spk_%d.txt')
+    empty_spike.write(tmp_path / 'empty_spk.txt')
+    empty_spike.write(tmp_path / 'empty_spk_{0}.txt')
+    assert empty_spike == read_spikes(tmp_path / 'empty_spk_*.txt')
 
     assert ("CellResponse | 2 simulation trials" in repr(empty_spike))
 
@@ -154,23 +154,22 @@ def test_cell_response(tmp_path):
         'L2_basket': [[test_rate], [0.0]]}
 
     # Write spike file with no 'types' column
-    for fname in sorted(glob(str(tmp_path.join('spk_*.txt')))):
+    for fname in sorted(glob(str(tmp_path / 'spk_*.txt'))):
         times_gids_only = np.loadtxt(fname, dtype=str)[:, (0, 1)]
         np.savetxt(fname, times_gids_only, delimiter='\t', fmt='%s')
 
     # Check that spike_types are updated according to gid_ranges
-    cell_response = read_spikes(tmp_path.join('spk_*.txt'),
-                                gid_ranges=gid_ranges)
+    cell_response = read_spikes(tmp_path / 'spk_*.txt', gid_ranges=gid_ranges)
     assert cell_response.spike_types == spike_types
 
     # Check for gid_ranges errors
     with pytest.raises(ValueError, match="gid_ranges must be provided if "
                        "spike types are unspecified in the file "):
-        cell_response = read_spikes(tmp_path.join('spk_*.txt'))
+        cell_response = read_spikes(tmp_path / 'spk_*.txt')
     with pytest.raises(ValueError, match="gid_ranges should contain only "
                        "disjoint sets of gid values"):
         gid_ranges = {'L2_pyramidal': range(3), 'L2_basket': range(2, 4),
                       'L5_pyramidal': range(4, 6), 'L5_basket': range(6, 8)}
-        cell_response = read_spikes(tmp_path.join('spk_*.txt'),
+        cell_response = read_spikes(tmp_path / 'spk_*.txt',
                                     gid_ranges=gid_ranges)
     plt.close('all')

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -19,12 +19,12 @@ from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
 matplotlib.use('agg')
 
 
-def test_dipole(tmpdir, run_hnn_core_fixture):
+def test_dipole(tmp_path, run_hnn_core_fixture):
     """Test dipole object."""
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
-    dpl_out_fname = tmpdir.join('dpl1.txt')
-    dpl_out_hdf5_fname = tmpdir.join('dpl.hdf5')
+    dpl_out_fname = tmp_path.join('dpl1.txt')
+    dpl_out_hdf5_fname = tmp_path.join('dpl.hdf5')
     params = read_params(params_fname)
     times = np.arange(0, 6000 * params['dt'], params['dt'])
     data = np.random.random((6000, 3))
@@ -86,12 +86,12 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     # Testing for wrong extension provided
     with pytest.raises(NameError,
                        match="File extension should be either txt or hdf5"):
-        dipole.write(tmpdir.join('dpl.xls'))
+        dipole.write(tmp_path.join('dpl.xls'))
 
     # Testing File Not Found Error
     with pytest.raises(FileNotFoundError,
                        match="File not found at "):
-        read_dipole(tmpdir.join('dpl1.hdf5'))
+        read_dipole(tmp_path.join('dpl1.hdf5'))
 
     # dpls with different scale_applied should not be averaged.
     with pytest.raises(RuntimeError,
@@ -100,16 +100,16 @@ def test_dipole(tmpdir, run_hnn_core_fixture):
     # Checking object type field not exists error
     dummy_data = dict()
     dummy_data['objective'] = "Check Object type errors"
-    write_hdf5(tmpdir.join('not_dpl.hdf5'), dummy_data)
+    write_hdf5(tmp_path.join('not_dpl.hdf5'), dummy_data)
     with pytest.raises(NameError,
                        match="The given file is not compatible."):
-        read_dipole(tmpdir.join('not_dpl.hdf5'))
+        read_dipole(tmp_path.join('not_dpl.hdf5'))
     # Checking wrong object type error
     dummy_data['object_type'] = "dpl"
-    write_hdf5(tmpdir.join('not_dpl.hdf5'), dummy_data, overwrite=True)
+    write_hdf5(tmp_path.join('not_dpl.hdf5'), dummy_data, overwrite=True)
     with pytest.raises(ValueError,
                        match="The object should be of type Dipole."):
-        read_dipole(tmpdir.join('not_dpl.hdf5'))
+        read_dipole(tmp_path.join('not_dpl.hdf5'))
     # force the scale_applied to be identical across dpls to allow averaging.
     dipole.scale_applied = dipole_read.scale_applied
     # average two identical dipole objects

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -23,8 +23,8 @@ def test_dipole(tmp_path, run_hnn_core_fixture):
     """Test dipole object."""
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
-    dpl_out_fname = tmp_path.join('dpl1.txt')
-    dpl_out_hdf5_fname = tmp_path.join('dpl.hdf5')
+    dpl_out_fname = tmp_path / 'dpl1.txt'
+    dpl_out_hdf5_fname = tmp_path / 'dpl.hdf5'
     params = read_params(params_fname)
     times = np.arange(0, 6000 * params['dt'], params['dt'])
     data = np.random.random((6000, 3))
@@ -86,12 +86,12 @@ def test_dipole(tmp_path, run_hnn_core_fixture):
     # Testing for wrong extension provided
     with pytest.raises(NameError,
                        match="File extension should be either txt or hdf5"):
-        dipole.write(tmp_path.join('dpl.xls'))
+        dipole.write(tmp_path / 'dpl.xls')
 
     # Testing File Not Found Error
     with pytest.raises(FileNotFoundError,
                        match="File not found at "):
-        read_dipole(tmp_path.join('dpl1.hdf5'))
+        read_dipole(tmp_path / 'dpl1.hdf5')
 
     # dpls with different scale_applied should not be averaged.
     with pytest.raises(RuntimeError,
@@ -100,16 +100,16 @@ def test_dipole(tmp_path, run_hnn_core_fixture):
     # Checking object type field not exists error
     dummy_data = dict()
     dummy_data['objective'] = "Check Object type errors"
-    write_hdf5(tmp_path.join('not_dpl.hdf5'), dummy_data)
+    write_hdf5(tmp_path / 'not_dpl.hdf5', dummy_data)
     with pytest.raises(NameError,
                        match="The given file is not compatible."):
-        read_dipole(tmp_path.join('not_dpl.hdf5'))
+        read_dipole(tmp_path / 'not_dpl.hdf5')
     # Checking wrong object type error
     dummy_data['object_type'] = "dpl"
-    write_hdf5(tmp_path.join('not_dpl.hdf5'), dummy_data, overwrite=True)
+    write_hdf5(tmp_path / 'not_dpl.hdf5', dummy_data, overwrite=True)
     with pytest.raises(ValueError,
                        match="The object should be of type Dipole."):
-        read_dipole(tmp_path.join('not_dpl.hdf5'))
+        read_dipole(tmp_path / 'not_dpl.hdf5')
     # force the scale_applied to be identical across dpls to allow averaging.
     dipole.scale_applied = dipole_read.scale_applied
     # average two identical dipole objects

--- a/hnn_core/tests/test_optimization.py
+++ b/hnn_core/tests/test_optimization.py
@@ -170,9 +170,9 @@ def test_optimize_evoked():
     assert drive_static_params_opt == drive_static_params_orig
 
     # ensure that only the drive that we wanted to optimzie over changed
-    drive_evdist1_dynamics_offset, drive_evdist1_syn_weights_offset,\
+    drive_evdist1_dynamics_offset, drive_evdist1_syn_weights_offset, \
         drive_static_params_offset = _get_drive_params(net_offset, ['evdist1'])
-    drive_evdist1_dynamics_opt, drive_evdist1_syn_weights_opt,\
+    drive_evdist1_dynamics_opt, drive_evdist1_syn_weights_opt, \
         drive_static_params_opt = _get_drive_params(net_opt, ['evdist1'])
 
     # assert that evdist1 did NOT change


### PR DESCRIPTION
The goal here is to fix a few minor bugs that have popped up in master branch due to updates in dependencies. The biggest one revealed a bug on our end (as the title states), but the others were caused by an update in flake8 and a divergence between the object returned by pytest's legacy tmpdir ([`py.path.local` instance](https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures)) and what h5py expects to read from / write to (a str specifying a path or pathlib.Path instance).