### PR TITLE
Remove ipywidgets version number from readme 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,10 +57,13 @@ Optional dependencies
 GUI
 ~~~
 
-* ipywidgets (>=8.0.0)
+* ipywidgets
 * voila
 * ipympl
 * ipykernel
+
+*Note*: Please follow the **GUI installation** section to install the correct
+GUI dependency versions automatically.
 
 Optimization
 ~~~~~~~~~~~~


### PR DESCRIPTION
Removed ipywidgets version and added note pointing to GUI installation section.

Discussed in #747 