### PR TITLE
Debug codecov issues

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test with pytest
         shell: bash -el {0}
         run: |
-          python -m pytest .  --cov=hnn_core hnn_core/tests/ --cov-report=xml
+          python -m pytest ./hnn_core/tests/test_io.py --cov=hnn_core --cov-report=xml
       - name:  Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -51,7 +51,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
             directory: ./
-            fail_ci_if_error: true
+            fail_ci_if_error: false
             files: ./coverage.xml
             flags: unittests
             token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -48,10 +48,6 @@ jobs:
         run: |
           python -m pytest ./hnn_core/tests/test_io.py --cov=hnn_core --cov-report=xml
       - name:  Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-            directory: ./
-            fail_ci_if_error: false
-            files: ./coverage.xml
-            flags: unittests
-            token: ${{ secrets.CODECOV_TOKEN }}
+        shell: bash -el {0}
+        run: |
+            bash <(curl -s https://codecov.io/bash) -f ./coverage.xml

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Test with pytest
         shell: cmd
         run: |
-          python -m pytest .  --cov=hnn_core hnn_core/tests/ --cov-report=xml
+          python -m pytest ./hnn_core/tests/test_io.py  --cov=hnn_core --cov-report=xml


### PR DESCRIPTION
Debugging GitHub actions for uploading codecov report. Unittest actions have been failing since switching to using the [codecov-action](https://github.com/codecov/codecov-action) v4 in #758 .

Codecov uploads have sporadically been failing due to rate-limiting of 'tokenless' uploads.  It is not actually tokenless, see explanation below.

> If Codecov detects that reports are being uploaded from a fork of an open source repository, Codecov will automatically switch to tokenless uploading...Token-less uploads still use a token to upload to Codecov - just that it's Codecov's Github token instead of the project's own. As such, uploading to Codecov via tokenless (whether it's via forks, or by an older version of the Codecov action) ends up consuming from the shared request pool of a lot of Codecov users, instead of your own. **Therefore, there may be cases when uploading to Codecov via tokenless fails because Codecov is being rate limited.** [Source](https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov)

This issue has been documented by others:
https://github.com/codecov/feedback/issues/358
https://github.com/codecov/feedback/issues/301
https://github.com/codecov/feedback/issues/112