### PR TITLE
[MRG] Make all plots with time end at tstop 

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -64,6 +64,10 @@ Changelog
 - Added GUI feature to include Tonic input drives in simulations, 
   by `Camilo Diaz` :gh:`773`
 
+- :func:`~plot_laminar_lfp`, :func:`~plot_dipole`, :func:`~plot_spikes_hist`, 
+  and :func:`~plot_spikes_raster` now plotted from 0 to tstop. Inputs tmin and tmax are deprecated,
+  by `Aritra Sinha`_, `Tianqi Cheng`_, and `Katharina Duecker`_ in :gh:`769`
+
 Bug
 ~~~
 - Fix inconsistent connection mapping from drive gids to cell gids, by

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,7 +66,7 @@ Changelog
 
 - :func:`~plot_laminar_lfp`, :func:`~plot_dipole`, :func:`~plot_spikes_hist`, 
   and :func:`~plot_spikes_raster` now plotted from 0 to tstop. Inputs tmin and tmax are deprecated,
-  by `Aritra Sinha`_, `Tianqi Cheng`_, and `Katharina Duecker`_ in :gh:`769`
+  by `Katharina Duecker`_ in :gh:`769`
 
 Bug
 ~~~
@@ -497,3 +497,4 @@ People who contributed to this release (in alphabetical order):
 .. _George Dang: https://github.com/gtdang
 .. _Camilo Diaz: https://github.com/kmilo9999
 .. _Abdul Samad Siddiqui: https://github.com/samadpls
+.. _Katharina Duecker: https://github.com/katduecker

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -474,10 +474,6 @@ class Dipole(object):
 
         Parameters
         ----------
-        tmin : float or None
-            Start time of plot (in ms). If None, plot entire simulation.
-        tmax : float or None
-            End time of plot (in ms). If None, plot entire simulation.
         layer : str
             The layer to plot. Can be one of 'agg', 'L2', and 'L5'
         decimate : int
@@ -494,6 +490,7 @@ class Dipole(object):
         fig : instance of plt.fig
             The matplotlib figure handle.
         """
+        
         return plot_dipole(self, tmin=tmin, tmax=tmax, ax=ax, layer=layer,
                            decim=decim, color=color, show=show)
 

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -490,7 +490,7 @@ class Dipole(object):
         fig : instance of plt.fig
             The matplotlib figure handle.
         """
-        
+
         return plot_dipole(self, tmin=tmin, tmax=tmax, ax=ax, layer=layer,
                            decim=decim, color=color, show=show)
 

--- a/hnn_core/extracellular.py
+++ b/hnn_core/extracellular.py
@@ -457,11 +457,6 @@ class ExtracellularArray:
             Trial number(s) to plot
         contact_no : int | list of int | slice
             Electrode contact number(s) to plot
-        tmin : float | None
-            Start time of plot in milliseconds. If None, plot entire
-            simulation.
-        tmax : float | None
-            End time of plot in milliseconds. If None, plot entire simulation.
         ax : instance of matplotlib figure | None
             The matplotlib axis
         decim : int | list of int | None (default)

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -258,3 +258,21 @@ def test_rec_array_calculation():
         assert_allclose(net.rec_arrays['arr1']._data[trial_idx][1],
                         net.rec_arrays['arr2']._data[trial_idx][1],
                         rtol=1e-3, atol=1e-3)
+
+def test_extracellular_viz():
+    """Test if deprecation warning is raised in plot_laminar_lfp."""
+    hnn_core_root = op.dirname(hnn_core.__file__)
+    params_fname = op.join(hnn_core_root, 'param', 'default.json')
+    params = read_params(params_fname)
+    params.update({'t_evprox_1': 7, 't_evdist_1': 17})
+    net = jones_2009_model(params, mesh_shape=(3, 3),
+                           add_drives_from_params=True)
+
+    # one electrode inside, one above the active elements of the network,
+    # and two more to allow calculation of CSD (2nd spatial derivative)
+    electrode_pos = [(1, 2, 1000), (2, 3, 3000), (3, 4, 5000), (4, 5, 7000)]
+    net.add_electrode_array('arr1', electrode_pos)
+    _ = simulate_dipole(net, tstop=5, n_trials=1)
+
+    with pytest.deprecated_call():
+        net.rec_arrays['arr1'].plot_lfp(show=False, tmin=10, tmax=100)

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -259,6 +259,7 @@ def test_rec_array_calculation():
                         net.rec_arrays['arr2']._data[trial_idx][1],
                         rtol=1e-3, atol=1e-3)
 
+
 def test_extracellular_viz():
     """Test if deprecation warning is raised in plot_laminar_lfp."""
     hnn_core_root = op.dirname(hnn_core.__file__)

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -194,6 +194,10 @@ def test_dipole_visualization(setup_net):
         dpl_sfreq.sfreq /= 10
         plot_psd([dpls[0], dpl_sfreq])
 
+    # pytest deprecation warning for tmin and tmax
+    with pytest.deprecated_call():
+        plot_dipole(dpls[0], show=False, tmin=10, tmax=100)
+
     # test cell response plotting
     with pytest.raises(TypeError, match="trial_idx must be an instance of"):
         net.cell_response.plot_spikes_raster(trial_idx='blah', show=False)

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -180,7 +180,7 @@ def plot_laminar_lfp(times, data, contact_labels, tmin=None, tmax=None,
             col = color
         ax.plot(plot_times, plot_data + trace_offsets[contact_no],
                 label=f'C{contact_no}', color=col)
-        
+
         # To be removed after deprecation cycle
         if tmin is not None or tmax is not None:
             ax.set_xlim(left=tmin, right=tmax)
@@ -291,7 +291,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
 
             if layer in dpl_trial.data.keys():
 
-                 # extract scaled data and times
+                # extract scaled data and times
                 data = dpl_trial.data[layer]
                 times = dpl_trial.times
 
@@ -304,7 +304,7 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
                     alpha = 0.5 if average else 1.
                     ax.plot(times, data, color=_lighten_color(color, 0.5),
                             alpha=alpha, lw=1.)
-            
+
             # To be removed after deprecation cycle
             if tmin is not None or tmax is not None:
                 if tmin is not None or tmax is not None:
@@ -491,7 +491,7 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
         hist_color = spike_color[spike_label]
         ax.hist(plot_data, bins,
                 label=spike_label, color=hist_color, **kwargs_hist)
-        
+
     if len(cell_response.times) > 0:
         ax.set_xlim(left=0, right=cell_response.times[-1])
     else:
@@ -579,7 +579,6 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
         ax.set_xlim(left=0, right=cell_response.times[-1])
     else:
         ax.set_xlim(left=0)
-        
     ax.set_xlim(left=0)
 
     plt_show(show)


### PR DESCRIPTION
This pull request supersedes PR[#752](https://github.com/jonescompneurolab/hnn-core/pull/752)

The x/time-axis of all plots now ends at tstop. Deprecation cycle for tmin and tmax added to plot_laminar_lfp, plot_dipole. tmin and tmax are still required for plot_psd and plot_tfr_morlet.