### PR TITLE
 [MRG] Fix: Added Axes object check in `plot_cells`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -44,7 +44,7 @@ Changelog
   in :gh:`739`
 
 - Added check for invalid Axes object in :func:`~hnn_core/viz/plot_cells` 
-  function, by `Abdul Samad Siddiqui`_ in :gh:`744`
+  function, by `Abdul Samad Siddiqui`_ in :gh:`744`.
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,6 +43,9 @@ Changelog
   returned for cases when there should be no valid matches, by `George Dang`_
   in :gh:`739`
 
+- Added check for invalid Axes object in :func:`~hnn_core/viz/plot_cells` 
+  function, by `Abdul Samad Siddiqui`_ in :gh:`744`
+
 Bug
 ~~~
 - Fix inconsistent connection mapping from drive gids to cell gids, by
@@ -467,4 +470,4 @@ People who contributed to this release (in alphabetical order):
 .. _Kaisu Lankinen: https://github.com/klankinen
 .. _George Dang: https://github.com/gtdang
 .. _Camilo Diaz: https://github.com/kmilo9999
-
+.. _Abdul Samad Siddiqui: https://github.com/samadpls

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -79,6 +79,12 @@ def test_network_visualization():
     with pytest.raises(TypeError, match='color must be'):
         cell_type.plot_morphology(color=123)
 
+    # test for invalid Axes object to plot_cells
+    fig, axes = plt.subplots(1, 1)
+    with pytest.raises(TypeError,
+                       match="'ax' to be an instance of Axes3D, but got Axes"):
+        plot_cells(net, ax=axes, show=False)
+
     plt.close('all')
 
     # test interactive clicking updates the position of src_cell in plot

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -577,11 +577,15 @@ def plot_cells(net, ax=None, show=True):
         The matplotlib figure handle.
     """
     import matplotlib.pyplot as plt
-    from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+    from mpl_toolkits.mplot3d import Axes3D
 
     if ax is None:
         fig = plt.figure()
         ax = fig.add_subplot(111, projection='3d')
+
+    elif not isinstance(ax, Axes3D):
+        raise TypeError("Expected 'ax' to be an instance of Axes3D, "
+                        f"but got {type(ax).__name__}")
 
     colors = {'L5_pyramidal': 'b', 'L2_pyramidal': 'c',
               'L5_basket': 'r', 'L2_basket': 'm'}


### PR DESCRIPTION
Closes #735 
- Added check for invalid Axes object in `plot_cells` function, raises an error if found.