### PR TITLE
[MRG] GUI dipole plot bug. 

### DIFF
--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -150,7 +150,7 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
 
     elif plot_type == 'PSD':
         if len(dpls_copied) > 0:
-            color = next(ax._get_lines.prop_cycler)['color']
+            color = ax._get_lines.get_next_color()
             dpls_copied[0].plot_psd(fmin=0, fmax=50, ax=ax, color=color,
                                     label=sim_name, show=False)
 
@@ -175,7 +175,7 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
             else:
                 label = sim_name
 
-            color = next(ax._get_lines.prop_cycler)['color']
+            color = ax._get_lines.get_next_color()
             if plot_type == 'current dipole':
                 plot_dipole(dpls_copied,
                             ax=ax,

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -299,8 +299,11 @@ def test_gui_add_figure():
     gui.run_button.click()
     assert len(fig_tabs.children) == 1
     assert len(axes_config_tabs.children) == 1
-
     assert gui.viz_manager.fig_idx['idx'] == 2
+
+    # Check default figs have data on their axis
+    assert gui.viz_manager.figs[1].axes[0].has_data()
+    assert gui.viz_manager.figs[1].axes[1].has_data()
 
     for idx in range(3):
         n_fig = idx + 2


### PR DESCRIPTION
- Refactored GUI color cycling be compatible with matplotlib 3.8.x deprecation of `ax._get_lines.prop_cycler`. Substituted with  `ax._get_lines.get_next_color()`.
- Tested with older versions matplotlib==3.5.3 and 3.7.4 to make sure the plots still work.

closes #694 #688