### PR TITLE
[ENH] Dev extras

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,15 +30,13 @@ jobs:
                   conda create -n testenv --yes pip python=3.8
                   source activate testenv
                   conda install --yes scipy numpy matplotlib
-                  pip install mne pooch tqdm psutil mpi4py joblib nibabel
+                  pip install pooch tqdm mpi4py
 
           - run:
               name: Setup doc building stuff
               command: |
                   source ~/miniconda/bin/activate testenv
                   sudo apt-get install pandoc
-                  pip install sphinx numpydoc sphinx_bootstrap_theme sphinx-copybutton pillow nbsphinx
-                  pip install --user -U https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master
 
           - run:
               name: Setup Neuron
@@ -51,7 +49,7 @@ jobs:
               command: |
                   source ~/miniconda/bin/activate testenv
                   pip install -U pip setuptools virtualenv
-                  pip install '.[gui]'
+                  pip install '.[parallel, docs, gui]'
 
           - restore_cache:
               keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
                   conda create -n testenv --yes pip python=3.8
                   source activate testenv
                   conda install --yes scipy numpy matplotlib
-                  pip install pooch tqdm mpi4py
+                  pip install mpi4py
 
           - run:
               name: Setup doc building stuff

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -27,8 +27,8 @@ jobs:
           sudo apt-get install pandoc
           python -m pip install --upgrade pip
           pip install numpy matplotlib scipy NEURON
-          pip install sphinx-gallery sphinx sphinx_bootstrap_theme sphinx-copybutton numpydoc pillow nbsphinx
-          pip install '.[gui]'
+          pip install '.[gui, docs]'
+
       - name: Linkcheck
         shell: bash -el {0}
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -33,13 +33,11 @@ jobs:
         shell: bash -el {0}
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-cov
-          pip install psutil joblib
-          conda install --yes -c conda-forge mpi4py openmpi
+          conda install --yes -c conda-forge openmpi
       - name: Install HNN-core
         shell: bash -el {0}
         run: |
-          pip install --verbose '.[gui,opt]'
+          pip install --verbose '.[opt, parallel, test, gui]'
       - name: Lint with flake8
         shell: bash -el {0}
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash -el {0}
         run: |
           python -m pip install --upgrade pip
-          conda install --yes -c conda-forge openmpi
+          conda install --yes -c conda-forge mpi4py openmpi
       - name: Install HNN-core
         shell: bash -el {0}
         run: |

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -38,9 +38,7 @@ jobs:
         shell: cmd
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-cov
-          pip install psutil joblib
-          pip install --verbose .[gui,opt]
+          pip install --verbose .[opt,parallel,test,gui]
       - name: Test with pytest
         shell: cmd
         run: |

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -38,7 +38,7 @@ jobs:
         shell: cmd
         run: |
           python -m pip install --upgrade pip
-          pip install --verbose .[opt, parallel, test, gui]
+          pip install --verbose .[opt,parallel,test,gui]
       - name: Test with pytest
         shell: cmd
         run: |

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -38,7 +38,7 @@ jobs:
         shell: cmd
         run: |
           python -m pip install --upgrade pip
-          pip install --verbose .[opt,parallel,test,gui]
+          pip install --verbose .[opt, parallel, test, gui]
       - name: Test with pytest
         shell: cmd
         run: |

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -115,8 +115,12 @@ repository and use pip with the editable (``-e``) flag::
 
     $ git clone https://github.com/jonescompneurolab/hnn-core
     $ cd hnn-core
-    $ pip install -e '.[gui]'
+    $ pip install -e '.[dev]'
     $ python setup.py build_mod
+
+The ``pip install -e '.[dev]'`` step will install all extra packages used by
+developers to access all features and to perform testing and building of
+documentation.
 
 The last step builds ``mod`` files which specifies the dynamics of specific
 cellular mechanisms. These are converted to C, and hence require a compilation
@@ -135,10 +139,6 @@ your change has been made. We recommend developers to run tests locally
 on their computers after making changes.
 
 We use the ``pytest`` testing framework.
-
-Install the following python packages::
-
-    $ pip install flake8 pytest pytest-cov
 
 To run the tests simply type into your terminal::
 
@@ -166,19 +166,12 @@ pull requests.
 Building the documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The documentation can be built using sphinx. For that, please additionally
-install the following::
-
-    $ pip install matplotlib sphinx numpydoc sphinx-gallery sphinx_bootstrap_theme sphinx-copybutton pillow joblib psutil nbsphinx
+The documentation can be built using sphinx.
 
 You can build the documentation locally using the command::
 
 $ cd doc/
 $ make html
-
-While MNE is not needed to install hnn-core, as a developer you will need to
-install it to run all the examples successfully. Please find the installation
-instructions on the `MNE website <https://mne.tools/stable/install/index.html>`_.
 
 If you want to build the documentation locally without running all the examples,
 use the command::

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,12 @@ Changelog
 - Update minimum supported version of Python to 3.8, by `Ryan Thorpe`_ in
   :gh:`678`.
 
