### PR TITLE
[MRG] Update GUI to latest version of ipywidgets and voila

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
               command: |
                   source ~/miniconda/bin/activate testenv
                   cd doc/ && make html
+              no_output_timeout: 20m
 
           - persist_to_workspace:
               root: doc/_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ jobs:
               command: |
                   source ~/miniconda/bin/activate testenv
                   cd doc/ && make html
-              no_output_timeout: 20m
 
           - persist_to_workspace:
               root: doc/_build

--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,10 @@ Optional dependencies
 GUI
 ~~~
 
-* ipywidgets (<=7.7.1)
-* voila (<=0.3.6)
+* ipywidgets (>=8.0.0)
+* voila
+* ipympl
+* ipykernel
 
 Optimization
 ~~~~~~~~~~~~

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -150,7 +150,7 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
 
     elif plot_type == 'PSD':
         if len(dpls_copied) > 0:
-            color = next(ax._get_lines.prop_cycler)['color']
+            color = ax._get_lines.get_next_color()
             dpls_copied[0].plot_psd(fmin=0, fmax=50, ax=ax, color=color,
                                     label=sim_name, show=False)
 
@@ -175,7 +175,7 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
             else:
                 label = sim_name
 
-            color = next(ax._get_lines.prop_cycler)['color']
+            color = ax._get_lines.get_next_color()
             if plot_type == 'current dipole':
                 plot_dipole(dpls_copied,
                             ax=ax,

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -101,7 +101,7 @@ def plot_type_coupled_change(new_plot_type, target_data_selection):
 
 def unlink_relink(attribute):
     """
-    Wrapper function to unlink widgets and re-link widgets.
+    Decorator function to unlink widgets and re-link widgets.
 
     Unlinks linked widgets, runs the wrapped function, and relinks the widgets
     upon completion. To be used as a decorator on class methods. The class must

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -604,7 +604,7 @@ def _add_figure(b, widgets, data, scale=0.95, dpi=96):
             display(widgets['figs_tabs'])
 
     widgets['figs_tabs'].children = (
-            [s for s in widgets['figs_tabs'].children] + [fig_outputs]
+        [s for s in widgets['figs_tabs'].children] + [fig_outputs]
     )
     widgets['figs_tabs'].set_title(n_tabs, _idx2figname(fig_idx))
 

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -658,7 +658,7 @@ class _VizManager:
         self.figs_config_tab_link = link(
             (self.axes_config_tabs, 'selected_index'),
             (self.figs_tabs, 'selected_index'),
-                                         )
+        )
 
         template_names = list(fig_templates.keys())
         self.templates_dropdown = Dropdown(

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -255,9 +255,7 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
 def _static_rerender(widgets, fig, fig_idx):
     logger.debug('_static_re_render is called')
     figs_tabs = widgets['figs_tabs']
-    titles = [
-        figs_tabs.get_title(idx) for idx in range(len(figs_tabs.children))
-    ]
+    titles = figs_tabs.titles
     fig_tab_idx = titles.index(_idx2figname(fig_idx))
     fig_output = widgets['figs_tabs'].children[fig_tab_idx]
     fig_output.clear_output()
@@ -531,7 +529,7 @@ def _close_figure(b, widgets, data, fig_idx):
     fig_related_widgets = [widgets['figs_tabs'], widgets['axes_config_tabs']]
     for w_idx, tab in enumerate(fig_related_widgets):
         tab_children = list(tab.children)
-        titles = [tab.get_title(idx) for idx in range(len(tab.children))]
+        titles = tab.titles
         tab_idx = titles.index(_idx2figname(fig_idx))
         print(f"Del fig_idx={fig_idx}, fig_idx={fig_idx}")
         del tab_children[tab_idx], titles[tab_idx]
@@ -758,7 +756,7 @@ class _VizManager:
 
     def _simulate_delete_figure(self, fig_name):
         tab = self.axes_config_tabs
-        titles = [tab.get_title(idx) for idx in range(len(tab.children))]
+        titles = tab.titles
         assert fig_name in titles
         tab_idx = titles.index(fig_name)
 
@@ -793,16 +791,13 @@ class _VizManager:
         assert operation in ("plot", "clear")
 
         tab = self.axes_config_tabs
-        titles = [tab.get_title(idx) for idx in range(len(tab.children))]
+        titles = tab.titles
         assert fig_name in titles, "No such figure"
         tab_idx = titles.index(fig_name)
         self.axes_config_tabs.selected_index = tab_idx
 
         ax_control_tabs = self.axes_config_tabs.children[tab_idx].children[1]
-        ax_titles = [
-            ax_control_tabs.get_title(idx)
-            for idx in range(len(ax_control_tabs.children))
-        ]
+        ax_titles = ax_control_tabs.titles
         assert ax_name in ax_titles, "No such axis"
         ax_idx = ax_titles.index(ax_name)
         ax_control_tabs.selected_index = ax_idx

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -99,15 +99,18 @@ def plot_type_coupled_change(new_plot_type, target_data_selection):
         target_data_selection.disabled = False
 
 
-def unlink_relink(attribute: str):
+def unlink_relink(attribute):
     """
-    Wrapper function to unlink widgets to perform edits and re-link them on
-    completion. Used as a decorator on class methods. The class must have an
-    attribute containing an ipywidgets/traitlets link object.
+    Wrapper function to unlink widgets and re-link widgets.
+
+    Unlinks linked widgets, runs the wrapped function, and relinks the widgets
+    upon completion. To be used as a decorator on class methods. The class must
+    have an attribute containing an ipywidgets/traitlets link object.
 
     Parameters
     ----------
-    attribute: The class attribute containing link object of ipywidgets widgets
+    attribute: (str) The class attribute containing link object of ipywidgets
+               widgets
 
     """
     def _unlink_relink(f):
@@ -120,7 +123,7 @@ def unlink_relink(attribute: str):
             # Call the original function
             result = f(self, *args, **kwargs)
 
-            # Re-link the widgets using link.link()
+            # Re-link the widgets
             link_attribute.link()
 
             return result
@@ -600,8 +603,9 @@ def _add_figure(b, widgets, data, scale=0.95, dpi=96):
         with widgets['figs_output']:
             display(widgets['figs_tabs'])
 
-    widgets['figs_tabs'].children = \
-        [s for s in widgets['figs_tabs'].children] + [fig_outputs]
+    widgets['figs_tabs'].children = (
+            [s for s in widgets['figs_tabs'].children] + [fig_outputs]
+    )
     widgets['figs_tabs'].set_title(n_tabs, _idx2figname(fig_idx))
 
     with fig_outputs:

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -528,18 +528,25 @@ def _get_ax_control(widgets, data, fig_idx, fig, ax):
 def _close_figure(b, widgets, data, fig_idx):
     fig_related_widgets = [widgets['figs_tabs'], widgets['axes_config_tabs']]
     for w_idx, tab in enumerate(fig_related_widgets):
+        # Get tab object's list of children and their titles
         tab_children = list(tab.children)
-        titles = tab.titles
+        titles = list(tab.titles)
+        # Get the index based on the title
         tab_idx = titles.index(_idx2figname(fig_idx))
+        # Remove the child and title specified
         print(f"Del fig_idx={fig_idx}, fig_idx={fig_idx}")
-        del tab_children[tab_idx], titles[tab_idx]
+        tab_children.pop(tab_idx)
+        titles.pop(tab_idx)
+        # Reset children and titles of the tab object
+        tab.children = tab_children
+        tab.titles = titles
 
-        tab.children = tuple(tab_children)
-        [tab.set_title(idx, title) for idx, title in enumerate(titles)]
-
+        # If the figure tab group...
         if w_idx == 0:
+            # Close figure and delete the data
             plt.close(data['figs'][fig_idx])
-            del data['figs'][fig_idx]
+            data['figs'].pop(fig_idx)
+            # Redisplay the remaining children
             n_tabs = len(tab.children)
             for idx in range(n_tabs):
                 _fig_idx = _figname2idx(tab.get_title(idx))
@@ -549,10 +556,11 @@ def _close_figure(b, widgets, data, fig_idx):
                 with tab.children[idx]:
                     display(data['figs'][_fig_idx].canvas)
 
-        if n_tabs == 0:
-            widgets['figs_output'].clear_output()
-            with widgets['figs_output']:
-                display(Label(_fig_placeholder))
+            # If all children have been deleted display the placeholder
+            if n_tabs == 0:
+                widgets['figs_output'].clear_output()
+                with widgets['figs_output']:
+                    display(Label(_fig_placeholder))
 
 
 def _add_axes_controls(widgets, data, fig, axd):

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -101,9 +101,9 @@ def plot_type_coupled_change(new_plot_type, target_data_selection):
 
 def unlink_relink(attribute: str):
     """
-    Wrapper function to unlink widgets to perform edits and re-link them on completion.
-    Used as a decorator on class methods. The class must have an attribute containing an
-    ipywidgets/traitlets link object.
+    Wrapper function to unlink widgets to perform edits and re-link them on
+    completion. Used as a decorator on class methods. The class must have an
+    attribute containing an ipywidgets/traitlets link object.
 
     Parameters
     ----------
@@ -600,7 +600,8 @@ def _add_figure(b, widgets, data, scale=0.95, dpi=96):
         with widgets['figs_output']:
             display(widgets['figs_tabs'])
 
-    widgets['figs_tabs'].children = [s for s in widgets['figs_tabs'].children] + [fig_outputs]
+    widgets['figs_tabs'].children = \
+        [s for s in widgets['figs_tabs'].children] + [fig_outputs]
     widgets['figs_tabs'].set_title(n_tabs, _idx2figname(fig_idx))
 
     with fig_outputs:

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -565,8 +565,7 @@ def _add_figure(b, widgets, data, scale=0.95, dpi=96):
         with widgets['figs_output']:
             display(widgets['figs_tabs'])
 
-    widgets['figs_tabs'].children = widgets['figs_tabs'].children + (
-        fig_outputs, )
+    widgets['figs_tabs'].children = [s for s in widgets['figs_tabs'].children] + [fig_outputs]
     widgets['figs_tabs'].set_title(n_tabs, _idx2figname(fig_idx))
 
     with fig_outputs:

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -438,8 +438,7 @@ class HNNGUI:
             'Layer 2/3 Pyramidal', 'Layer 5 Pyramidal', 'Layer 2 Basket',
             'Layer 5 Basket')
         cell_connectivity = Accordion(children=connectivity_boxes)
