### PR TITLE
[MRG] Update GitHub actions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,6 +17,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: test
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -47,7 +47,11 @@ jobs:
         shell: bash -el {0}
         run: |
           python -m pytest .  --cov=hnn_core hnn_core/tests/ --cov-report=xml
-      - name: Upload code coverage
-        shell: bash -el {0}
-        run: |
-          bash <(curl -s https://codecov.io/bash) -f ./coverage.xml
+      - name:  Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+            directory: ./
+            fail_ci_if_error: true
+            files: ./coverage.xml
+            flags: unittests
+            token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.8, 3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: test
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           activate-environment: test
           python-version: ${{ matrix.python-version }}
+          fetch-depth: 2
       - name: Install ubuntu dependencies
         shell: bash -el {0}
         run: |

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: test
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: [3.8, 3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test


### PR DESCRIPTION
Runners were no longer finding the conda base version preventing gh runners to build. 

- Updating the setup-miniconda line to version 3 seemed to fix the problem.  
- Updated the checkout action to v4. 
- Changed fetch-depth to 2 because it was stalling on codecov step on linux runners. [source](https://github.com/codecov/codecov-action/issues/190)
- Updated to use codecov upload action v4 instead of shell command

[setup-miniconda](https://github.com/conda-incubator/setup-miniconda/releases)
[checkout](https://github.com/actions/checkout/releases/tag/v4.1.4)