### PR TITLE
[MRG] Optimize GUI tests

### DIFF
--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -229,9 +229,9 @@ def test_gui_run_simulations(setup_gui):
     """Test if run button triggers multiple simulations correctly."""
     gui = setup_gui
 
-    tstop_trials_tstep = [(10, 1, 0.5),
+    tstop_trials_tstep = [(10, 1, 0.25),
                           (10, 2, 0.5),
-                          (12, 1, 1.0)]
+                          (12, 1, 0.5)]
     assert gui.widget_backend_selection.value == "Joblib"
     sim_count = 0
 

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -479,9 +479,7 @@ def test_gui_adaptive_spectrogram(setup_gui):
     plt.close('all')
 
 
-@pytest.mark.parametrize("viz_type", ["layer2 dipole", "layer5 dipole",
-                                      "spikes", "PSD", "network"])
-def test_gui_visualization(setup_gui, viz_type):
+def test_gui_visualization(setup_gui):
     """Test visualization functionality in the HNNGUI."""
     gui = setup_gui
     gui.run_button.click()
@@ -489,14 +487,17 @@ def test_gui_visualization(setup_gui, viz_type):
     figid = 1
     figname = f'Figure {figid}'
     axname = 'ax1'
-    gui._simulate_viz_action("edit_figure", figname,
-                             axname, 'default', viz_type, {}, 'clear')
-    gui._simulate_viz_action("edit_figure", figname,
-                             axname, 'default', viz_type, {}, 'plot')
-    # Check if data is plotted on the axes
-    assert len(gui.viz_manager.figs[figid].axes) == 2
-    # Check default figs have data on their axis
-    assert gui.viz_manager.figs[figid].axes[1].has_data()
+
+    plot_types = ["layer2 dipole", "layer5 dipole", "spikes", "PSD", "network"]
+    for viz_type in plot_types:
+        gui._simulate_viz_action("edit_figure", figname,
+                                 axname, 'default', viz_type, {}, 'clear')
+        gui._simulate_viz_action("edit_figure", figname,
+                                 axname, 'default', viz_type, {}, 'plot')
+        # Check if data is plotted on the axes
+        assert len(gui.viz_manager.figs[figid].axes) == 2
+        # Check default figs have data on their axis
+        assert gui.viz_manager.figs[figid].axes[1].has_data()
 
 
 def test_unlink_relink_widget():

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1,4 +1,6 @@
 # Authors: Huzi Cheng <hzcheng15@icloud.com>
+#          Camilo Diaz <camilo_diaz@brown.edu>
+#          George Dang <george_dang@brown.edu>
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -220,44 +220,40 @@ def test_gui_run_simulation_mpi(setup_gui):
     plt.close('all')
 
 
-def test_gui_run_simulations():
+def test_gui_run_simulations(setup_gui):
     """Test if run button triggers multiple simulations correctly."""
-    gui = HNNGUI()
-    app_layout = gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
+    gui = setup_gui
 
-    assert app_layout is not None
+    tstop_trials_tstep = [(10, 1, 0.5),
+                          (10, 2, 0.5),
+                          (12, 1, 1.0)]
     assert gui.widget_backend_selection.value == "Joblib"
-    val_tstop = 20
-    val_ntrials = 1
     sim_count = 0
-    for val_tstop in (10, 12):
-        for val_ntrials in (1, 2):
-            for val_tstep in (0.05, 0.08):
-                gui.widget_simulation_name.value = str(sim_count)
-                gui.widget_tstop.value = val_tstop
-                gui.widget_ntrials.value = val_ntrials
-                gui.widget_dt.value = val_tstep
 
-                gui.run_button.click()
-                sim_name = gui.widget_simulation_name.value
-                dpls = gui.simulation_data[sim_name]['dpls']
+    for val_tstop, val_ntrials, val_tstep in tstop_trials_tstep:
+        gui.widget_simulation_name.value = str(sim_count)
+        gui.widget_tstop.value = val_tstop
+        gui.widget_ntrials.value = val_ntrials
+        gui.widget_dt.value = val_tstep
 
