### PR TITLE
[MRG] Optimize rhythmic drives

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -84,6 +84,9 @@ Changelog
 
 - Added GUI feature to read and modify cell parameters,
   by `Camilo Diaz`_  in :gh:`806`.
+  
+- Add ability to optimize parameters associated with rhythmic drives,
+  by `Carolina Fernandez Pujol`_ in :gh:`673`.
 
 
 Bug

--- a/examples/howto/optimize_evoked.py
+++ b/examples/howto/optimize_evoked.py
@@ -188,10 +188,10 @@ from hnn_core.optimization import Optimizer
 
 net = jones_2009_model()
 optim = Optimizer(net, tstop=tstop, constraints=constraints,
-                  set_params=set_params, scale_factor=scale_factor,
-                  smooth_window_len=smooth_window_len, max_iter=40)
+                  set_params=set_params, max_iter=40)
 with MPIBackend(n_procs=n_procs, mpi_cmd='mpiexec'):
-    optim.fit(exp_dpl)
+    optim.fit(target=exp_dpl, scale_factor=scale_factor,
+              smooth_window_len=smooth_window_len)
 
 ###############################################################################
 # Finally, we can plot the experimental data alongside the post-optimization

--- a/examples/howto/optimize_evoked.py
+++ b/examples/howto/optimize_evoked.py
@@ -188,7 +188,7 @@ from hnn_core.optimization import Optimizer
 
 net = jones_2009_model()
 optim = Optimizer(net, tstop=tstop, constraints=constraints,
-                  set_params=set_params, max_iter=40)
+                  set_params=set_params)
 with MPIBackend(n_procs=n_procs, mpi_cmd='mpiexec'):
     optim.fit(target=exp_dpl, scale_factor=scale_factor,
               smooth_window_len=smooth_window_len)

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -94,7 +94,6 @@ scale_factor = 3000
 smooth_window_len = 20
 
 net = jones_2009_model()
-
 optim = Optimizer(net, tstop=tstop, constraints=constraints,
                   set_params=set_params, scale_factor=scale_factor,
                   smooth_window_len=smooth_window_len, obj_fun='maximize_psd')

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -110,7 +110,7 @@ optim = Optimizer(net, tstop=tstop, constraints=constraints,
 # 8-15 Hz (alpha) and 15-30 Hz (beta) are the frequency bands whose
 # power we wish to maximize in a ratio of 1 to 2.
 with MPIBackend(n_procs=n_procs, mpi_cmd='mpiexec'):
-    optim.fit(f_bands=[(8, 15), (15, 30)], relative_bandpower=(1, 2))
+    optim.fit(f_bands=[(9, 11), (19, 21)], relative_bandpower=(1, 2))
 
 ###############################################################################
 # Finally, we can plot the optimized dipole, power spectral density (PSD), and

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -26,10 +26,6 @@ n_procs = 10
 # object with no attached drives, and a dictionary of the parameters we wish to
 # optimize.
 
-# define set_params function and constraints
-net = jones_2009_model()
-
-
 def set_params(net, params):
 
     # Proximal (alpha)

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -78,12 +78,12 @@ def set_params(net, params):
 constraints = dict()
 constraints.update({'alpha_prox_weight': (4.4e-5, 6.4e-5),
                     'alpha_prox_tstart': (45, 55),
-                    'alpha_prox_burst_rate': (8, 12),
-                    'alpha_prox_burst_std': (10, 25),
+                    'alpha_prox_burst_rate': (1, 30),
+                    'alpha_prox_burst_std': (10, 30),
                     'alpha_dist_weight': (4.4e-5, 6.4e-5),
                     'alpha_dist_tstart': (45, 55),
-                    'alpha_dist_burst_rate': (8, 12),
-                    'alpha_dist_burst_std': (10, 25)})
+                    'alpha_dist_burst_rate': (1, 30),
+                    'alpha_dist_burst_std': (10, 30)})
 
 ###############################################################################
 # Now we define and fit the optimizer.
@@ -94,14 +94,15 @@ scale_factor = 3000
 smooth_window_len = 20
 
 net = jones_2009_model()
+
 optim = Optimizer(net, tstop=tstop, constraints=constraints,
                   set_params=set_params, scale_factor=scale_factor,
                   smooth_window_len=smooth_window_len, obj_fun='maximize_psd')
 
-# 8-12 Hz (alpha) and 18-22 Hz (beta) are the frequency bands whose
+# 8-15 Hz (alpha) and 15-30 Hz (beta) are the frequency bands whose
 # power we wish to maximize in a ratio of 1 to 2.
 with MPIBackend(n_procs=n_procs, mpi_cmd='mpiexec'):
-    optim.fit(f_bands=[(8, 12), (18, 22)], relative_bandpower=(1, 2))
+    optim.fit(f_bands=[(8, 15), (15, 30)], relative_bandpower=(1, 2))
 
 ###############################################################################
 # Finally, we can plot the optimized dipole, power spectral density (PSD), and

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -104,13 +104,13 @@ smooth_window_len = 20
 
 net = jones_2009_model()
 optim = Optimizer(net, tstop=tstop, constraints=constraints,
-                  set_params=set_params, scale_factor=scale_factor,
-                  smooth_window_len=smooth_window_len, obj_fun='maximize_psd')
+                  set_params=set_params, obj_fun='maximize_psd')
 
 # 8-15 Hz (alpha) and 15-30 Hz (beta) are the frequency bands whose
 # power we wish to maximize in a ratio of 1 to 2.
 with MPIBackend(n_procs=n_procs, mpi_cmd='mpiexec'):
-    optim.fit(f_bands=[(9, 11), (19, 21)], relative_bandpower=(1, 2))
+    optim.fit(f_bands=[(9, 11), (19, 21)], relative_bandpower=(1, 2),
+              scale_factor=scale_factor, smooth_window_len=smooth_window_len)
 
 ###############################################################################
 # Finally, we can plot the optimized dipole, power spectral density (PSD), and

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -5,11 +5,16 @@
 
 This example demonstrates how to optimize the power spectral density (PSD)
 <<<<<<< HEAD
