### PR TITLE
Codecov upload revert

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -48,10 +48,6 @@ jobs:
         run: |
           python -m pytest .  --cov=hnn_core hnn_core/tests/ --cov-report=xml
       - name:  Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-            directory: ./
-            fail_ci_if_error: true
-            files: ./coverage.xml
-            flags: unittests
-            token: ${{ secrets.CODECOV_TOKEN }}
+        shell: bash -el {0}
+        run: |
+          bash <(curl -s https://codecov.io/bash) -f ./coverage.xml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test with pytest
         shell: bash -el {0}
         run: |
-          python -m pytest .  --cov=hnn_core hnn_core/tests/ --cov-report=xml
+          python -m pytest ./hnn_core/tests/  --cov=hnn_core --cov-report=xml
       - name:  Upload coverage to Codecov
         shell: bash -el {0}
         run: |

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Test with pytest
         shell: cmd
         run: |
-          python -m pytest .  --cov=hnn_core hnn_core/tests/ --cov-report=xml
+          python -m pytest ./hnn_core/tests/


### PR DESCRIPTION
Reverting back to the bash uploader until the codecov upload action is corrected. See details in #760 and #759.

closes #760 