-        for idx, connectivity_name in enumerate(connectivity_names):
-            cell_connectivity.set_title(idx, connectivity_name)
+        cell_connectivity.titles = [s for s in connectivity_names]
 
         drive_selections = VBox([
             self.add_drive_button, self.widget_drive_type_selection,

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1186,9 +1186,8 @@ def on_upload_params_change(change, params, tstop, dt, log_out, drive_boxes,
                       layout)
     else:
         raise ValueError
-
-    change['owner'].set_trait('_counter', 0)
-    change['owner'].set_trait('value', {})
+    # Resets file counter to 0
+    change['owner'].set_trait('value', ([]))
 
 
 def _init_network_from_widgets(params, dt, tstop, single_simulation_data,

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -615,15 +615,14 @@ class HNNGUI:
         self.load_drives_button.set_trait('value', uploaded_value)
 
     def _simulate_left_tab_click(self, tab_title):
-        tab_index = None
+        # Get left tab group object
         left_tab = self.app_layout.left_sidebar.children[0].children[0]
-        for idx in left_tab._titles.keys():
-            if tab_title == left_tab._titles[idx]:
-                tab_index = int(idx)
-                break
-        if tab_index is None:
-            raise ValueError("Incorrect tab title")
-        left_tab.selected_index = tab_index
+        # Check that the title is in the tab group
+        if tab_title in left_tab.titles:
+            # Simulate the user clicking on the tab
+            left_tab.selected_index = left_tab.titles.index(tab_title)
+        else:
+            raise ValueError("Tab title does not exist.")
 
     def _simulate_make_figure(self,):
         self._simulate_left_tab_click("Visualization")

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -448,24 +448,17 @@ def test_unlink_relink_widget():
             self.add_child(to_add)
 
     # Check that widgets are linked.
-    gui = MiniViz()
-    error = False
-    try:
-        gui.add_child(2)
-    except traitlets.TraitError:
-        error = True
     # Error from tab groups momentarily having a different number of children
-    assert error
+    gui = MiniViz()
+    with pytest.raises(traitlets.TraitError, match='.*index out of bounds.*'):
+        gui.add_child(2)
 
     # Check decorator unlinks and is able to make a change
     gui = MiniViz()
-    error1 = False
-    try:
-        gui.add_child_decorated(2)
-    except traitlets.TraitError:
-        error1 = True
-    assert not error1
+    gui.add_child_decorated(2)
+    assert len(gui.tab_group_1.children) == 2
     assert gui.tab_group_1.selected_index == 1
+    assert len(gui.tab_group_2.children) == 2
     assert gui.tab_group_2.selected_index == 1
 
     # Check if the widgets are relinked, the selected index should be synced

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -3,14 +3,18 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+import traitlets
+
 from hnn_core import Dipole, Network, Params
 from hnn_core.gui import HNNGUI
-from hnn_core.gui._viz_manager import _idx2figname, _no_overlay_plot_types
+from hnn_core.gui._viz_manager import _idx2figname, _no_overlay_plot_types, \
+    unlink_relink
 from hnn_core.gui.gui import _init_network_from_widgets
 from hnn_core.network import pick_connection
 from hnn_core.network_models import jones_2009_model
 from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
 from IPython.display import IFrame
+from ipywidgets import Tab, Text, link
 
 matplotlib.use('agg')
 
@@ -413,3 +417,57 @@ def test_gui_adaptive_spectrogram():
                 for attr in dir(gui.viz_manager.figs[figid])]) is False
     assert len(gui.viz_manager.figs[1].axes) == 2
     plt.close('all')
+
+
+def test_unlink_relink_widget():
+    """Tests the unlinking and relinking of widgets decorator."""
+
+    # Create a basic version of the VizManager class
+    class MiniViz:
+        def __init__(self):
+            self.tab_group_1 = Tab()
+            self.tab_group_2 = Tab()
+            self.tab_link = link(
+                (self.tab_group_1, 'selected_index'),
+                (self.tab_group_2, 'selected_index'),
+            )
+
+        def add_child(self, to_add=1):
+            n_tabs = len(self.tab_group_2.children) + to_add
+            # Add figure tab and select latest tab
+            self.tab_group_1.children = \
+                [Text(f'Test{s}') for s in np.arange(n_tabs)]
+            self.tab_group_1.selected_index = n_tabs - 1
+
+            self.tab_group_2.children = \
+                [Text(f'Test{s}') for s in np.arange(n_tabs)]
+            self.tab_group_2.selected_index = n_tabs - 1
+
+        @unlink_relink(attribute='tab_link')
+        def add_child_decorated(self, to_add):
+            self.add_child(to_add)
+
+    # Check that widgets are linked.
+    gui = MiniViz()
+    error = False
+    try:
+        gui.add_child(2)
+    except traitlets.TraitError:
+        error = True
+    # Error from tab groups momentarily having a different number of children
+    assert error
+
+    # Check decorator unlinks and is able to make a change
+    gui = MiniViz()
+    error1 = False
+    try:
+        gui.add_child_decorated(2)
+    except traitlets.TraitError:
+        error1 = True
+    assert not error1
+    assert gui.tab_group_1.selected_index == 1
+    assert gui.tab_group_2.selected_index == 1
+
+    # Check if the widgets are relinked, the selected index should be synced
+    gui.tab_group_1.selected_index = 0
+    assert gui.tab_group_2.selected_index == 0

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -7,8 +7,8 @@ import traitlets
 
 from hnn_core import Dipole, Network, Params
 from hnn_core.gui import HNNGUI
-from hnn_core.gui._viz_manager import _idx2figname, _no_overlay_plot_types, \
-    unlink_relink
+from hnn_core.gui._viz_manager import (_idx2figname, _no_overlay_plot_types,
+                                       unlink_relink)
 from hnn_core.gui.gui import _init_network_from_widgets
 from hnn_core.network import pick_connection
 from hnn_core.network_models import jones_2009_model
@@ -434,7 +434,7 @@ def test_unlink_relink_widget():
 
         def add_child(self, to_add=1):
             n_tabs = len(self.tab_group_2.children) + to_add
-            # Add figure tab and select latest tab
+            # Add tab and select latest tab
             self.tab_group_1.children = \
                 [Text(f'Test{s}') for s in np.arange(n_tabs)]
             self.tab_group_1.selected_index = n_tabs - 1

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,18 @@ class build_py_mod(build_py):
 
 
 if __name__ == "__main__":
+    extras = {
+              'gui': ['ipywidgets>=8.0.0', 'ipykernel', 'voila', 'ipympl',
+                      ],
+              'opt': ['scikit-learn'],
+              'test': ['flake8', 'pytest', 'pytest-cov'],
+              'docs': ['psutil', 'mne', 'sphinx', 'nbsphinx', 'sphinx-gallery',
+                       'sphinx_bootstrap_theme', 'sphinx-copybutton', 'pillow',
+                       'numpydoc', 'joblib'
+                       ]
+          }
+    extras['dev'] = extras['test'] + extras['docs'] + extras['gui']
+
     setup(name=DISTNAME,
           maintainer=MAINTAINER,
           maintainer_email=MAINTAINER_EMAIL,
@@ -105,10 +117,7 @@ if __name__ == "__main__":
               'scipy',
               'h5io'
           ],
-          extras_require={
-              'gui': ['ipywidgets>=8.0.0', 'ipykernel'],
-              'opt': ['scikit-learn']
-          },
+          extras_require=extras,
           python_requires='>=3.8',
           packages=find_packages(),
           package_data={'hnn_core': [

--- a/setup.py
+++ b/setup.py
@@ -76,18 +76,6 @@ class build_py_mod(build_py):
 
 
 if __name__ == "__main__":
-    extras = {
-              'gui': ['ipywidgets>=8.0.0', 'ipykernel', 'voila', 'ipympl',
-                      ],
-              'opt': ['scikit-learn'],
-              'test': ['flake8', 'pytest', 'pytest-cov'],
-              'docs': ['psutil', 'mne', 'sphinx', 'nbsphinx', 'sphinx-gallery',
-                       'sphinx_bootstrap_theme', 'sphinx-copybutton', 'pillow',
-                       'numpydoc', 'joblib'
-                       ]
-          }
-    extras['dev'] = extras['test'] + extras['docs'] + extras['gui']
-
     setup(name=DISTNAME,
           maintainer=MAINTAINER,
           maintainer_email=MAINTAINER_EMAIL,
@@ -117,7 +105,10 @@ if __name__ == "__main__":
               'scipy',
               'h5io'
           ],
-          extras_require=extras,
+          extras_require={
+              'gui': ['ipywidgets>=8.0.0', 'ipykernel', 'ipympl', 'voila'],
+              'opt': ['scikit-learn']
+          },
           python_requires='>=3.8',
           packages=find_packages(),
           package_data={'hnn_core': [

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
               'h5io'
           ],
           extras_require={
-              'gui': ['ipywidgets>=8.0.0'],
+              'gui': ['ipywidgets>=8.0.0', 'ipykernel'],
               'opt': ['scikit-learn']
           },
           python_requires='>=3.8',

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
               'h5io'
           ],
           extras_require={
-              'gui': ['ipywidgets >=8.1.1'],
+              'gui': ['ipywidgets>=8.0.0'],
               'opt': ['scikit-learn']
           },
           python_requires='>=3.8',

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
               'h5io'
           ],
           extras_require={
-              'gui': ['ipywidgets <=7.7.1', 'ipympl<0.9', 'voila<=0.3.6'],
+              'gui': ['ipywidgets >=8.1.1'],
               'opt': ['scikit-learn']
           },
           python_requires='>=3.8',


### PR DESCRIPTION
**Completed**
* Removed pinning of older versions ipywidgets, ipympl, and voila. Set a requirement for ipywidgets >=8.1.1, because of breaking changes to v8.x. 
    * Updating to the latest versions resolved js errors that were previously preventing the GUI from rendering, which was the impetus for pinning versions #585 #586. 
* Addressed some [ipywidgets 8.x API changes](https://ipywidgets.readthedocs.io/en/latest/user_migration_guides.html) that prevented GUI composition, running simulations, and plotting. 
    * Implemented new methods of assigning titles and children to collection widgets (Tabs and Accordion). ~~Though only to the scope of what was causes crashes with what I was testing (composition and simulation launch).~~ There could be more areas were it should be updated. 
    * Linking of Tab collections was causinging an issue with new ipywidgets validation logic. Solution was to write a decorator function that unlinks linked Tab collections (Figure tabs and Fig-Config tab groups) before editing functions and re-links them upon completion. 
        * Added test for decorator.
    * Updated to new `FileUpload` widget API
        * This involved restructuring the input structure to the widget. It now takes a list of dicts instead of a single dict.
        * Access to the file upload dict items was updated.
        * For the file upload pytests the simulated file dict also had to be restructured to the new dictionary structure FileUpload expects.
        * Removed setting of the deprecated `_counter` trait of `FileUpload`.
    * Added `ipykernel` as a GUI dependency. ipywidgets removed its dependency of ipykernel to allow more flexibility to use other kernels. This might only need to be a test dependency? 


**Remarks**
* ~~I've only tested the using the GUI to launch the default simulation and adding some of the plots. Will need to test/search for more updates to the ipywidgets 8.x API. I suspect features like file-upload also need to be updated.~~

**Questions**
* The `FileUpload` button widget has a counter displayed showing the number of files uploaded. This counter cannot be disabled. (https://github.com/jupyter-widgets/ipywidgets/issues/2904) For the network connectivity and drives upload button, the current code always keeps this number at 0. Do we want to keep it that way or should it counter increment to 1 if the user loads a param file? 
    * ~~Personally I don't think the counter is great for our application and wish it could be removed... I think the user does need to have some confirmation that a file has been loaded though. An informational display of what files have been loaded for network and drive would be nice. And this could even show that a default file has been loaded at the start.~~ We decided to keep the counter always at 0. 
    * On a slightly related note, this widget is able to accept multiple files. Would this be useful for loading multiple data files? That could be a feature we can add in a future PR.


**To do:**
- [x] Check file upload feature
- [x] Test for other functionality that may error
- [x] Add unit test for decorator