+<<<<<<< HEAD
 of a current dipole signal with significant alpha and beta spectral
 components.
 =======
 of a sensory evoked response in the alpha and beta frequency bands.
 >>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
+=======
+of a current dipole signal with significant alpha and beta spectral
+components.
+>>>>>>> 35dd061b (rename variables, update example description)
 """
 
 # Authors: Carolina Fernandez <cxf418@miami.edu>

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -74,7 +74,6 @@ def set_params(net, params):
 # The following synaptic weight parameter ranges (units of micro-siemens)
 # were chosen so as to keep the model in physiologically realistic regimes.
 
-
 constraints = dict()
 constraints.update({'alpha_prox_weight': (4.4e-5, 6.4e-5),
                     'alpha_prox_tstart': (45, 55),

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -1,0 +1,126 @@
+"""
+=========================================
+05. Optimize simulated rhythmic responses
+=========================================
+
+This example demonstrates how to optimize the power spectral density (PSD)
+of a sensory evoked response in the alpha and beta frequency bands.
+"""
+
+# Authors: Carolina Fernandez <cxf418@miami.edu>
+
+import matplotlib.pyplot as plt
+
+###############################################################################
+# Let us import hnn_core
+
+from hnn_core import (MPIBackend, jones_2009_model, simulate_dipole)
+
+# The number of cores may need modifying depending on your current machine.
+n_procs = 10
+
+###############################################################################
+# First, we define a function that will tell the optimization routine how to
+# modify the network drive parameters. The function will take in the Network
+# object with no attached drives, and a dictionary of the paramters we wish to
+# optimize.
+
+# define set_params function and constraints
+net = jones_2009_model()
+
+
+def set_params(net, params):
+
+    # Proximal (alpha)
+    weights_ampa_p = {'L2_pyramidal': params['alpha_prox_weight'],
+                      'L5_pyramidal': 4.4e-5}
+    syn_delays_p = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.}
+
+    net.add_bursty_drive('alpha_prox',
+                         tstart=params['alpha_prox_tstart'],
+                         burst_rate=params['alpha_prox_burst_rate'],
+                         burst_std=params['alpha_prox_burst_std'],
+                         numspikes=2,
+                         spike_isi=10,
+                         n_drive_cells=10,
+                         location='proximal',
+                         weights_ampa=weights_ampa_p,
+                         synaptic_delays=syn_delays_p)
+
+    # Distal (beta)
+    weights_ampa_d = {'L2_pyramidal': params['alpha_dist_weight'],
+                      'L5_pyramidal': 4.4e-5}
+    syn_delays_d = {'L2_pyramidal': 5., 'L5_pyramidal': 5.}
+
+    net.add_bursty_drive('alpha_dist',
+                         tstart=params['alpha_dist_tstart'],
+                         burst_rate=params['alpha_dist_burst_rate'],
+                         burst_std=params['alpha_dist_burst_std'],
+                         numspikes=2,
+                         spike_isi=10,
+                         n_drive_cells=10,
+                         location='distal',
+                         weights_ampa=weights_ampa_d,
+                         synaptic_delays=syn_delays_d)
+
+###############################################################################
+# Then, we define the constraints.
+#
+# The constraints must be a dictionary of tuples where the first value in each
+# tuple is the lower bound and the second value is the upper bound for the
+# corresponding parameter.
+#
+# The following synaptic weight parameter ranges (units of micro-siemens)
+# were chosen so as to keep the model in physiologically realistic regimes.
+
+
+constraints = dict()
+constraints.update({'alpha_prox_weight': (4.4e-5, 6.4e-5),
+                    'alpha_prox_tstart': (45, 55),
+                    'alpha_prox_burst_rate': (8, 12),
+                    'alpha_prox_burst_std': (10, 25),
+                    'alpha_dist_weight': (4.4e-5, 6.4e-5),
+                    'alpha_dist_tstart': (45, 55),
+                    'alpha_dist_burst_rate': (8, 12),
+                    'alpha_dist_burst_std': (10, 25)})
+
+###############################################################################
+# Now we define and fit the optimizer.
+from hnn_core.optimization import Optimizer
+
+tstop = 300
+scale_factor = 3000
+smooth_window_len = 20
+
+net = jones_2009_model()
+optim = Optimizer(net, tstop=tstop, constraints=constraints,
+                  set_params=set_params, scale_factor=scale_factor,
+                  smooth_window_len=smooth_window_len, obj_fun='maximize_psd')
+
+# 8-12 Hz (alpha) and 18-22 Hz (beta) are the frequency bands whose
+# power we wish to maximize in a ratio of 1 to 2.
+with MPIBackend(n_procs=n_procs, mpi_cmd='mpiexec'):
+    optim.fit(f_bands=[(8, 12), (18, 22)], weights=(1, 2))
+
+###############################################################################
+# Finally, we can plot the optimized dipole, power spectral density (PSD), and
+# convergence plot.
+
+from hnn_core.viz import plot_psd
+
+with MPIBackend(n_procs=n_procs, mpi_cmd='mpiexec'):
+    opt_dpl = simulate_dipole(optim.net_, tstop=tstop, n_trials=1)[0]
+opt_dpl.scale(scale_factor)
+opt_dpl.smooth(smooth_window_len)
+
+fig, axes = plt.subplots(2, 1, figsize=(6, 6))
+
+# plot dipole
+opt_dpl.plot(ax=axes[0], layer='agg', show=False, color='tab:green')
+axes[0].legend(['optimized'])
+
+# plot psd
+plot_psd(opt_dpl, fmax=50, ax=axes[1], show=False)
+
+# convergence
+fig1 = optim.plot_convergence()

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -4,7 +4,8 @@
 =========================================
 
 This example demonstrates how to optimize the power spectral density (PSD)
-of a sensory evoked response in the alpha and beta frequency bands.
+of a current dipole signal with significant alpha and beta spectral
+components.
 """
 
 # Authors: Carolina Fernandez <cxf418@miami.edu>
