### PR TITLE
[MRG] ENH: Add ability to define cell grid dimensions

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,6 +27,9 @@ Changelog
 - Add dependency groups to setup.py and update CI workflows to reference
   dependency groups, by `George Dang`_ in :gh:`703`.
 
+- Add ability to specify number of cells in :class:`~hnn_core.Network`,
+  by `Nick Tolley`_ in :gh:`705`
+
 Bug
 ~~~
 - Fix inconsistent connection mapping from drive gids to cell gids, by

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -288,9 +288,8 @@ class Network(object):
     legacy_mode : bool
         Set to True by default to enable matching HNN GUI output when drives
         are added suitably. Will be deprecated in a future release.
-    mesh_shape : tuple of int
+    mesh_shape : tuple of int (default: (10, 10))
         Defines the (n_x, n_y) shape of the grid of pyramidal cells.
-        Default: None (use values from params which is a 10x10 grid).
 
 
     Attributes
@@ -342,7 +341,7 @@ class Network(object):
     """
 
     def __init__(self, params, add_drives_from_params=False,
-                 legacy_mode=False, mesh_shape=None):
+                 legacy_mode=False, mesh_shape=(10, 10)):
         # Save the parameters used to create the Network
         _validate_type(params, dict, 'params')
         self._params = params
@@ -393,20 +392,17 @@ class Network(object):
         self.pos_dict = dict()
         self.cell_types = dict()
 
-        if mesh_shape is None:
-            self._N_pyr_x = self._params['N_pyr_x']
-            self._N_pyr_y = self._params['N_pyr_y']
-        else:
-            _validate_type(mesh_shape, tuple, 'mesh_shape')
-            _validate_type(mesh_shape[0], int, 'mesh_shape[0]')
-            _validate_type(mesh_shape[1], int, 'mesh_shape[1]')
+        # set the mesh shape
+        _validate_type(mesh_shape, tuple, 'mesh_shape')
+        _validate_type(mesh_shape[0], int, 'mesh_shape[0]')
+        _validate_type(mesh_shape[1], int, 'mesh_shape[1]')
 
-            if mesh_shape[0] < 1 or mesh_shape[1] < 1:
-                raise ValueError('mesh_shape must be a tuple of positive '
-                                 f'integers, got: {mesh_shape}')
+        if mesh_shape[0] < 1 or mesh_shape[1] < 1:
+            raise ValueError('mesh_shape must be a tuple of positive '
+                             f'integers, got: {mesh_shape}')
 
-            self._N_pyr_x = mesh_shape[0]
-            self._N_pyr_y = mesh_shape[1]
+        self._N_pyr_x = mesh_shape[0]
+        self._N_pyr_y = mesh_shape[1]
 
         self._inplane_distance = 1.0  # XXX hard-coded default
         self._layer_separation = 1307.4  # XXX hard-coded default

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -55,7 +55,7 @@ def _create_cell_coords(n_pyr_x, n_pyr_y, zdiff, inplane_distance):
     Notes
     -----
     Common positions are all located at origin.
-    Sort of a hack bc of redundancy
+    Sort of a hack because of redundancy.
     """
     pos_dict = dict()
 
@@ -288,6 +288,10 @@ class Network(object):
     legacy_mode : bool
         Set to True by default to enable matching HNN GUI output when drives
         are added suitably. Will be deprecated in a future release.
+    mesh_shape : tuple of int
+        Defines the (n_x, n_y) shape of the grid of pyramidal cells.
+        Default: None (use values from params which is a 10x10 grid).
+
 
     Attributes
     ----------
@@ -338,7 +342,7 @@ class Network(object):
     """
 
     def __init__(self, params, add_drives_from_params=False,
-                 legacy_mode=False):
+                 legacy_mode=False, mesh_shape=None):
         # Save the parameters used to create the Network
         _validate_type(params, dict, 'params')
         self._params = params
@@ -389,8 +393,21 @@ class Network(object):
         self.pos_dict = dict()
         self.cell_types = dict()
 
-        self._N_pyr_x = self._params['N_pyr_x']
-        self._N_pyr_y = self._params['N_pyr_y']
+        if mesh_shape is None:
+            self._N_pyr_x = self._params['N_pyr_x']
+            self._N_pyr_y = self._params['N_pyr_y']
+        else:
+            _validate_type(mesh_shape, tuple, 'mesh_shape')
+            _validate_type(mesh_shape[0], int, 'mesh_shape[0]')
+            _validate_type(mesh_shape[1], int, 'mesh_shape[1]')
+
+            if mesh_shape[0] < 1 or mesh_shape[1] < 1:
+                raise ValueError('mesh_shape must be a tuple of positive '
+                                 f'integers, got: {mesh_shape}')
+
+            self._N_pyr_x = mesh_shape[0]
+            self._N_pyr_y = mesh_shape[1]
+
         self._inplane_distance = 1.0  # XXX hard-coded default
         self._layer_separation = 1307.4  # XXX hard-coded default
         self.set_cell_positions(inplane_distance=self._inplane_distance,

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -12,7 +12,7 @@ from .externals.mne import _validate_type
 
 
 def jones_2009_model(params=None, add_drives_from_params=False,
-                     legacy_mode=False):
+                     legacy_mode=False, mesh_shape=None):
     """Instantiate the network model described in
     Jones et al. J. of Neurophys. 2009 [1]_
 