-                assert isinstance(gui.simulation_data[sim_name]["net"],
-                                  Network)
-                assert isinstance(dpls, list)
-                assert all([isinstance(dpl, Dipole) for dpl in dpls])
-                assert len(dpls) == val_ntrials
-                assert all([
-                    pytest.approx(dpl.times[-1]) == val_tstop for dpl in dpls
-                ])
-                assert all([
-                    pytest.approx(dpl.times[1] - dpl.times[0]) == val_tstep
-                    for dpl in dpls
-                ])
+        gui.run_button.click()
+        sim_name = gui.widget_simulation_name.value
+        dpls = gui.simulation_data[sim_name]['dpls']
 
-                sim_count += 1
+        assert isinstance(gui.simulation_data[sim_name]["net"],
+                          Network)
+        assert isinstance(dpls, list)
+        assert all([isinstance(dpl, Dipole) for dpl in dpls])
+        assert len(dpls) == val_ntrials
+        assert all([
+            pytest.approx(dpl.times[-1]) == val_tstop for dpl in dpls
+        ])
+        assert all([
+            pytest.approx(dpl.times[1] - dpl.times[0]) == val_tstep
+            for dpl in dpls
+        ])
+
+        sim_count += 1
 
     assert len(list(gui.simulation_data)) == sim_count
 

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -8,6 +8,7 @@ import pytest
 import traitlets
 import os
 