@@ -22,7 +23,7 @@ n_procs = 10
 ###############################################################################
 # First, we define a function that will tell the optimization routine how to
 # modify the network drive parameters. The function will take in the Network
-# object with no attached drives, and a dictionary of the paramters we wish to
+# object with no attached drives, and a dictionary of the parameters we wish to
 # optimize.
 
 # define set_params function and constraints
@@ -100,7 +101,7 @@ optim = Optimizer(net, tstop=tstop, constraints=constraints,
 # 8-12 Hz (alpha) and 18-22 Hz (beta) are the frequency bands whose
 # power we wish to maximize in a ratio of 1 to 2.
 with MPIBackend(n_procs=n_procs, mpi_cmd='mpiexec'):
-    optim.fit(f_bands=[(8, 12), (18, 22)], weights=(1, 2))
+    optim.fit(f_bands=[(8, 12), (18, 22)], relative_bandpower=(1, 2))
 
 ###############################################################################
 # Finally, we can plot the optimized dipole, power spectral density (PSD), and

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -4,17 +4,8 @@
 =========================================
 
 This example demonstrates how to optimize the power spectral density (PSD)
-<<<<<<< HEAD
-<<<<<<< HEAD
 of a current dipole signal with significant alpha and beta spectral
 components.
-=======
-of a sensory evoked response in the alpha and beta frequency bands.
->>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
-=======
-of a current dipole signal with significant alpha and beta spectral
-components.
->>>>>>> 35dd061b (rename variables, update example description)
 """
 
 # Authors: Carolina Fernandez <cxf418@miami.edu>

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -1,6 +1,6 @@
 """
 =========================================
-05. Optimize simulated rhythmic responses
+08. Optimize simulated rhythmic responses
 =========================================
 
 This example demonstrates how to optimize the power spectral density (PSD)

--- a/examples/howto/optimize_rhythmic.py
+++ b/examples/howto/optimize_rhythmic.py
@@ -4,8 +4,12 @@
 =========================================
 
 This example demonstrates how to optimize the power spectral density (PSD)
+<<<<<<< HEAD
 of a current dipole signal with significant alpha and beta spectral
 components.
+=======
+of a sensory evoked response in the alpha and beta frequency bands.
+>>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
 """
 
 # Authors: Carolina Fernandez <cxf418@miami.edu>

--- a/hnn_core/optimization/__init__.py
+++ b/hnn_core/optimization/__init__.py
@@ -1,1 +1,1 @@
-from .optimize_evoked import optimize_evokedfrom .general_optimization import Optimizer
+from .optimize_evoked import optimize_evokedfrom .general_optimization import Optimizer, _update_params

--- a/hnn_core/optimization/general_optimization.py
+++ b/hnn_core/optimization/general_optimization.py
@@ -113,13 +113,12 @@ class Optimizer:
         relative_bandpower : tuple (if obj_fun='maximize_psd')
             Weight for each frequency band.
         """
-
         if (self.obj_fun_name == 'dipole_rmse' and
                 'target' not in obj_fun_kwargs):
             raise Exception('target must be specified')
         elif (self.obj_fun_name == 'maximize_psd' and
-              'f_bands' not in obj_fun_kwargs or
-              'relative_bandpower' not in obj_fun_kwargs):
+              ('f_bands' not in obj_fun_kwargs or
+               'relative_bandpower' not in obj_fun_kwargs)):
             raise Exception('f_bands and relative_bandpower must be specified')
 
         constraints = self._assemble_constraints(self.constraints)

--- a/hnn_core/optimization/general_optimization.py
+++ b/hnn_core/optimization/general_optimization.py
@@ -108,7 +108,7 @@ class Optimizer:
         name = self.__class__.__name__
         return f"<{name}\nsolver={self.solver}\nfit={is_fit}>"
 
-    def fit(self, target=None, f_bands=None, weights=None):
+    def fit(self, target=None, f_bands=None, relative_bandpower=None):
         """Runs optimization routine.
 
         Parameters
@@ -118,7 +118,7 @@ class Optimizer:
         f_bands : list of tuples, optional
             Lower and higher limit for each frequency band. The default is
             None.
-        weights : tuple, optional
+        relative_bandpower : tuple, optional
             Weight for each frequency band. The default is None.
         """
 
@@ -136,7 +136,7 @@ class Optimizer:
                                               self.smooth_window_len,
                                               target,
                                               f_bands,
-                                              weights)
+                                              relative_bandpower)
 
         self.net_ = net_
         self.obj_ = obj
@@ -273,7 +273,7 @@ def _update_params(initial_params, predicted_params):
 def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
                       initial_params, max_iter, scale_factor=1.,
                       smooth_window_len=None, target=None, f_bands=None,
-                      weights=None):
+                      relative_bandpower=None):
     """Runs optimization routine with gp_minimize optimizer.
 
     Parameters
@@ -300,7 +300,7 @@ def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
         A dipole object with experimental data. The default is None.
     f_bands : list of tuples, optional
         Lower and higher limit for each frequency band. The default is None.
-    weights : tuple, optional
+    relative_bandpower : tuple, optional
         Weight for each frequency band. The default is None.
 
     Returns
@@ -329,7 +329,7 @@ def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
                        tstop=tstop,
                        target=target,
                        f_bands=f_bands,
-                       weights=weights)
+                       relative_bandpower=relative_bandpower)
 
     opt_results, _ = bayes_opt(func=_obj_func,
                                x0=list(initial_params.values()),
@@ -354,7 +354,7 @@ def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
 def _run_opt_cobyla(initial_net, tstop, constraints, set_params, obj_fun,
                     initial_params, max_iter, scale_factor=1.,
                     smooth_window_len=None, target=None, f_bands=None,
-                    weights=None):
+                    relative_bandpower=None):
     """Runs optimization routine with fmin_cobyla optimizer.
 
     Parameters
