### PR TITLE
Renamed 'calcium model' to 'Kohl_2021'

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -30,7 +30,7 @@ Network Models (:py:mod:`hnn_core`):
 
    jones_2009_model
    law_2021_model
-   calcium_model
+   Kohl_2021
 
 Optimization (:py:mod:`hnn_core.optimization`):
 -----------------------------------------------

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -1,7 +1,7 @@
 from .dipole import simulate_dipole, read_dipole, average_dipoles, Dipole
 from .params import Params, read_params
 from .network import Network, pick_connection
-from .network_models import jones_2009_model, law_2021_model, calcium_model
+from .network_models import jones_2009_model, law_2021_model, Kohl_2021
 from .cell import Cell
 from .cell_response import CellResponse, read_spikes
 from .cells_default import pyramidal, basket

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -262,7 +262,7 @@ def law_2021_model(params=None, add_drives_from_params=False,
 
 # Remove params argument after updating examples
 # (only relevant for Jones 2009 model)
-def calcium_model(params=None, add_drives_from_params=False,
+def Kohl_2021(params=None, add_drives_from_params=False,
                   legacy_mode=False, mesh_shape=(10, 10)):
     """Instantiate the Jones 2009 model with improved calcium dynamics in
     L5 pyramidal neurons. For more details on changes to calcium dynamics

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -9,7 +9,7 @@ import pytest
 import numpy as np
 
 from hnn_core import (read_network, simulate_dipole, read_params,
-                      jones_2009_model, calcium_model,
+                      jones_2009_model, Kohl_2021,
                       )
 
 from hnn_core.hnn_io import (_cell_response_to_dict, _rec_array_to_dict,
@@ -53,7 +53,7 @@ def jones_2009_network(params):
 @pytest.fixture
 def calcium_network(params):
     # Instantiating network along with drives
-    net = calcium_model(params=params, add_drives_from_params=True,
+    net = Kohl_2021(params=params, add_drives_from_params=True,
                         mesh_shape=(3, 3))
 
     # Adding bias

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -8,7 +8,7 @@ import pytest
 
 import hnn_core
 from hnn_core import read_params, CellResponse, Network
-from hnn_core import jones_2009_model, law_2021_model, calcium_model
+from hnn_core import jones_2009_model, law_2021_model, Kohl_2021
 from hnn_core.network_models import add_erp_drives_to_jones_model
 from hnn_core.network_builder import NetworkBuilder
 from hnn_core.network import pick_connection
@@ -45,7 +45,7 @@ def test_network_models():
     assert len(net_default.connectivity) == n_conn + 14
 
     # Ensure distant dependent calcium gbar
-    net_calcium = calcium_model()
+    net_calcium = Kohl_2021()
     # instantiate drive events for NetworkBuilder
     net_calcium._instantiate_drives(tstop=net_calcium._params['tstop'],
                                     n_trials=net_calcium._params['N_trials'])
@@ -399,7 +399,7 @@ def test_network_drives_legacy():
     with pytest.warns(DeprecationWarning, match='Legacy mode'):
         _ = jones_2009_model(legacy_mode=True)
         _ = law_2021_model(legacy_mode=True)
-        _ = calcium_model(legacy_mode=True)
+        _ = Kohl_2021(legacy_mode=True)
         _ = Network(params, legacy_mode=True)
 
     net = jones_2009_model(params, legacy_mode=True,
@@ -945,5 +945,5 @@ def test_network_mesh():
 
     # Smoke test for all models
     _ = jones_2009_model(mesh_shape=mesh_shape)
-    _ = calcium_model(mesh_shape=mesh_shape)
+    _ = Kohl_2021(mesh_shape=mesh_shape)
     _ = law_2021_model(mesh_shape=mesh_shape)


### PR DESCRIPTION
Resolved issue #674 

- Rename `calcium_model` to `Kohl_2021` for consistency in model naming