### PR TITLE
[MRG] Fix pick connection

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,6 +36,10 @@ Changelog
 - Add feature to convert param and json files to HDF5 format, by `George Dang`_
   in :gh:`723`
 
+- Fixed bug in :func:`~hnn_core/network/pick_connection` where connections were
+  returned for cases when there should be no valid matches, by `George Dang`_
+  in :gh:`739`
+
 Bug
 ~~~
 - Fix inconsistent connection mapping from drive gids to cell gids, by

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,7 +36,7 @@ Changelog
 - Add feature to convert param and json files to HDF5 format, by `George Dang`_
   in :gh:`723`
 
-- Fixed bug in :func:`~hnn_core/network/pick_connection` where connections were
+- Fix bug in :func:`~hnn_core/network/pick_connection` where connections are
   returned for cases when there should be no valid matches, by `George Dang`_
   in :gh:`739`
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -233,9 +233,10 @@ def pick_connection(net, src_gids=None, target_gids=None,
     valid_srcs = list(net.gid_ranges.keys())  # includes drives as srcs
     valid_targets = list(net.cell_types.keys())
     src_gids_checked = _check_gids(src_gids, net.gid_ranges,
-                           valid_srcs, 'src_gids', same_type=False)
+                                   valid_srcs, 'src_gids', same_type=False)
     target_gids_checked = _check_gids(target_gids, net.gid_ranges,
-                              valid_targets, 'target_gids', same_type=False)
+                                      valid_targets, 'target_gids',
+                                      same_type=False)
 
     _validate_type(loc, (str, list, None), 'loc', 'str, list, or None')
     _validate_type(receptor, (str, list, None), 'receptor',

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -269,13 +269,13 @@ def pick_connection(net, src_gids=None, target_gids=None,
 
     # Look up conn indices that match search terms and add to set.
     conn_set = set()
-    search_pairs = [(src_gids, src_gids_checked, src_dict),
-                    (target_gids, target_gids_checked, target_dict),
-                    (loc, loc_list, loc_dict),
-                    (receptor, receptor_list, receptor_dict),
+    search_pairs = [(src_gids_checked, src_dict),
+                    (target_gids_checked, target_dict),
+                    (loc_list, loc_dict),
+                    (receptor_list, receptor_dict),
                     ]
-    for arg_input, search_terms, search_dict in search_pairs:
-        if arg_input is not None:
+    for search_terms, search_dict in search_pairs:
+        if search_terms:
             inner_set = set()
             # Union of indices which match inputs for single parameter
             for term in search_terms:

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -283,7 +283,7 @@ def pick_connection(net, src_gids=None, target_gids=None,
 
             # Empty search
             if not inner_set:
-                return []
+                return list()
             # Initial search has results
             elif inner_set and not conn_set:
                 conn_set = inner_set.copy()
@@ -293,7 +293,7 @@ def pick_connection(net, src_gids=None, target_gids=None,
                 conn_set = conn_set.intersection(inner_set)
                 # If at any point there's no matching elements, return empty
                 if not conn_set:
-                    return []
+                    return list()
 
     return sorted(conn_set)
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -286,8 +286,9 @@ def pick_connection(net, src_gids=None, target_gids=None,
             # Initial search has results
             elif inner_set and not conn_set:
                 conn_set = inner_set.copy()
-            # Intersect across parameters
+            # Subsequent searches have results
             elif inner_set and conn_set:
+                # Intersect across parameters
                 conn_set = conn_set.intersection(inner_set)
                 # If at any point there's no matching elements, return empty
                 if not conn_set:

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -809,6 +809,15 @@ def test_network_connectivity():
             kwargs[arg] = string_arg
             pick_connection(**kwargs)
 
+    # Test network with only drive information
+    # Searching for cell connection should return empty list
+    net_only_drives = Network(params, add_drives_from_params=True,
+                              legacy_mode=False)
+    indices = pick_connection(net_only_drives,
+                              src_gids='L2_basket',
+                              target_gids='L2_basket')
+    assert len(indices) == 0
+
     # Test removing connections from net.connectivity
     # Needs to be updated if number of drives change in preceding tests
     net.clear_connectivity()


### PR DESCRIPTION
This fix resolves the bug discussed in #734 where the `pick_connection` function was picking incorrect connections. This was discovered when the function was tasked to pick cell connections in a Network where only drive connections were configured. The function still selected drive connections instead of returning an empty list. 

**Changes** 
1. pick_connection
    i. Return empty list return whenever `inner_set` search is empty
    ii. Prevent doing searches for arguments the user doesn't ask for (forwarding kw arguments to search loop)
    iii. Refactor 
2. tests
    i. Added test for searching for a cell connection in a network with only drives configured



closes #734 