@@ -381,7 +381,7 @@ def _run_opt_cobyla(initial_net, tstop, constraints, set_params, obj_fun,
         A dipole object with experimental data. The default is None.
     f_bands : list of tuples, optional
         Lower and higher limit for each frequency band. The default is None.
-    weights : tuple, optional
+    relative_bandpower : tuple, optional
         Weight for each frequency band. The default is None.
 
     Returns
@@ -410,7 +410,7 @@ def _run_opt_cobyla(initial_net, tstop, constraints, set_params, obj_fun,
                        tstop=tstop,
                        target=target,
                        f_bands=f_bands,
-                       weights=weights)
+                       relative_bandpower=relative_bandpower)
 
     opt_results = fmin_cobyla(_obj_func,
                               cons=constraints,

--- a/hnn_core/optimization/general_optimization.py
+++ b/hnn_core/optimization/general_optimization.py
@@ -12,7 +12,7 @@ from .objective_functions import _rmse_evoked, _maximize_psd
 
 class Optimizer:
     def __init__(self, initial_net, tstop, constraints, set_params,
-                 solver='cobyla', obj_fun='dipole_rmse', scale_factor=1.,
+                 solver='bayesian', obj_fun='dipole_rmse', scale_factor=1.,
                  smooth_window_len=None, max_iter=200):
         """Parameter optimization.
 

--- a/hnn_core/optimization/general_optimization.py
+++ b/hnn_core/optimization/general_optimization.py
@@ -32,8 +32,10 @@ class Optimizer:
             of the parameters that will be set inside the function.
         solver : str
             The optimizer, 'bayesian' or 'cobyla'.
-        obj_fun : str
-            The objective function to be minimized.
+        obj_fun : str | func
+            The objective function to be minimized. Can be 'dipole_rmse',
+            'maximize_psd', or a user-defined function. The default is
+            'dipole_rmse'.
         max_iter : int, optional
             The max number of calls to the objective function. The default is
             200.
@@ -87,7 +89,8 @@ class Optimizer:
             self.obj_fun = _maximize_psd
             self.obj_fun_name = 'maximize_psd'
         else:
-            raise ValueError("obj_fun must be 'dipole_rmse' or 'maximize_psd'")
+            self.obj_fun = obj_fun  # user-defined function
+            self.obj_fun_name = None
         self.tstop = tstop
         self.net_ = None
         self.obj_ = list()
@@ -112,6 +115,10 @@ class Optimizer:
             Lower and higher limit for each frequency band.
         relative_bandpower : tuple (if obj_fun='maximize_psd')
             Weight for each frequency band.
+        scale_factor : float, optional
+            The dipole scale factor.
+        smooth_window_len : float, optional
+            The smooth window length.
         """
         if (self.obj_fun_name == 'dipole_rmse' and
                 'target' not in obj_fun_kwargs):

--- a/hnn_core/optimization/general_optimization.py
+++ b/hnn_core/optimization/general_optimization.py
@@ -108,11 +108,7 @@ class Optimizer:
         name = self.__class__.__name__
         return f"<{name}\nsolver={self.solver}\nfit={is_fit}>"
 
-<<<<<<< HEAD
     def fit(self, target=None, f_bands=None, relative_bandpower=None):
-=======
-    def fit(self, target=None, f_bands=None, weights=None):
->>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
         """Runs optimization routine.
 
         Parameters
@@ -122,11 +118,7 @@ class Optimizer:
         f_bands : list of tuples, optional
             Lower and higher limit for each frequency band. The default is
             None.
-<<<<<<< HEAD
         relative_bandpower : tuple, optional
-=======
-        weights : tuple, optional
->>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
             Weight for each frequency band. The default is None.
         """
 
@@ -144,11 +136,7 @@ class Optimizer:
                                               self.smooth_window_len,
                                               target,
                                               f_bands,
-<<<<<<< HEAD
                                               relative_bandpower)
-=======
-                                              weights)
->>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
 
         self.net_ = net_
         self.obj_ = obj
@@ -285,11 +273,7 @@ def _update_params(initial_params, predicted_params):
 def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
                       initial_params, max_iter, scale_factor=1.,
                       smooth_window_len=None, target=None, f_bands=None,
-<<<<<<< HEAD
                       relative_bandpower=None):
-=======
-                      weights=None):
->>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
     """Runs optimization routine with gp_minimize optimizer.
 
     Parameters
@@ -317,10 +301,14 @@ def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
     f_bands : list of tuples, optional
         Lower and higher limit for each frequency band. The default is None.
 <<<<<<< HEAD
+<<<<<<< HEAD
     relative_bandpower : tuple, optional
 =======
     weights : tuple, optional
 >>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
+=======
+    relative_bandpower : tuple, optional
+>>>>>>> 35dd061b (rename variables, update example description)
         Weight for each frequency band. The default is None.
 
     Returns
@@ -349,11 +337,7 @@ def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
                        tstop=tstop,
                        target=target,
                        f_bands=f_bands,
-<<<<<<< HEAD
                        relative_bandpower=relative_bandpower)
-=======
-                       weights=weights)
->>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
 
     opt_results, _ = bayes_opt(func=_obj_func,
                                x0=list(initial_params.values()),
@@ -378,11 +362,7 @@ def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
 def _run_opt_cobyla(initial_net, tstop, constraints, set_params, obj_fun,
                     initial_params, max_iter, scale_factor=1.,
                     smooth_window_len=None, target=None, f_bands=None,
-<<<<<<< HEAD
                     relative_bandpower=None):
-=======
-                    weights=None):
->>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
     """Runs optimization routine with fmin_cobyla optimizer.
 
     Parameters