+from pathlib import Path
 from hnn_core import Dipole, Network, Params
 from hnn_core.gui import HNNGUI
 from hnn_core.gui._viz_manager import (_idx2figname, _no_overlay_plot_types,
@@ -21,6 +22,8 @@ from IPython.display import IFrame
 from ipywidgets import Tab, Text, link
 
 matplotlib.use('agg')
+hnn_core_root = Path(__file__).parents[1]
+assets_path = Path(hnn_core_root, 'tests', 'assets')
 
 
 @pytest.fixture
@@ -586,15 +589,16 @@ def test_gui_upload_csv_simulation(setup_gui):
     assert len(gui.viz_manager.data['figs']) == 0
     assert len(gui.data['simulation_data']) == 0
 
-    # Relative path to the file
-    file_relative_path = "./hnn_core/tests/assets/test_default.csv"
-    absolute_path = os.path.abspath(file_relative_path)
+    # Formulate path to the file
+    file_path = assets_path / 'test_default.csv'
+    absolute_path = str(file_path.resolve())
     if os.name == 'nt':  # Windows
         # Convert backslashes to forward slashes and
         # ensure we have three slashes after 'file:'
         file_url = 'file:///' + absolute_path.replace('\\', '/')
     else:  # UNIX-like systems
         file_url = 'file://' + absolute_path
+
     _ = gui._simulate_upload_data(file_url)
 
     # we are loading only 1 trial,

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -21,6 +21,17 @@ from ipywidgets import Tab, Text, link
 matplotlib.use('agg')
 
 
+@pytest.fixture
+def setup_gui():
+    gui = HNNGUI()
+    gui.compose()
+    gui.params['N_pyr_x'] = 3
+    gui.params['N_pyr_y'] = 3
+    gui.widget_dt.value = 0.5  # speed up tests
+    gui.widget_tstop.value = 70  # speed up tests
+    return gui
+
+
 def test_gui_load_params():
     """Test if gui loads default parameters properly"""
     gui = HNNGUI()
@@ -195,15 +206,11 @@ def test_gui_init_network():
 
 @requires_mpi4py
 @requires_psutil
-def test_gui_run_simulation_mpi():
+def test_gui_run_simulation_mpi(setup_gui):
     """Test if run button triggers simulation with MPIBackend."""
-    gui = HNNGUI()
-    _ = gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
+    gui = setup_gui
 
     gui.widget_backend_selection.value = "MPI"
-    gui.widget_tstop.value = 30  # speed up tests
     gui.run_button.click()
     default_name = gui.widget_simulation_name.value
     dpls = gui.simulation_data[default_name]['dpls']
@@ -254,11 +261,10 @@ def test_gui_run_simulations():
 
     assert len(list(gui.simulation_data)) == sim_count
 
-    # make sure different simulations must have distinct names
-    gui = HNNGUI()
-    _ = gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
+
+def test_non_unique_name_error(setup_gui):
+    """ Checks that simulation fails if new name is not supplied. """
+    gui = setup_gui
 
     sim_name = gui.widget_simulation_name.value
 
@@ -289,12 +295,9 @@ def test_gui_take_screenshots():
     plt.close('all')
 
 
-def test_gui_add_figure():
+def test_gui_add_figure(setup_gui):
     """Test if the GUI adds/deletes figs properly."""
-    gui = HNNGUI()
-    _ = gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
+    gui = setup_gui
 
     fig_tabs = gui.viz_manager.figs_tabs
     axes_config_tabs = gui.viz_manager.axes_config_tabs
@@ -340,12 +343,9 @@ def test_gui_add_figure():
     plt.close('all')
 
 
-def test_gui_add_data_dependent_figure():
+def test_gui_add_data_dependent_figure(setup_gui):
     """Test if the GUI adds/deletes figs data dependent properly."""
-    gui = HNNGUI()
-    _ = gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
+    gui = setup_gui
 
     fig_tabs = gui.viz_manager.figs_tabs
     axes_config_tabs = gui.viz_manager.axes_config_tabs
@@ -380,12 +380,9 @@ def test_gui_add_data_dependent_figure():
     assert len(fig_tabs.children) == n_fig
 
 
-def test_gui_edit_figure():
+def test_gui_edit_figure(setup_gui):
     """Test if the GUI adds/deletes figs properly."""
-    gui = HNNGUI()
-    _ = gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
+    gui = setup_gui
 
     fig_tabs = gui.viz_manager.figs_tabs
     axes_config_tabs = gui.viz_manager.axes_config_tabs
@@ -406,14 +403,9 @@ def test_gui_edit_figure():
     plt.close('all')
 
 
-def test_gui_synchronous_inputs():
+def test_gui_synchronous_inputs(setup_gui):
     """Test if the GUI creates plot using synchronous_inputs."""
-    gui = HNNGUI()
-    _ = gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
-
-    gui.widget_dt.value = 0.85
+    gui = setup_gui
 
     # set synch inputs to first driver in simulation
     driver_name = gui.drive_widgets[0]['name']
@@ -433,12 +425,9 @@ def test_gui_synchronous_inputs():
         assert len(connectivity['src_gids']) == 1
 
 
-def test_gui_figure_overlay():
+def test_gui_figure_overlay(setup_gui):
     """Test if the GUI adds/deletes figs properly."""
-    gui = HNNGUI()
-    _ = gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
+    gui = setup_gui
 
     axes_config_tabs = gui.viz_manager.axes_config_tabs
 
@@ -464,12 +453,9 @@ def test_gui_figure_overlay():
     plt.close('all')
 
 
-def test_gui_adaptive_spectrogram():
+def test_gui_adaptive_spectrogram(setup_gui):
     """Test the adaptive spectrogram functionality of the HNNGUI."""
-    gui = HNNGUI()
-    gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
+    gui = setup_gui
 
     gui.run_button.click()
     figid = 1
@@ -492,21 +478,13 @@ def test_gui_adaptive_spectrogram():
     plt.close('all')
 
 
-@pytest.fixture
-def setup_gui():
-    gui = HNNGUI()
-    gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
-    gui.run_button.click()
-    return gui
-
-
 @pytest.mark.parametrize("viz_type", ["layer2 dipole", "layer5 dipole",
                                       "spikes", "PSD", "network"])
 def test_gui_visualization(setup_gui, viz_type):
     """Test visualization functionality in the HNNGUI."""
     gui = setup_gui
+    gui.run_button.click()
+
     figid = 1
     figname = f'Figure {figid}'
     axname = 'ax1'

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -543,15 +543,12 @@ def test_unlink_relink_widget():
     assert gui.tab_group_2.selected_index == 0
 
 
-def test_gui_download_simulation():
+def test_gui_download_simulation(setup_gui):
     """Test the GUI download simulation pipeline."""
-    gui = HNNGUI()
-    _ = gui.compose()
-    gui.params['N_pyr_x'] = 3
-    gui.params['N_pyr_y'] = 3
 
-    # Run a simulation with 3 trials
-    gui.widget_dt.value = 0.85
+    gui = setup_gui
+
+    # Run a simulation with 2 trials
     gui.widget_ntrials.value = 2
 
     # Initiate 1rs simulation
@@ -567,7 +564,6 @@ def test_gui_download_simulation():
     assert file_extension == ".zip"
 
     # Run a simulation with 1 trials
-    gui.widget_dt.value = 0.85
     gui.widget_ntrials.value = 1
 
     # Initiate 2nd simulation
@@ -582,10 +578,10 @@ def test_gui_download_simulation():
     assert file_extension == ".csv"
 
 
-def test_gui_upload_csv_simulation():
+def test_gui_upload_csv_simulation(setup_gui):
     """Test if gui handles uploaded csv data"""
-    gui = HNNGUI()
-    _ = gui.compose()
+
+    gui = setup_gui
 
     assert len(gui.viz_manager.data['figs']) == 0
     assert len(gui.data['simulation_data']) == 0

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -11,7 +11,9 @@ import os
 from pathlib import Path
 from hnn_core import Dipole, Network, Params
 from hnn_core.gui import HNNGUI
-from hnn_core.gui._viz_manager import (_idx2figname, _no_overlay_plot_types,
+from hnn_core.gui._viz_manager import (_idx2figname,
+                                       _plot_types,
+                                       _no_overlay_plot_types,
                                        unlink_relink)
 from hnn_core.gui.gui import _init_network_from_widgets
 from hnn_core.gui.gui import serialize_simulation
@@ -480,15 +482,28 @@ def test_gui_adaptive_spectrogram(setup_gui):
 
 
 def test_gui_visualization(setup_gui):
-    """Test visualization functionality in the HNNGUI."""
+    """ Tests updating a figure creates plots with data. """
+
     gui = setup_gui
     gui.run_button.click()
 
     figid = 1
     figname = f'Figure {figid}'
     axname = 'ax1'
+    # Spectrogram has a separate test and does not need to be tested here
+    gui_plots_no_spectrogram = [s for s in _plot_types if s != 'spectrogram']
 
-    plot_types = ["layer2 dipole", "layer5 dipole", "spikes", "PSD", "network"]
+    plot_types = ['current dipole',
+                  'layer2 dipole',
+                  'layer5 dipole',
+                  'input histogram',
+                  'spikes',
+                  'PSD',
+                  'network']
+    # Make sure all plot types are tested.
+    assert len(plot_types) == len(gui_plots_no_spectrogram)
+    assert all([name in gui_plots_no_spectrogram for name in plot_types])
+
     for viz_type in plot_types:
         gui._simulate_viz_action("edit_figure", figname,
                                  axname, 'default', viz_type, {}, 'clear')
@@ -498,6 +513,7 @@ def test_gui_visualization(setup_gui):
         assert len(gui.viz_manager.figs[figid].axes) == 2
         # Check default figs have data on their axis
         assert gui.viz_manager.figs[figid].axes[1].has_data()
+    plt.close('all')
 
 
 def test_unlink_relink_widget():


### PR DESCRIPTION
Refactored the GUI tests to improve speed. Running simulations is the largest contributor to runtime so this focused on shortening simulation time and number of simulations run. Was able to reduce runtime by more than half.

* Created a fixture with reduced tstop and dt for faster simulations. Used the fixture in applicable tests.
* Reduced unnecessary iterations where simulations were run multiple times.


_Previous_
![Screenshot 2024-05-08 at 5 40 18 PM](https://github.com/jonescompneurolab/hnn-core/assets/53052793/3314caf0-8f96-4c56-8dd9-4b09d1b230bb)


_Refactored_
![Screenshot 2024-05-09 at 9 46 19 AM](https://github.com/jonescompneurolab/hnn-core/assets/53052793/f71c5348-c77d-428d-ad26-fef5c5bccab8)
