### PR TITLE
[WIP] update convert_to_hdf5 to use Jones 2009 connectivity by default

### DIFF
--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -671,10 +671,11 @@ def convert_to_hdf5(params_fname,
         Path to file
     out_fname: str
         Path to output
-    network_connectivity: str or None, default="jones_2009_model"
-        Neocortical network model to use. Models are defined in
-        network_models.py. If None, the base Network object with no defined
-        network connectivity will be used.
+    network_connectivity: str or None, default:' jones_2009_model'
+        Options: ['jones_2009_model', 'law_2021_model', 'calcium_model', None]
+        Neocortical network model to use. Models are defined in network_models.
+        If None, the base Network object with no defined network connectivity
+        will be used.
     include_drives: bool, default=True
         Include drives from params file
     overwrite: bool, default=True

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -694,7 +694,12 @@ def convert_to_hdf5(params_fname,
                        'calcium_model': calcium_model
                        }
     if network_connectivity:
-        network_model = model_functions[network_connectivity]
+        try:
+            network_model = model_functions[network_connectivity]
+        except KeyError:
+            raise KeyError(f'Invalid network connectivity: '
+                           f'"{network_connectivity}"; '
+                           f'Valid options: {list(model_functions.keys())}')
     else:
         network_model = Network
 

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -184,6 +184,7 @@ class TestConvertToHDF5:
         good_path = hnn_core_root
         path_str = str(good_path)
         bad_path = 5
+        bad_network_conn = 'bad_model'
 
         # Valid path and string, but not actual files
         with pytest.raises(
@@ -205,3 +206,11 @@ class TestConvertToHDF5:
                 match="out_fname must be an instance of str or Path"
         ):
             convert_to_hdf5(good_path, bad_path)
+
+        # Bad network_connectivity
+        with pytest.raises(
+                KeyError,
+                match="Invalid network connectivity:"
+        ):
+            convert_to_hdf5(good_path, good_path,
+                            network_connectivity=bad_network_conn)


### PR DESCRIPTION
Previous hdf5 conversion from param and json format did not include connectivity information because the conversion was using the base Network object to initialize the networks. This change makes the default to use the Jones 2009 model so that network connectivity is encoded in the hdf5. This was decided because the tutorial only uses this model. Other saved model types are also available as well as an option to not use any model. 
 