@@ -409,11 +389,7 @@ def _run_opt_cobyla(initial_net, tstop, constraints, set_params, obj_fun,
         A dipole object with experimental data. The default is None.
     f_bands : list of tuples, optional
         Lower and higher limit for each frequency band. The default is None.
-<<<<<<< HEAD
     relative_bandpower : tuple, optional
-=======
-    weights : tuple, optional
->>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
         Weight for each frequency band. The default is None.
 
     Returns
@@ -442,11 +418,7 @@ def _run_opt_cobyla(initial_net, tstop, constraints, set_params, obj_fun,
                        tstop=tstop,
                        target=target,
                        f_bands=f_bands,
-<<<<<<< HEAD
                        relative_bandpower=relative_bandpower)
-=======
-                       weights=weights)
->>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
 
     opt_results = fmin_cobyla(_obj_func,
                               cons=constraints,

--- a/hnn_core/optimization/general_optimization.py
+++ b/hnn_core/optimization/general_optimization.py
@@ -108,7 +108,11 @@ class Optimizer:
         name = self.__class__.__name__
         return f"<{name}\nsolver={self.solver}\nfit={is_fit}>"
 
+<<<<<<< HEAD
     def fit(self, target=None, f_bands=None, relative_bandpower=None):
+=======
+    def fit(self, target=None, f_bands=None, weights=None):
+>>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
         """Runs optimization routine.
 
         Parameters
@@ -118,7 +122,11 @@ class Optimizer:
         f_bands : list of tuples, optional
             Lower and higher limit for each frequency band. The default is
             None.
+<<<<<<< HEAD
         relative_bandpower : tuple, optional
+=======
+        weights : tuple, optional
+>>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
             Weight for each frequency band. The default is None.
         """
 
@@ -136,7 +144,11 @@ class Optimizer:
                                               self.smooth_window_len,
                                               target,
                                               f_bands,
+<<<<<<< HEAD
                                               relative_bandpower)
+=======
+                                              weights)
+>>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
 
         self.net_ = net_
         self.obj_ = obj
@@ -273,7 +285,11 @@ def _update_params(initial_params, predicted_params):
 def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
                       initial_params, max_iter, scale_factor=1.,
                       smooth_window_len=None, target=None, f_bands=None,
+<<<<<<< HEAD
                       relative_bandpower=None):
+=======
+                      weights=None):
+>>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
     """Runs optimization routine with gp_minimize optimizer.
 
     Parameters
@@ -300,7 +316,11 @@ def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
         A dipole object with experimental data. The default is None.
     f_bands : list of tuples, optional
         Lower and higher limit for each frequency band. The default is None.
+<<<<<<< HEAD
     relative_bandpower : tuple, optional
+=======
+    weights : tuple, optional
+>>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
         Weight for each frequency band. The default is None.
 
     Returns
@@ -329,7 +349,11 @@ def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
                        tstop=tstop,
                        target=target,
                        f_bands=f_bands,
+<<<<<<< HEAD
                        relative_bandpower=relative_bandpower)
+=======
+                       weights=weights)
+>>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
 
     opt_results, _ = bayes_opt(func=_obj_func,
                                x0=list(initial_params.values()),
@@ -354,7 +378,11 @@ def _run_opt_bayesian(initial_net, tstop, constraints, set_params, obj_fun,
 def _run_opt_cobyla(initial_net, tstop, constraints, set_params, obj_fun,
                     initial_params, max_iter, scale_factor=1.,
                     smooth_window_len=None, target=None, f_bands=None,
+<<<<<<< HEAD
                     relative_bandpower=None):
+=======
+                    weights=None):
+>>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
     """Runs optimization routine with fmin_cobyla optimizer.
 
     Parameters
@@ -381,7 +409,11 @@ def _run_opt_cobyla(initial_net, tstop, constraints, set_params, obj_fun,
         A dipole object with experimental data. The default is None.
     f_bands : list of tuples, optional
         Lower and higher limit for each frequency band. The default is None.
+<<<<<<< HEAD
     relative_bandpower : tuple, optional
+=======
+    weights : tuple, optional
+>>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
         Weight for each frequency band. The default is None.
 
     Returns
@@ -410,7 +442,11 @@ def _run_opt_cobyla(initial_net, tstop, constraints, set_params, obj_fun,
                        tstop=tstop,
                        target=target,
                        f_bands=f_bands,
+<<<<<<< HEAD
                        relative_bandpower=relative_bandpower)
+=======
+                       weights=weights)
+>>>>>>> 72423f24 (add obj func for rhythmic drives, tests, and example)
 
     opt_results = fmin_cobyla(_obj_func,
                               cons=constraints,

--- a/hnn_core/optimization/objective_functions.py
+++ b/hnn_core/optimization/objective_functions.py
@@ -97,7 +97,7 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
     -----
     The objective function minimizes the sum of the weighted (user-defined)
     frequency band PSDs (user-defined) relative to the total PSD of the signal.
-    The objective function can be represented as -Σc[ΣPSD(i)/PSD(j)] where c
+    The objective function can be represented as -Σc[ΣPSD(i)/ΣPSD(j)] where c
     is the weight for each frequency band, PSD(i) is the PSD for each frequency
     band, and PSD(j) is the total PSD of the signal.
     """

--- a/hnn_core/optimization/objective_functions.py
+++ b/hnn_core/optimization/objective_functions.py
@@ -86,7 +86,6 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
     f_bands : list of tuples
         Lower and higher limit for each frequency band.
     relative_bandpower : tuple
-        Weight for each frequency band.
 
     Returns
     -------

--- a/hnn_core/optimization/objective_functions.py
+++ b/hnn_core/optimization/objective_functions.py
@@ -91,13 +91,13 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
     Returns
     -------
     obj : float
-        Normalized RMSE between recorded and simulated dipole.
+        Sum of the weighted frequency band PSDs relative to total signal PSD.
 
     Notes
     -----
     The objective function minimizes the sum of the weighted (user-defined)
     frequency band PSDs (user-defined) relative to the total PSD of the signal.
-    The objective function can be represented as -Σc[ΣPSD(i)/ΣPSD(j)] where c
+    The objective function can be represented as -Σc[ΣPSD(i)/PSD(j)] where c
     is the weight for each frequency band, PSD(i) is the PSD for each frequency
     band, and PSD(j) is the total PSD of the signal.
     """

--- a/hnn_core/optimization/objective_functions.py
+++ b/hnn_core/optimization/objective_functions.py
@@ -10,8 +10,7 @@ from ..dipole import _rmse
 
 
 def _rmse_evoked(initial_net, initial_params, set_params, predicted_params,
-                 update_params, obj_values, scale_factor, smooth_window_len,
-                 tstop, **kwargs):
+                 update_params, obj_values, tstop, obj_fun_kwargs):
     """The objective function for evoked responses.
 
     Parameters
@@ -26,10 +25,6 @@ def _rmse_evoked(initial_net, initial_params, set_params, predicted_params,
         Parameters selected by the optimizer.
     update_params : func
         Function to update params.
-    scale_factor : float
-        The dipole scale factor.
-    smooth_window_len : float
-        The smooth window length.
     tstop : float
         The simulated dipole's duration.
     target : instance of Dipole
@@ -49,11 +44,12 @@ def _rmse_evoked(initial_net, initial_params, set_params, predicted_params,
     dpl = simulate_dipole(new_net, tstop=tstop, n_trials=1)[0]
 
     # smooth & scale
-    dpl.scale(scale_factor)
-    if smooth_window_len is not None:
-        dpl.smooth(smooth_window_len)
+    if 'scale_factor' in obj_fun_kwargs:
+        dpl.scale(obj_fun_kwargs['scale_factor'])
+    if 'smooth_window_len' in obj_fun_kwargs:
+        dpl.smooth(obj_fun_kwargs['smooth_window_len'])
 
-    obj = _rmse(dpl, kwargs['target'], tstop=tstop)
+    obj = _rmse(dpl, obj_fun_kwargs['target'], tstop=tstop)
 
     obj_values.append(obj)
 
@@ -61,8 +57,7 @@ def _rmse_evoked(initial_net, initial_params, set_params, predicted_params,
 
 
 def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
-                  update_params, obj_values, scale_factor, smooth_window_len,
-                  tstop, **kwargs):
+                  update_params, obj_values, tstop, obj_fun_kwargs):
     """The objective function for PSDs.
 
     Parameters