@@ -29,6 +29,9 @@ def jones_2009_model(params=None, add_drives_from_params=False,
     legacy_mode : bool
         Set to False by default. Enables matching HNN GUI output when drives
         are added suitably. Will be deprecated in a future release.
+    mesh_shape : tuple of int
+        Defines the (n_x, n_y) shape of the grid of pyramidal cells.
+        Default: None (use values from params which is a 10x10 grid).
 
     Returns
     -------
@@ -59,7 +62,7 @@ def jones_2009_model(params=None, add_drives_from_params=False,
         params = read_params(params)
 
     net = Network(params, add_drives_from_params=add_drives_from_params,
-                  legacy_mode=legacy_mode)
+                  legacy_mode=legacy_mode, mesh_shape=mesh_shape)
 
     delay = net.delay
 
@@ -174,7 +177,7 @@ def jones_2009_model(params=None, add_drives_from_params=False,
 
 
 def law_2021_model(params=None, add_drives_from_params=False,
-                   legacy_mode=False):
+                   legacy_mode=False, mesh_shape=None):
     """Instantiate the expansion of Jones 2009 model to study beta
     modulated ERPs as described in
     Law et al. Cereb. Cortex 2021 [1]_
@@ -208,7 +211,8 @@ def law_2021_model(params=None, add_drives_from_params=False,
            Perception." Cerebral Cortex, 32, 668–688 (2022).
     """
 
-    net = jones_2009_model(params, add_drives_from_params, legacy_mode)
+    net = jones_2009_model(params, add_drives_from_params, legacy_mode,
+                           mesh_shape=mesh_shape)
 
     # Update biophysics (increase gabab duration of inhibition)
     net.cell_types['L2_pyramidal'].synapses['gabab']['tau1'] = 45.0
@@ -260,7 +264,7 @@ def law_2021_model(params=None, add_drives_from_params=False,
 # Remove params argument after updating examples
 # (only relevant for Jones 2009 model)
 def calcium_model(params=None, add_drives_from_params=False,
-                  legacy_mode=False):
+                  legacy_mode=False, mesh_shape=None):
     """Instantiate the Jones 2009 model with improved calcium dynamics in
     L5 pyramidal neurons. For more details on changes to calcium dynamics
     see Kohl et al. Brain Topragr 2022 [1]_
@@ -294,7 +298,8 @@ def calcium_model(params=None, add_drives_from_params=False,
     if params is None:
         params = read_params(params_fname)
 
-    net = jones_2009_model(params, add_drives_from_params, legacy_mode)
+    net = jones_2009_model(params, add_drives_from_params, legacy_mode,
+                           mesh_shape=mesh_shape)
 
     # Replace L5 pyramidal cell template with updated calcium
     cell_name = 'L5_pyramidal'

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -12,7 +12,7 @@ from .externals.mne import _validate_type
 
 
 def jones_2009_model(params=None, add_drives_from_params=False,
-                     legacy_mode=False, mesh_shape=None):
+                     legacy_mode=False, mesh_shape=(10, 10)):
     """Instantiate the network model described in
     Jones et al. J. of Neurophys. 2009 [1]_
 
@@ -29,9 +29,8 @@ def jones_2009_model(params=None, add_drives_from_params=False,
     legacy_mode : bool
         Set to False by default. Enables matching HNN GUI output when drives
         are added suitably. Will be deprecated in a future release.
-    mesh_shape : tuple of int
+    mesh_shape : tuple of int (default: (10, 10))
         Defines the (n_x, n_y) shape of the grid of pyramidal cells.
-        Default: None (use values from params which is a 10x10 grid).
 
     Returns
     -------
@@ -177,7 +176,7 @@ def jones_2009_model(params=None, add_drives_from_params=False,
 
 
 def law_2021_model(params=None, add_drives_from_params=False,
-                   legacy_mode=False, mesh_shape=None):
+                   legacy_mode=False, mesh_shape=(10, 10)):
     """Instantiate the expansion of Jones 2009 model to study beta
     modulated ERPs as described in
     Law et al. Cereb. Cortex 2021 [1]_
@@ -264,7 +263,7 @@ def law_2021_model(params=None, add_drives_from_params=False,
 # Remove params argument after updating examples
 # (only relevant for Jones 2009 model)
 def calcium_model(params=None, add_drives_from_params=False,
-                  legacy_mode=False, mesh_shape=None):
+                  legacy_mode=False, mesh_shape=(10, 10)):
     """Instantiate the Jones 2009 model with improved calcium dynamics in
     L5 pyramidal neurons. For more details on changes to calcium dynamics
     see Kohl et al. Brain Topragr 2022 [1]_

--- a/hnn_core/tests/conftest.py
+++ b/hnn_core/tests/conftest.py
@@ -86,17 +86,18 @@ def run_hnn_core_fixture():
         tstop = 170.
         legacy_mode = True
         if reduced:
-            params.update({'N_pyr_x': 3,
-                           'N_pyr_y': 3,
-                           't_evprox_1': 5,
+            mesh_shape = (3, 3)
+            params.update({'t_evprox_1': 5,
                            't_evdist_1': 10,
                            't_evprox_2': 20,
                            'N_trials': 2})
             tstop = 40.
             legacy_mode = False
+        else:
+            mesh_shape = (10, 10)
         # Legacy mode necessary for exact dipole comparison test
         net = jones_2009_model(params, add_drives_from_params=True,
-                               legacy_mode=legacy_mode)
+                               legacy_mode=legacy_mode, mesh_shape=mesh_shape)
         if electrode_array is not None:
             for name, positions in electrode_array.items():
                 net.add_electrode_array(name, positions)

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -173,13 +173,12 @@ def test_dipole_simulation():
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
-    params.update({'N_pyr_x': 3,
-                   'N_pyr_y': 3,
-                   'dipole_smooth_win': 5,
+    params.update({'dipole_smooth_win': 5,
                    't_evprox_1': 5,
                    't_evdist_1': 10,
                    't_evprox_2': 20})
-    net = jones_2009_model(params, add_drives_from_params=True)
+    net = jones_2009_model(params, add_drives_from_params=True,
+                           mesh_shape=(3, 3))
     with pytest.raises(ValueError, match="Invalid number of simulations: 0"):
         simulate_dipole(net, tstop=25., n_trials=0)
     with pytest.raises(ValueError, match="Invalid value for the"):

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -207,11 +207,10 @@ def test_rec_array_calculation():
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
-    params.update({'N_pyr_x': 3,
-                   'N_pyr_y': 3,
-                   't_evprox_1': 7,
+    params.update({'t_evprox_1': 7,
                    't_evdist_1': 17})
-    net = jones_2009_model(params, add_drives_from_params=True)
+    net = jones_2009_model(params, mesh_shape=(3, 3),
+                           add_drives_from_params=True)
 
     # one electrode inside, one above the active elements of the network,
     # and two more to allow calculation of CSD (2nd spatial derivative)

--- a/hnn_core/tests/test_general_optimization.py
+++ b/hnn_core/tests/test_general_optimization.py
@@ -25,9 +25,7 @@ def test_optimize_evoked(solver):
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
 
-    params.update({'N_pyr_x': 3,
-                   'N_pyr_y': 3})
-    net_orig = jones_2009_model(params)
+    net_orig = jones_2009_model(params, mesh_shape=(3, 3))
 
     mu_orig = 2.
     weights_ampa = {'L2_basket': 0.5,

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -113,13 +113,12 @@ def test_child_run():
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
     params_reduced = params.copy()
-    params_reduced.update({'N_pyr_x': 3,
-                           'N_pyr_y': 3,
-                           't_evprox_1': 5,
+    params_reduced.update({'t_evprox_1': 5,
                            't_evdist_1': 10,
                            't_evprox_2': 20})
     tstop, n_trials = 25, 2
-    net_reduced = jones_2009_model(params_reduced, add_drives_from_params=True)
+    net_reduced = jones_2009_model(params_reduced, add_drives_from_params=True,
+                                   mesh_shape=(3, 3))
     net_reduced._instantiate_drives(tstop=tstop, n_trials=n_trials)
 
     with MPISimulation(skip_mpi_import=True) as mpi_sim:

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -921,11 +921,18 @@ def test_network_mesh():
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
 
+    # Test custom mesh_shape
     mesh_shape = (2, 3)
     net = Network(params, mesh_shape=mesh_shape)
     assert net._N_pyr_x == mesh_shape[0]
     assert net._N_pyr_y == mesh_shape[1]
     assert net.gid_ranges['L2_basket'] == range(0, 3)
+
+    # Test default mesh_shape loaded
+    net = Network(params)
+    assert net._N_pyr_x == 10
+    assert net._N_pyr_y == 10
+    assert net.gid_ranges['L2_basket'] == range(0, 35)
 
     with pytest.raises(ValueError, match='mesh_shape must be'):
         net = Network(params, mesh_shape=(-2, 3))

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -911,3 +911,32 @@ def test_tonic_biases():
     assert net.external_biases['tonic']['L2_pyramidal']['t0'] == 0
     with pytest.raises(ValueError, match=r'Tonic bias already defined for.*$'):
         net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0)
+
+
+def test_network_mesh():
+    """Test mesh for defining cell positions biases."""
+    hnn_core_root = op.dirname(hnn_core.__file__)
+
+    # default params
+    params_fname = op.join(hnn_core_root, 'param', 'default.json')
+    params = read_params(params_fname)
+
+    mesh_shape = (2, 3)
+    net = Network(params, mesh_shape=mesh_shape)
+    assert net._N_pyr_x == mesh_shape[0]
+    assert net._N_pyr_y == mesh_shape[1]
+    assert net.gid_ranges['L2_basket'] == range(0, 3)
+
+    with pytest.raises(ValueError, match='mesh_shape must be'):
+        net = Network(params, mesh_shape=(-2, 3))
+
+    with pytest.raises(TypeError, match='mesh_shape\\[0\\] must be'):
+        net = Network(params, mesh_shape=(2.0, 3))
+
+    with pytest.raises(TypeError, match='mesh_shape must be'):
+        net = Network(params, mesh_shape='abc')
+
+    # Smoke test for all models
+    _ = jones_2009_model(mesh_shape=mesh_shape)
+    _ = calcium_model(mesh_shape=mesh_shape)
+    _ = law_2021_model(mesh_shape=mesh_shape)

--- a/hnn_core/tests/test_optimize_evoked.py
+++ b/hnn_core/tests/test_optimize_evoked.py
@@ -89,25 +89,23 @@ def test_optimize_evoked():
 
     # simulate a dipole to establish ground-truth drive parameters
     mu_orig = 6.
-    params.update({'N_pyr_x': 3,
-                   'N_pyr_y': 3,
-                   't_evprox_1': mu_orig,
+    params.update({'t_evprox_1': mu_orig,
                    'sigma_t_evprox_1': 2.,
                    't_evdist_1': mu_orig + 2,
                    'sigma_t_evdist_1': 2.})
-    net_orig = jones_2009_model(params, add_drives_from_params=True)
+    net_orig = jones_2009_model(params, add_drives_from_params=True,
+                                mesh_shape=(3, 3))
     del net_orig.external_drives['evprox2']
     dpl_orig = simulate_dipole(net_orig, tstop=tstop, n_trials=n_trials)[0]
 
     # simulate a dipole with a time-shifted drive
     mu_offset = 4.
-    params.update({'N_pyr_x': 3,
-                   'N_pyr_y': 3,
-                   't_evprox_1': mu_offset,
+    params.update({'t_evprox_1': mu_offset,
                    'sigma_t_evprox_1': 2.,
                    't_evdist_1': mu_offset + 2,
                    'sigma_t_evdist_1': 2.})
-    net_offset = jones_2009_model(params, add_drives_from_params=True)
+    net_offset = jones_2009_model(params, add_drives_from_params=True,
+                                  mesh_shape=(3, 3))
     del net_offset.external_drives['evprox2']
     dpl_offset = simulate_dipole(net_offset, tstop=tstop, n_trials=n_trials)[0]
     # get drive params from the pre-optimization Network instance

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -184,7 +184,7 @@ class TestParallelBackends():
         # force oversubscription + hyperthreading, but make sure there are
         # always enough cells in the network
         oversubscribed_procs = cpu_count() + 1
-        n_grid_1d = np.ceil(np.sqrt(oversubscribed_procs)).astype(int)
+        n_grid_1d = int(np.ceil(np.sqrt(oversubscribed_procs)))
         params.update({'t_evprox_1': 5,
                        't_evdist_1': 10,
                        't_evprox_2': 20,

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -130,13 +130,12 @@ class TestParallelBackends():
         hnn_core_root = op.dirname(hnn_core.__file__)
         params_fname = op.join(hnn_core_root, 'param', 'default.json')
         params = read_params(params_fname)
-        params.update({'N_pyr_x': 3,
-                       'N_pyr_y': 3,
-                       't_evprox_1': 5,
+        params.update({'t_evprox_1': 5,
                        't_evdist_1': 10,
                        't_evprox_2': 20,
                        'N_trials': 2})
-        net = jones_2009_model(params, add_drives_from_params=True)
+        net = jones_2009_model(params, add_drives_from_params=True,
+                               mesh_shape=(3, 3))
 
         with MPIBackend() as backend:
             event = Event()
@@ -167,13 +166,12 @@ class TestParallelBackends():
         hnn_core_root = op.dirname(hnn_core.__file__)
         params_fname = op.join(hnn_core_root, 'param', 'default.json')
         params = read_params(params_fname)
-        params.update({'N_pyr_x': 3,
-                       'N_pyr_y': 3,
-                       't_evprox_1': 5,
+        params.update({'t_evprox_1': 5,
                        't_evdist_1': 10,
                        't_evprox_2': 20,
                        'N_trials': 2})
-        net = jones_2009_model(params, add_drives_from_params=True)
+        net = jones_2009_model(params, add_drives_from_params=True,
+                               mesh_shape=(3, 3))
 
         # try running with more procs than cells in the network (will probably
         # oversubscribe)
@@ -187,13 +185,12 @@ class TestParallelBackends():
         # always enough cells in the network
         oversubscribed_procs = cpu_count() + 1
         n_grid_1d = np.ceil(np.sqrt(oversubscribed_procs))
-        params.update({'N_pyr_x': n_grid_1d,
-                       'N_pyr_y': n_grid_1d,
-                       't_evprox_1': 5,
+        params.update({'t_evprox_1': 5,
                        't_evdist_1': 10,
                        't_evprox_2': 20,
                        'N_trials': 2})
-        net = jones_2009_model(params, add_drives_from_params=True)
+        net = jones_2009_model(params, add_drives_from_params=True,
+                               mesh_shape=(n_grid_1d, n_grid_1d))
         with MPIBackend(n_procs=oversubscribed_procs) as backend:
             assert backend.n_procs == oversubscribed_procs
             simulate_dipole(net, tstop=40)

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -184,7 +184,7 @@ class TestParallelBackends():
         # force oversubscription + hyperthreading, but make sure there are
         # always enough cells in the network
         oversubscribed_procs = cpu_count() + 1
-        n_grid_1d = np.ceil(np.sqrt(oversubscribed_procs))
+        n_grid_1d = np.ceil(np.sqrt(oversubscribed_procs)).astype(int)
         params.update({'t_evprox_1': 5,
                        't_evdist_1': 10,
                        't_evprox_2': 20,

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -31,9 +31,7 @@ def test_network_visualization():
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
-    params.update({'N_pyr_x': 3,
-                   'N_pyr_y': 3})
-    net = jones_2009_model(params)
+    net = jones_2009_model(params, mesh_shape=(3, 3))
     plot_cells(net)
     ax = net.cell_types['L2_pyramidal'].plot_morphology()
     assert len(ax.lines) == 8
@@ -105,9 +103,7 @@ def test_dipole_visualization():
     hnn_core_root = op.dirname(hnn_core.__file__)
     params_fname = op.join(hnn_core_root, 'param', 'default.json')
     params = read_params(params_fname)
-    params.update({'N_pyr_x': 3,
-                   'N_pyr_y': 3})
-    net = jones_2009_model(params)
+    net = jones_2009_model(params, mesh_shape=(3, 3))
     weights_ampa = {'L2_pyramidal': 5.4e-5, 'L5_pyramidal': 5.4e-5}
     syn_delays = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.}
 


### PR DESCRIPTION
As discussed in #704, we've realized that it is necessary to have an explicit API fro defining the size of the network object. Previously this was done in a hacky way by directly editing the `params` object. The proposed API here is 
```py
net = jones_2009_model(mesh_shape=(10, 10))
```