### PR TITLE
[MRG] ENH: `plot_spikes_raster` to always include all cell types

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -115,7 +115,6 @@ html_theme_options = {
     'navbar_sidebarrel': False,
     'navbar_links': [
         ("Examples", "auto_examples/index"),
-        ("GUI", "gui/index"),
         ("API", "api"),
         ("Glossary", "glossary"),
         ("What's new", "whats_new"),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,7 +94,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'gui/index.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/doc/gui/index.rst
+++ b/doc/gui/index.rst
@@ -3,35 +3,3 @@ GUI
 ===
 
 The brand-new lightweight web-based hnn GUI that works with hnn-core.
-
-.. raw:: html
-
-    <div class="sphx-glr-thumbnails">
-        <div class="sphx-glr-thumbcontainer"
-            tooltip="Basic GUI usage">
-
-.. only:: html
-
-  .. image:: https://user-images.githubusercontent.com/11160442/197026635-39b6564a-f529-4caf-870e-af9ca4d2fb75.png
-     :alt: 01. Basic GUI usage
-
-  :doc:`basic_gui_usage`
-
-.. raw:: html
-
-      <div class="sphx-glr-thumbnail-title">01. Basic GUI usage</div>
-    </div>
-    <div class="sphx-glr-thumbcontainer" tooltip="Simulate ERP using GUI">
-
-.. only:: html
-
-  .. image:: https://hnn.brown.edu/wp-content/uploads/2019/06/ERP_.png
-     :alt: 02. Simulate Event Related Potentials (ERPs)
-
-  :doc:`tutorial_erp`
-
-.. raw:: html
-
-        <div class="sphx-glr-thumbnail-title">02. Simulate ERP using GUI</div>
-        </div>
-    </div>

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,9 @@ Changelog
 - Add :class:`~hnn_core.BatchSimulate` for batch simulation capability,
   by `Abdul Samad Siddiqui`_ in :gh:`782`.
 
+- Updated `plot_spikes_raster` logic to include all neurons in network model.
+  Removed GUI exclusion from build, by `Abdul Samad Siddiqui`_  in :gh:`754`.
+
 Bug
 ~~~
 - Fix inconsistent connection mapping from drive gids to cell gids, by

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -202,7 +202,8 @@ def test_dipole_visualization(setup_net):
     with pytest.raises(TypeError, match="trial_idx must be an instance of"):
         net.cell_response.plot_spikes_raster(trial_idx='blah', show=False)
     net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
-    net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
+    fig = net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
+    assert len(fig.axes[0].collections) > 0, "No data plotted in raster plot"
 
     with pytest.raises(TypeError, match="trial_idx must be an instance of"):
         net.cell_response.plot_spikes_hist(trial_idx='blah')

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -534,17 +534,12 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
     _validate_type(trial_idx, list, 'trial_idx', 'int, list of int')
 
     # Extract desired trials
-    if len(cell_response._spike_times[0]) > 0:
-        spike_times = np.concatenate(
-            np.array(cell_response._spike_times, dtype=object)[trial_idx])
-        spike_types = np.concatenate(
-            np.array(cell_response._spike_types, dtype=object)[trial_idx])
-        spike_gids = np.concatenate(
-            np.array(cell_response._spike_gids, dtype=object)[trial_idx])
-    else:
-        spike_times = np.array([])
-        spike_types = np.array([])
-        spike_gids = np.array([])
+    spike_times = np.concatenate(
+        np.array(cell_response._spike_times, dtype=object)[trial_idx])
+    spike_types = np.concatenate(
+        np.array(cell_response._spike_types, dtype=object)[trial_idx])
+    spike_gids = np.concatenate(
+        np.array(cell_response._spike_gids, dtype=object)[trial_idx])
 
     cell_types = ['L2_basket', 'L2_pyramidal', 'L5_basket', 'L5_pyramidal']
     cell_type_colors = {'L5_pyramidal': 'r', 'L5_basket': 'b',
@@ -553,7 +548,6 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
     if ax is None:
         _, ax = plt.subplots(1, 1, constrained_layout=True)
 
-    ypos = 0
     events = []
     for cell_type in cell_types:
         cell_type_gids = np.unique(spike_gids[spike_types == cell_type])
@@ -561,12 +555,16 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
         for gid in cell_type_gids:
             gid_time = spike_times[spike_gids == gid]
             cell_type_times.append(gid_time)
-            cell_type_ypos.append(ypos)
-            ypos = ypos - 1
+            cell_type_ypos.append(-gid)
 
         if cell_type_times:
             events.append(
                 ax.eventplot(cell_type_times, lineoffsets=cell_type_ypos,
+                             color=cell_type_colors[cell_type],
+                             label=cell_type, linelengths=5))
+        else:
+            events.append(
+                ax.eventplot([-1], lineoffsets=[-1],
                              color=cell_type_colors[cell_type],
                              label=cell_type, linelengths=5))
 


### PR DESCRIPTION
Closes #658

- Updated `plot_spikes_raster` logic to always include all cell types.