+- Update GUI to use ipywidgets v8.0.0+ API, by `George Dang`_ in
+  :gh:`696`.
+
+- Add dependency groups to setup.py and update CI workflows to reference
+  dependency groups, by `George Dang`_ in :gh:`703`.
+
 Bug
 ~~~
 - Fix inconsistent connection mapping from drive gids to cell gids, by
@@ -28,6 +34,9 @@ Bug
 
 - Objective function called by :func:`~hnn_core/optimization/optimize_evoked`
   now returns a scalar instead of tuple, by `Ryan Thorpe`_ in :gh:`670`.
+
+- Fix GUI plotting bug due to deprecation of matplotlib color cycling method,
+  by `George Dang`_ in :gh:`695`.
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -449,3 +449,4 @@ People who contributed to this release (in alphabetical order):
 .. _Stephanie R. Jones: https://github.com/stephanie-r-jones
 .. _Steven Brandt: https://github.com/spbrandt
 .. _Kaisu Lankinen: https://github.com/klankinen
+.. _George Dang: https://github.com/gtdang

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,20 @@ class build_py_mod(build_py):
 
 
 if __name__ == "__main__":
+    extras = {
+        'opt': ['scikit-learn'],
+        'parallel': ['joblib', 'psutil', 'mpi4py'],
+        'test': ['flake8', 'pytest', 'pytest-cov', ],
+        'docs': ['mne', 'sphinx', 'nbsphinx', 'sphinx-gallery',
+                 'sphinx_bootstrap_theme', 'sphinx-copybutton', 'pillow',
+                 'numpydoc',
+                 ],
+        'gui': ['ipywidgets>=8.0.0', 'ipykernel', 'ipympl', 'voila', ],
+    }
+    extras['dev'] = (extras['opt'] + extras['parallel'] + extras['test'] +
+                     extras['docs'] + extras['gui']
+                     )
+
     setup(name=DISTNAME,
           maintainer=MAINTAINER,
           maintainer_email=MAINTAINER_EMAIL,
@@ -105,10 +119,7 @@ if __name__ == "__main__":
               'scipy',
               'h5io'
           ],
-          extras_require={
-              'gui': ['ipywidgets>=8.0.0', 'ipykernel', 'ipympl', 'voila'],
-              'opt': ['scikit-learn']
-          },
+          extras_require=extras,
           python_requires='>=3.8',
           packages=find_packages(),
           package_data={'hnn_core': [

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ if __name__ == "__main__":
                      extras['docs'] + extras['gui']
                      )
 
+
     setup(name=DISTNAME,
           maintainer=MAINTAINER,
           maintainer_email=MAINTAINER_EMAIL,

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         'opt': ['scikit-learn'],
         'parallel': ['joblib', 'psutil'],
         'test': ['flake8', 'pytest', 'pytest-cov', ],
-        'docs': ['mne', 'sphinx', 'nbsphinx', 'sphinx-gallery',
+        'docs': ['mne', 'nibabel', 'sphinx', 'nbsphinx', 'sphinx-gallery',
                  'sphinx_bootstrap_theme', 'sphinx-copybutton', 'pillow',
                  'numpydoc',
                  ],

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,10 @@ if __name__ == "__main__":
         'opt': ['scikit-learn'],
         'parallel': ['joblib', 'psutil'],
         'test': ['flake8', 'pytest', 'pytest-cov', ],
-        'docs': ['mne', 'nibabel', 'sphinx', 'nbsphinx', 'sphinx-gallery',
-                 'sphinx_bootstrap_theme', 'sphinx-copybutton', 'pillow',
-                 'numpydoc',
+        'docs': ['mne', 'nibabel', 'pooch', 'tdqm',
+                 'sphinx', 'nbsphinx', 'sphinx-gallery',
+                 'sphinx_bootstrap_theme', 'sphinx-copybutton',
+                 'pillow', 'numpydoc',
                  ],
         'gui': ['ipywidgets>=8.0.0', 'ipykernel', 'ipympl', 'voila', ],
     }

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ class build_py_mod(build_py):
 if __name__ == "__main__":
     extras = {
         'opt': ['scikit-learn'],
-        'parallel': ['joblib', 'psutil', 'mpi4py'],
+        'parallel': ['joblib', 'psutil'],
         'test': ['flake8', 'pytest', 'pytest-cov', ],
         'docs': ['mne', 'sphinx', 'nbsphinx', 'sphinx-gallery',
                  'sphinx_bootstrap_theme', 'sphinx-copybutton', 'pillow',


### PR DESCRIPTION
This is a small PR to improve the classification & organization of extra dependencies. The key benefits to this change are:

1. Streamlines developer dependencies install 
    - Contributors only need to run `pip install -e '.[dev]'`, to get all the dependencies for joblib, GUI, test, docs generation.
2. Installation of dependencies for Github runners uses the dependencies specified by the setup file.
    - Prevents discrepancies between package versions specified in the setup file and workflow yml files 
    - We don't have to remember to change dependency specifications in multiple files

*Note:*
- The mpi4py was left out of the dependency group because it was causing issues in tests when added to the `parallel` group. So developers will still need to manually install mpi4py and openmpi as recommended in the contributor guide.

To do: 
- [ ]  Test dev install with a fresh install on Mac and Windows 