@@ -77,10 +72,6 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
         Parameters selected by the optimizer.
     update_params : func
         Function to update params.
-    scale_factor : float
-        The dipole scale factor.
-    smooth_window_len : float
-        The smooth window length.
     tstop : float
         The simulated dipole's duration.
     f_bands : list of tuples
@@ -114,9 +105,10 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
     dpl = simulate_dipole(new_net, tstop=tstop, n_trials=1)[0]
 
     # smooth & scale
-    dpl.scale(scale_factor)
-    if smooth_window_len is not None:
-        dpl.smooth(smooth_window_len)
+    if 'scale_factor' in obj_fun_kwargs:
+        dpl.scale(obj_fun_kwargs['scale_factor'])
+    if 'smooth_window_len' in obj_fun_kwargs:
+        dpl.smooth(obj_fun_kwargs['smooth_window_len'])
 
     # resample?
 
@@ -126,10 +118,10 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
 
     # for each f band
     f_bands_psds = list()
-    for idx, f_band in enumerate(kwargs['f_bands']):
+    for idx, f_band in enumerate(obj_fun_kwargs['f_bands']):
         f_band_idx = np.where(np.logical_and(freqs_simulated >= f_band[0],
                                              freqs_simulated <= f_band[1]))[0]
-        f_bands_psds.append(-kwargs['relative_bandpower'][idx] *
+        f_bands_psds.append(-obj_fun_kwargs['relative_bandpower'][idx] *
                             sum(psd_simulated[f_band_idx]))
 
     # grand sum

--- a/hnn_core/optimization/objective_functions.py
+++ b/hnn_core/optimization/objective_functions.py
@@ -85,7 +85,7 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
         The simulated dipole's duration.
     f_bands : list of tuples
         Lower and higher limit for each frequency band.
-    weights : tuple
+    relative_bandpower : tuple
         Weight for each frequency band.
 
     Returns
@@ -121,7 +121,7 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
     for idx, f_band in enumerate(kwargs['f_bands']):
         f_band_idx = np.where(np.logical_and(freqs_simulated >= f_band[0],
                                              freqs_simulated <= f_band[1]))[0]
-        f_bands_psds.append((-kwargs['weights'][idx] * sum(
+        f_bands_psds.append((-kwargs['relative_bandpower'][idx] * sum(
             psd_simulated[f_band_idx])) / sum(psd_simulated))
 
     # grand sum

--- a/hnn_core/optimization/objective_functions.py
+++ b/hnn_core/optimization/objective_functions.py
@@ -86,6 +86,7 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
     f_bands : list of tuples
         Lower and higher limit for each frequency band.
     relative_bandpower : tuple
+        Weight for each frequency band.
 
     Returns
     -------

--- a/hnn_core/optimization/objective_functions.py
+++ b/hnn_core/optimization/objective_functions.py
@@ -11,7 +11,7 @@ from ..dipole import _rmse
 
 def _rmse_evoked(initial_net, initial_params, set_params, predicted_params,
                  update_params, obj_values, scale_factor, smooth_window_len,
-                 target, tstop):
+                 tstop, **kwargs):
     """The objective function for evoked responses.
 
     Parameters
@@ -53,7 +53,79 @@ def _rmse_evoked(initial_net, initial_params, set_params, predicted_params,
     if smooth_window_len is not None:
         dpl.smooth(smooth_window_len)
 
-    obj = _rmse(dpl, target, tstop=tstop)
+    obj = _rmse(dpl, kwargs['target'], tstop=tstop)
+
+    obj_values.append(obj)
+
+    return obj
+
+
+def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
+                  update_params, obj_values, scale_factor, smooth_window_len,
+                  tstop, **kwargs):
+    """The objective function for evoked responses.
+
+    Parameters
+    ----------
+    initial_net : instance of Network
+        The network object.
+    initial_params : dict
+        Keys are parameter names, values are initial parameters.
+    set_params : func
+        User-defined function that sets network drives and parameters.
+    predicted_params : list
+        Parameters selected by the optimizer.
+    update_params : func
+        Function to update params.
+    scale_factor : float
+        The dipole scale factor.
+    smooth_window_len : float
+        The smooth window length.
+    tstop : float
+        The simulated dipole's duration.
+    f_bands : list of tuples
+        Lower and higher limit for each frequency band.
+    weights : tuple
+        Weight for each frequency band.
+
+    Returns
+    -------
+    obj : float
+        Normalized RMSE between recorded and simulated dipole.
+    """
+
+    import numpy as np
+
+    from scipy.signal import periodogram
+
+    params = update_params(initial_params, predicted_params)
+
+    # simulate dpl with predicted params
+    new_net = initial_net.copy()
+    set_params(new_net, params)
+    dpl = simulate_dipole(new_net, tstop=tstop, n_trials=1)[0]
+
+    # smooth & scale
+    dpl.scale(scale_factor)
+    if smooth_window_len is not None:
+        dpl.smooth(smooth_window_len)
+
+    # resample?
+
+    # get psd of simulated dpl
+    freqs_simulated, psd_simulated = periodogram(dpl.data['agg'], dpl.sfreq,
+                                                 window='hamming')
+
+    # for each f band
+    f_bands_psds = list()
+    for idx, f_band in enumerate(kwargs['f_bands']):
+        f_band_idx = np.where(np.logical_and(freqs_simulated >= f_band[0],
+                                             freqs_simulated <= f_band[1]))[0]
+        f_bands_psds.append((-kwargs['weights'][idx] * sum(
+            psd_simulated[f_band_idx])) / sum(psd_simulated))
+
+    # grand sum
+    obj = sum(f_bands_psds)
 
     obj_values.append(obj)
 

--- a/hnn_core/optimization/objective_functions.py
+++ b/hnn_core/optimization/objective_functions.py
@@ -63,7 +63,7 @@ def _rmse_evoked(initial_net, initial_params, set_params, predicted_params,
 def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
                   update_params, obj_values, scale_factor, smooth_window_len,
                   tstop, **kwargs):
-    """The objective function for evoked responses.
+    """The objective function for PSDs.
 
     Parameters
     ----------
@@ -92,6 +92,14 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
     -------
     obj : float
         Normalized RMSE between recorded and simulated dipole.
+
+    Notes
+    -----
+    The objective function minimizes the sum of the weighted (user-defined)
+    frequency band PSDs (user-defined) relative to the total PSD of the signal.
+    The objective function can be represented as -Σc[ΣPSD(i)/ΣPSD(j)] where c
+    is the weight for each frequency band, PSD(i) is the PSD for each frequency
+    band, and PSD(j) is the total PSD of the signal.
     """
 
     import numpy as np
@@ -121,11 +129,11 @@ def _maximize_psd(initial_net, initial_params, set_params, predicted_params,
     for idx, f_band in enumerate(kwargs['f_bands']):
         f_band_idx = np.where(np.logical_and(freqs_simulated >= f_band[0],
                                              freqs_simulated <= f_band[1]))[0]
-        f_bands_psds.append((-kwargs['relative_bandpower'][idx] * sum(
-            psd_simulated[f_band_idx])) / sum(psd_simulated))
+        f_bands_psds.append(-kwargs['relative_bandpower'][idx] *
+                            sum(psd_simulated[f_band_idx]))
 
     # grand sum
-    obj = sum(f_bands_psds)
+    obj = sum(f_bands_psds) / sum(psd_simulated)
 
     obj_values.append(obj)
 

--- a/hnn_core/tests/test_general_optimization.py
+++ b/hnn_core/tests/test_general_optimization.py
@@ -188,7 +188,7 @@ def test_rhythmic(solver):
     # test repr before fitting
     assert 'fit=False' in repr(optim), "optimizer is already fit"
 
-    optim.fit(f_bands=[(8, 12), (18, 22)], weights=(1, 2))
+    optim.fit(f_bands=[(8, 12), (18, 22)], relative_bandpower=(1, 2))
 
     # test repr after fitting
     assert 'fit=True' in repr(optim), "optimizer was not fit"

--- a/hnn_core/tests/test_general_optimization.py
+++ b/hnn_core/tests/test_general_optimization.py
@@ -103,3 +103,103 @@ def test_optimize_evoked(solver):
            "Number of rmse values should be the same as max_iter")
     # the returned rmse values should be positive
     assert all(vals >= 0 for vals in obj), "rmse values should be positive"
+
+
+@pytest.mark.parametrize("solver", ['bayesian', 'cobyla'])
+def test_rhythmic(solver):
+    """Test optimization routines for rhythmic drives in a reduced network."""
+
+    max_iter = 11
+    tstop = 300.
+
+    # simulate a dipole to establish ground-truth drive parameters
+    hnn_core_root = op.dirname(hnn_core.__file__)
+    params_fname = op.join(hnn_core_root, 'param', 'default.json')
+    params = read_params(params_fname)
+
+    params.update({'N_pyr_x': 3,
+                   'N_pyr_y': 3})
+    net_offset = jones_2009_model(params)
+
+    # define set_params function and constraints
+    def set_params(net_offset, params):
+
+        # Proximal (alpha)
+        weights_ampa_p = {'L2_pyramidal': params['alpha_prox_weight'],
+                          'L5_pyramidal': 4.4e-5}
+        syn_delays_p = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.}
+
+        net_offset.add_bursty_drive('alpha_prox',
+                                    tstart=params['alpha_prox_tstart'],
+                                    burst_rate=params['alpha_prox_burst_rate'],
+                                    burst_std=params['alpha_prox_burst_std'],
+                                    numspikes=2,
+                                    spike_isi=10,
+                                    n_drive_cells=10,
+                                    location='proximal',
+                                    weights_ampa=weights_ampa_p,
+                                    synaptic_delays=syn_delays_p)
+
+        # Distal (beta)
+        weights_ampa_d = {'L2_pyramidal': params['alpha_dist_weight'],
+                          'L5_pyramidal': 4.4e-5}
+        syn_delays_d = {'L2_pyramidal': 5., 'L5_pyramidal': 5.}
+
+        net_offset.add_bursty_drive('alpha_dist',
+                                    tstart=params['alpha_dist_tstart'],
+                                    burst_rate=params['alpha_dist_burst_rate'],
+                                    burst_std=params['alpha_dist_burst_std'],
+                                    numspikes=2,
+                                    spike_isi=10,
+                                    n_drive_cells=10,
+                                    location='distal',
+                                    weights_ampa=weights_ampa_d,
+                                    synaptic_delays=syn_delays_d)
+
+    # define constraints
+    constraints = dict()
+    constraints.update({'alpha_prox_weight': (4.4e-5, 6.4e-5),
+                        'alpha_prox_tstart': (45, 55),
+                        'alpha_prox_burst_rate': (8, 12),
+                        'alpha_prox_burst_std': (10, 25),
+                        'alpha_dist_weight': (4.4e-5, 6.4e-5),
+                        'alpha_dist_tstart': (45, 55),
+                        'alpha_dist_burst_rate': (8, 12),
+                        'alpha_dist_burst_std': (10, 25)})
+
+    # Optimize
+    optim = Optimizer(net_offset, tstop=tstop, constraints=constraints,
+                      set_params=set_params, solver=solver,
+                      obj_fun='maximize_psd', max_iter=max_iter)
+
+    # test exception raised
+    with pytest.raises(ValueError, match='The current Network instance has '
+                       'external drives, provide a Network object with no '
+                       'external drives.'):
+        net_with_drives = jones_2009_model(params, add_drives_from_params=True)
+        optim = Optimizer(net_with_drives,
+                          tstop=tstop,
+                          constraints=constraints,
+                          set_params=set_params,
+                          solver=solver,
+                          obj_fun='maximize_psd',
+                          max_iter=max_iter)
+
+    # test repr before fitting
+    assert 'fit=False' in repr(optim), "optimizer is already fit"
+
+    optim.fit(f_bands=[(8, 12), (18, 22)], weights=(1, 2))
+
+    # test repr after fitting
+    assert 'fit=True' in repr(optim), "optimizer was not fit"
+
+    # the optimized parameter is in the range
+    for param_idx, param in enumerate(optim.opt_params_):
+        assert (list(constraints.values())[param_idx][0] <= param <=
+                list(constraints.values())[param_idx][1]), (
+                    "Optimized parameter is not in user-defined range")
+
+    obj = optim.obj_
+    # the number of returned rmse values should be the same as max_iter
+    assert (len(obj) <= max_iter), (
+           "Number of rmse values should be the same as max_iter")

--- a/hnn_core/tests/test_general_optimization.py
+++ b/hnn_core/tests/test_general_optimization.py
@@ -86,7 +86,7 @@ def test_optimize_evoked(solver):
     # test repr before fitting
     assert 'fit=False' in repr(optim), "optimizer is already fit"
 
-    optim.fit(dpl_orig)
+    optim.fit(target=dpl_orig)
 
     # test repr after fitting
     assert 'fit=True' in repr(optim), "optimizer was not fit"

--- a/hnn_core/tests/test_general_optimization.py
+++ b/hnn_core/tests/test_general_optimization.py
@@ -240,7 +240,7 @@ def test_user_obj_fun(solver):
         electrode_pos = [(135, 135, dep) for dep in depths]
         new_net.add_electrode_array('shank1', electrode_pos)
 
-        dpl = simulate_dipole(new_net, tstop=tstop, n_trials=1)[0]
+        simulate_dipole(new_net, tstop=tstop, n_trials=1)[0]
 
         potentials = new_net.rec_arrays['shank1'][0]
 
@@ -263,8 +263,8 @@ def test_user_obj_fun(solver):
             depth_max = np.argmax(contact_labels >=
                                   obj_fun_kwargs['electrode_depths'][idx][1])
 
-            csd_subsets.append(sum(sum(csd[depth_min:depth_max+1,
-                                           t_min:t_max+1])))
+            csd_subsets.append(sum(sum(csd[depth_min:depth_max + 1,
+                                           t_min:t_max + 1])))
 
         obj = sum(csd_subsets) / sum(sum(csd))
         obj_values.append(obj)


### PR DESCRIPTION
The goals are:

1. To be able to optimize parameters associated with rhythmic drives. The user sets the frequency bands and relative bandpower. In the example below, we wish to optimize power in the 9-11 Hz and 19-21 Hz bands in a ratio of 1 to 2 (i.e. twice as much power in the beta band as in the alpha band). 

```
optim = Optimizer(net, tstop=tstop, constraints=constraints,
                  set_params=set_params, obj_fun='maximize_psd')
optim.fit(f_bands=[(9, 11), (19, 21)], relative_bandpower=(1, 2), scale_factor=scale_factor,
                  smooth_window_len=smooth_window_len)
```
**Example output**
![image](https://github.com/jonescompneurolab/hnn-core/assets/51917715/bb7db1f6-e3ed-4590-9ca3-d11b33381b8b)
![image](https://github.com/jonescompneurolab/hnn-core/assets/51917715/a20a6a25-43a1-4cc9-8f7b-13d7eb9884ff)

**Reversing the ratios**
```
optim.fit(f_bands=[(9, 11), (19, 21)], relative_bandpower=(2, 1), scale_factor=scale_factor,
                  smooth_window_len=smooth_window_len)
```
![image](https://github.com/jonescompneurolab/hnn-core/assets/51917715/8737ffe4-8090-4160-956c-5229ddaeda0f)
![image](https://github.com/jonescompneurolab/hnn-core/assets/51917715/1b568bc8-7924-472f-b2f8-88e13cb97d34)

2. To allow the user to define `obj_fun` as a callable.
