### PR TITLE
[REF]: Refactor network.add_tonic_bias

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -86,10 +86,8 @@ API
   convergence. User can constrain parameter ranges and specify solver,
   by `Carolina Fernandez Pujol`_ in :gh:`652`
 
-- :func:`network.add_tonic_bias` argument `amplitue` now  accepts a 
-  cell_type(str)-amplitude(float) dictionary in case `cell_type` argument is None,
-  otherwise `amplitue` is a float indicating the amplitude of the tonic input for the specific
-  `cell_type`
+- :func:`network.add_tonic_bias` cell-specific tonic bias can now be 
+  provided using the argument amplitude in network.add_tonic_bias`,
   by `Camilo Diaz`_ in :gh:`766`
 
 .. _0.3:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -86,6 +86,12 @@ API
   convergence. User can constrain parameter ranges and specify solver,
   by `Carolina Fernandez Pujol`_ in :gh:`652`
 
+- :func:`network.add_tonic_bias` argument `amplitue` now  accepts a 
+  cell_type(str)-amplitude(float) dictionary in case `cell_type` argument is None,
+  othwerise `amplitue` is a float indicating the amplitude of the tonic input for the specific
+  `cell_type`
+  by `Camilo Diaz`_ in :gh:`766`
+
 .. _0.3:
 
 0.3

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -88,7 +88,7 @@ API
 
 - :func:`network.add_tonic_bias` argument `amplitue` now  accepts a 
   cell_type(str)-amplitude(float) dictionary in case `cell_type` argument is None,
-  othwerise `amplitue` is a float indicating the amplitude of the tonic input for the specific
+  otherwise `amplitue` is a float indicating the amplitude of the tonic input for the specific
   `cell_type`
   by `Camilo Diaz`_ in :gh:`766`
 

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -197,7 +197,7 @@ def _add_drives_from_params(net):
         _t0 = bias_specs['tonic'][cellname]['t0']
         _tstop = bias_specs['tonic'][cellname]['tstop']
         net.add_tonic_bias(
-            cell_types_amplitudes=_cell_types_amplitudes,
+            amplitude=_cell_types_amplitudes,
             t0=_t0,
             tstop=_tstop)
 

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -188,12 +188,18 @@ def _add_drives_from_params(net):
                 event_seed=specs['event_seed'])
 
     # add tonic biases if present in params
-    for cellname in bias_specs['tonic']:
+    if bias_specs['tonic']:
+        _cell_types_amplitudes = dict()
+        for cellname in bias_specs['tonic']:
+            _cell_types_amplitudes[cellname] = (
+                bias_specs['tonic'][cellname]['amplitude'])
+
+        _t0 = bias_specs['tonic'][cellname]['t0']
+        _tstop = bias_specs['tonic'][cellname]['tstop']
         net.add_tonic_bias(
-            cell_type=cellname,
-            amplitude=bias_specs['tonic'][cellname]['amplitude'],
-            t0=bias_specs['tonic'][cellname]['t0'],
-            tstop=bias_specs['tonic'][cellname]['tstop'])
+            cell_types_amplitudes=_cell_types_amplitudes,
+            t0=_t0,
+            tstop=_tstop)
 
     # in HNN-GUI, seed is determined by "absolute GID" instead of the
     # gid offset with respect to the first cell of a population.

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1161,10 +1161,10 @@ class Network:
                           'Read the function docustring for more information',
                           DeprecationWarning,
                           stacklevel=1)
-            _validate_type(amplitude, float, 'amplitude')
+            _validate_type(amplitude, (float, int), 'amplitude')
 
             _add_cell_type_bias(network=self, cell_type=cell_type,
-                                amplitude=amplitude,
+                                amplitude=float(amplitude),
                                 t_0=t0, t_stop=tstop)
         else:
             _validate_type(amplitude, dict, 'amplitude')

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -25,6 +25,7 @@ from .extracellular import ExtracellularArray
 from .check import _check_gids, _gid_to_type, _string_input_to_list
 from .hnn_io import write_network
 from .externals.mne import copy_doc
+from typing import Union
 
 
 def _create_cell_coords(n_pyr_x, n_pyr_y, zdiff, inplane_distance):
@@ -298,7 +299,7 @@ def pick_connection(net, src_gids=None, target_gids=None,
     return sorted(conn_set)
 
 
-class Network(object):
+class Network:
     """The Network class.
 
     Parameters
@@ -1127,28 +1128,6 @@ class Network(object):
                 self.external_drives[
                     drive['name']]['events'].append(event_times)
 
-    def _add_cell_type_bias(self, *, cell_type=None, amplitude,
-                            t_0=0, t_stop=None):
-        if cell_type is not None:
-            # Validate cell_type value
-            if cell_type not in self.cell_types:
-                raise ValueError(f'cell_type must be one of '
-                                 f'{list(self.cell_types.keys())}. '
-                                 f'Got {cell_type}')
-
-            if 'tonic' not in self.external_biases:
-                self.external_biases['tonic'] = dict()
-
-            if cell_type in self.external_biases['tonic']:
-                raise ValueError(f'Tonic bias already defined for {cell_type}')
-
-            cell_type_bias = {
-                'amplitude': amplitude,
-                't0': t_0,
-                'tstop': t_stop
-            }
-            self.external_biases['tonic'][cell_type] = cell_type_bias
-
     def add_tonic_bias(self, *, cell_type=None, amplitude, t0=0, tstop=None):
         """Attaches parameters of tonic bias input for given cell types
 
@@ -1175,28 +1154,29 @@ class Network(object):
         """
 
         # old functionality single cell type - amplitude
-        if (cell_type is not None):
+        if cell_type is not None:
             warnings.warn('cell_type argument will be deprecated and '
-                          'removed in future releases', DeprecationWarning,
+                          'removed in future releases. Use amplitude as a '
+                          'cell_type:str,amplitude:float dictionary.'
+                          'Read the function docustring for more information',
+                          DeprecationWarning,
                           stacklevel=1)
-            if (not isinstance(amplitude, float)):
-                raise ValueError('amplitude parameter is not float')
+            _validate_type(amplitude, float, 'amplitude')
 
-            self._add_cell_type_bias(cell_type=cell_type, amplitude=amplitude,
-                                     t_0=t0, t_stop=tstop)
+            _add_cell_type_bias(network=self, cell_type=cell_type,
+                                amplitude=amplitude,
+                                t_0=t0, t_stop=tstop)
         else:
-            if (not isinstance(amplitude, dict)):
-                raise ValueError('amplitude parameter is not a dictionary')
-
-            if (len(amplitude) == 0):
+            _validate_type(amplitude, dict, 'amplitude')
+            if len(amplitude) == 0:
                 warnings.warn('No bias have been defined, no action taken',
                               UserWarning, stacklevel=1)
                 return
 
             for _cell_type, _amplitude in amplitude.items():
-                self._add_cell_type_bias(cell_type=_cell_type,
-                                         amplitude=_amplitude,
-                                         t_0=t0, t_stop=tstop)
+                _add_cell_type_bias(network=self, cell_type=_cell_type,
+                                    amplitude=_amplitude,
+                                    t_0=t0, t_stop=tstop)
 
     def _add_cell_type(self, cell_name, pos, cell_template=None):
         """Add cell type by updating pos_dict and gid_ranges."""
@@ -1578,3 +1558,35 @@ class _NetworkDrive(dict):
                      f"{len(self['events'])} trial{plurl}")
         entr += '>'
         return entr
+
+
+def _add_cell_type_bias(network: Network, amplitude: Union[float, dict],
+                        cell_type=None,
+                        t_0=0, t_stop=None):
+
+    if network is None:
+        raise ValueError('The "network" parameter is required '
+                         'but was not provided')
+    if amplitude is None:
+        raise ValueError('The "amplitude" parameter is required '
+                         'but was not provided')
+
+    if cell_type is not None:
+        # Validate cell_type value
+        if cell_type not in network.cell_types:
+            raise ValueError(f'cell_type must be one of '
+                             f'{list(network.cell_types.keys())}. '
+                             f'Got {cell_type}')
+
+        if 'tonic' not in network.external_biases:
+            network.external_biases['tonic'] = dict()
+
+        if cell_type in network.external_biases['tonic']:
+            raise ValueError(f'Tonic bias already defined for {cell_type}')
+
+        cell_type_bias = {
+            'amplitude': amplitude,
+            't0': t_0,
+            'tstop': t_stop
+        }
+        network.external_biases['tonic'][cell_type] = cell_type_bias

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1150,30 +1150,28 @@ class Network(object):
             self.external_biases['tonic'][cell_type] = cell_type_bias
 
     def add_tonic_bias(self, *, cell_type=None, amplitude, t0=0, tstop=None):
-        """Attach parameters of tonic biasing input for given cell types.
+        """Attaches parameters of tonic bias input for given cell types
 
         Parameters
         ----------
-        cell_types : str
-            If cell_types is a string, it indicates the cell type that
-            will receive the tonic input.whose cells will get the tonic input.
+        cell_types : str | None
+            The name of the cell type to add a tonic input. When supplied,
+            a float value must be provided with the `amplitude` keyword.
             Valid inputs are those listed in  `net.cell_types`.
-        amplitude: dict or float
-            If cell_types is None, amplitude should be a dictionary where the
-            keys are cell_types(str) that will receive the tonic input,
-            and the values are the amplitudes of the input.
+        amplitude: dict | float
+            A dictionary of cell type keys (str) to amplitude values (float).
             Valid inputs for cell types are those listed in `net.cell_types`.
             If `cell_types` is not None, `amplitude` should be
             a float indicating the amplitude of the tonic input
             for the specified cell type.
         t0 : float
             The start time of tonic input (in ms). Default: 0 (beginning of
-            simulation). This value will be applied to all the cells in
-            cell_types_amplitudes
+            simulation). This value will be applied to all the  tonic biases if
+            multiple are specified with the `amplitude` keyword.
         tstop : float
             The end time of tonic input (in ms). Default: end of simulation.
-            This value will be applied to all the cells in
-            cell_types_amplitudes
+            This value will be applied to all the  tonic biases if
+            multiple are specified with the `amplitude` keyword.
         """
 
         # old functionality single cell type - amplitude

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -39,7 +39,10 @@ def jones_2009_network(params):
                            mesh_shape=(3, 3))
 
     # Adding bias
-    net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0)
+    tonic_bias = {
+        'L2_pyramidal': 1.0
+    }
+    net.add_tonic_bias(cell_types_amplitudes=tonic_bias)
 
     # Add drives
     location = 'proximal'
@@ -76,7 +79,10 @@ def calcium_network(params):
                         mesh_shape=(3, 3))
 
     # Adding bias
-    net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0)
+    tonic_bias = {
+        'L2_pyramidal': 1.0
+    }
+    net.add_tonic_bias(cell_types_amplitudes=tonic_bias)
 
     # Adding electrode arrays
     electrode_pos = (1, 2, 3)

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -42,7 +42,7 @@ def jones_2009_network(params):
     tonic_bias = {
         'L2_pyramidal': 1.0
     }
-    net.add_tonic_bias(cell_types_amplitudes=tonic_bias)
+    net.add_tonic_bias(amplitude=tonic_bias)
 
     # Add drives
     location = 'proximal'
@@ -82,7 +82,7 @@ def calcium_network(params):
     tonic_bias = {
         'L2_pyramidal': 1.0
     }
-    net.add_tonic_bias(cell_types_amplitudes=tonic_bias)
+    net.add_tonic_bias(amplitude=tonic_bias)
 
     # Adding electrode arrays
     electrode_pos = (1, 2, 3)

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -762,28 +762,48 @@ def test_tonic_biases():
     }
 
     with pytest.raises(ValueError, match=r'cell_type must be one of .*$'):
-        net.add_tonic_bias(cell_types_amplitudes=tonic_bias_1, t0=0.0,
+        net.add_tonic_bias(amplitude=tonic_bias_1, t0=0.0,
                            tstop=4.0)
+
     tonic_bias_2 = {
         'L2_pyramidal': 1.0
     }
 
     with pytest.raises(ValueError, match='Duration of tonic input cannot be'
                        ' negative'):
-        net.add_tonic_bias(cell_types_amplitudes=tonic_bias_2,
+        net.add_tonic_bias(amplitude=tonic_bias_2,
                            t0=5.0, tstop=4.0)
         simulate_dipole(net, tstop=20.)
     net.external_biases = dict()
 
     with pytest.raises(ValueError, match='End time of tonic input cannot be'
                        ' negative'):
-        net.add_tonic_bias(cell_types_amplitudes=tonic_bias_2,
+        net.add_tonic_bias(amplitude=tonic_bias_2,
                            t0=5.0, tstop=-1.0)
         simulate_dipole(net, tstop=5.)
 
     with pytest.raises(ValueError, match='parameter may be missing'):
         params['Itonic_T_L2Pyr_soma'] = 5.0
         net = Network(params, add_drives_from_params=True)
+
+    # test adding single cell_type - amplitude (old API)
+    net.external_biases = dict()
+    with pytest.raises(ValueError, match=r'cell_type must be one of .*$'):
+        net.add_tonic_bias(cell_type='name_nonexistent', amplitude=1.0,
+                           t0=0.0, tstop=4.0)
+
+    with pytest.raises(ValueError, match='Duration of tonic input cannot be'
+                       ' negative'):
+        net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
+                           t0=5.0, tstop=4.0)
+        simulate_dipole(net, tstop=20.)
+    net.external_biases = dict()
+
+    with pytest.raises(ValueError, match='End time of tonic input cannot be'
+                       ' negative'):
+        net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
+                           t0=5.0, tstop=-1.0)
+        simulate_dipole(net, tstop=5.)
 
     params.update({
         'N_pyr_x': 3, 'N_pyr_y': 3,
@@ -804,12 +824,12 @@ def test_tonic_biases():
 
     # new API
     net = Network(params)
-    net.add_tonic_bias(cell_types_amplitudes=tonic_bias_2)
+    net.add_tonic_bias(amplitude=tonic_bias_2)
     assert 'tonic' in net.external_biases
     assert 'L5_pyramidal' not in net.external_biases['tonic']
     assert net.external_biases['tonic']['L2_pyramidal']['t0'] == 0
     with pytest.raises(ValueError, match=r'Tonic bias already defined for.*$'):
-        net.add_tonic_bias(cell_types_amplitudes=tonic_bias_2)
+        net.add_tonic_bias(amplitude=tonic_bias_2)
 
 
 def test_network_mesh():

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -756,20 +756,28 @@ def test_tonic_biases():
                        target_gids='L2_basket',
                        loc='soma', receptor='ampa', weight=1e-3,
                        delay=1.0, lamtha=3.0)
+
+    tonic_bias_1 = {
+        'name_nonexistent': 1.0
+    }
+
     with pytest.raises(ValueError, match=r'cell_type must be one of .*$'):
-        net.add_tonic_bias(cell_type='name_nonexistent', amplitude=1.0,
-                           t0=0.0, tstop=4.0)
+        net.add_tonic_bias(cell_types_amplitudes=tonic_bias_1, t0=0.0,
+                           tstop=4.0)
+    tonic_bias_2 = {
+        'L2_pyramidal': 1.0
+    }
 
     with pytest.raises(ValueError, match='Duration of tonic input cannot be'
                        ' negative'):
-        net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
+        net.add_tonic_bias(cell_types_amplitudes=tonic_bias_2,
                            t0=5.0, tstop=4.0)
         simulate_dipole(net, tstop=20.)
     net.external_biases = dict()
 
     with pytest.raises(ValueError, match='End time of tonic input cannot be'
                        ' negative'):
-        net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
+        net.add_tonic_bias(cell_types_amplitudes=tonic_bias_2,
                            t0=5.0, tstop=-1.0)
         simulate_dipole(net, tstop=5.)
 
@@ -796,12 +804,12 @@ def test_tonic_biases():
 
     # new API
     net = Network(params)
-    net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0)
+    net.add_tonic_bias(cell_types_amplitudes=tonic_bias_2)
     assert 'tonic' in net.external_biases
     assert 'L5_pyramidal' not in net.external_biases['tonic']
     assert net.external_biases['tonic']['L2_pyramidal']['t0'] == 0
     with pytest.raises(ValueError, match=r'Tonic bias already defined for.*$'):
-        net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0)
+        net.add_tonic_bias(cell_types_amplitudes=tonic_bias_2)
 
 
 def test_network_mesh():

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -758,15 +758,23 @@ def test_tonic_biases():
                        delay=1.0, lamtha=3.0)
 
     tonic_bias_1 = {
+        'L2_pyramidal': 1.0,
         'name_nonexistent': 1.0
     }
 
     with pytest.raises(ValueError, match=r'cell_type must be one of .*$'):
         net.add_tonic_bias(amplitude=tonic_bias_1, t0=0.0,
                            tstop=4.0)
+    net.external_biases = dict()
+
+    with pytest.raises(TypeError,
+                       match='amplitude must be an instance of dict'):
+        net.add_tonic_bias(amplitude=0.1,
+                           t0=5.0, tstop=-1.0)
 
     tonic_bias_2 = {
-        'L2_pyramidal': 1.0
+        'L2_pyramidal': 1.0,
+        'L5_basket': 0.5
     }
 
     with pytest.raises(ValueError, match='Duration of tonic input cannot be'
@@ -781,29 +789,44 @@ def test_tonic_biases():
         net.add_tonic_bias(amplitude=tonic_bias_2,
                            t0=5.0, tstop=-1.0)
         simulate_dipole(net, tstop=5.)
+    net.external_biases = dict()
 
     with pytest.raises(ValueError, match='parameter may be missing'):
         params['Itonic_T_L2Pyr_soma'] = 5.0
         net = Network(params, add_drives_from_params=True)
+    net.external_biases = dict()
 
     # test adding single cell_type - amplitude (old API)
-    net.external_biases = dict()
     with pytest.raises(ValueError, match=r'cell_type must be one of .*$'):
-        net.add_tonic_bias(cell_type='name_nonexistent', amplitude=1.0,
-                           t0=0.0, tstop=4.0)
+        with pytest.warns(DeprecationWarning,
+                          match=r'cell_type argument will be deprecated'):
+            net.add_tonic_bias(cell_type='name_nonexistent', amplitude=1.0,
+                               t0=0.0, tstop=4.0)
+
+    with pytest.raises(TypeError,
+                       match='amplitude must be an instance of float'):
+        with pytest.warns(DeprecationWarning,
+                          match=r'cell_type argument will be deprecated'):
+            net.add_tonic_bias(cell_type='L5_pyramidal',
+                               amplitude={'L2_pyramidal': 0.1},
+                               t0=5.0, tstop=-1.0)
 
     with pytest.raises(ValueError, match='Duration of tonic input cannot be'
                        ' negative'):
-        net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
-                           t0=5.0, tstop=4.0)
-        simulate_dipole(net, tstop=20.)
+        with pytest.warns(DeprecationWarning,
+                          match=r'cell_type argument will be deprecated'):
+            net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
+                               t0=5.0, tstop=4.0)
+            simulate_dipole(net, tstop=20.)
     net.external_biases = dict()
 
     with pytest.raises(ValueError, match='End time of tonic input cannot be'
                        ' negative'):
-        net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
-                           t0=5.0, tstop=-1.0)
-        simulate_dipole(net, tstop=5.)
+        with pytest.warns(DeprecationWarning,
+                          match=r'cell_type argument will be deprecated'):
+            net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
+                               t0=5.0, tstop=-1.0)
+            simulate_dipole(net, tstop=5.)
 
     params.update({
         'N_pyr_x': 3, 'N_pyr_y': 3,

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -765,6 +765,10 @@ def test_tonic_biases():
     with pytest.raises(ValueError, match=r'cell_type must be one of .*$'):
         net.add_tonic_bias(amplitude=tonic_bias_1, t0=0.0,
                            tstop=4.0)
+
+    # The previous test only adds L2_pyramidal and ignores name_nonexistent
+    # Testing the fist bias was added
+    assert net.external_biases['tonic']['L2_pyramidal'] is not None
     net.external_biases = dict()
 
     with pytest.raises(TypeError,
@@ -804,7 +808,7 @@ def test_tonic_biases():
                                t0=0.0, tstop=4.0)
 
     with pytest.raises(TypeError,
-                       match='amplitude must be an instance of float'):
+                       match='amplitude must be an instance of float or int'):
         with pytest.warns(DeprecationWarning,
                           match=r'cell_type argument will be deprecated'):
             net.add_tonic_bias(cell_type='L5_pyramidal',
@@ -815,7 +819,7 @@ def test_tonic_biases():
                        ' negative'):
         with pytest.warns(DeprecationWarning,
                           match=r'cell_type argument will be deprecated'):
-            net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1.0,
+            net.add_tonic_bias(cell_type='L2_pyramidal', amplitude=1,
                                t0=5.0, tstop=4.0)
             simulate_dipole(net, tstop=20.)
     net.external_biases = dict()


### PR DESCRIPTION
- Refactor `network.add_tonic_bias` to accept a dictionary of cell types and their amplitudes.
- Changed how drivers create tonic inputs
- Adjusted unit tests to the new `network.add_tonic_bias` arguments