### PR TITLE
[MRG] Update legacy json and param conversion function for new json format

### DIFF
--- a/dev_scripts/convert_params.py
+++ b/dev_scripts/convert_params.py
@@ -10,7 +10,9 @@ import tempfile
 from pathlib import Path
 from requests.exceptions import HTTPError
 
-from hnn_core import convert_to_hdf5
+from hnn_core import convert_to_json
+
+root_path = Path(__file__).parents[1]
 
 
 def download_folder_contents(owner, repo, path):
@@ -49,7 +51,7 @@ def download_folder_contents(owner, repo, path):
     return temp_dir
 
 
-def convert_param_files_from_repo(owner, repo, path):
+def convert_param_files_from_repo(owner, repo, repo_path, local_path):
     """Converts param and json parameter files to a hdf5 file.
 
     Parameters
@@ -66,17 +68,19 @@ def convert_param_files_from_repo(owner, repo, path):
     None
     """
     # Download param files
-    temp_dir = download_folder_contents(owner, repo, path)
+    temp_dir = download_folder_contents(owner, repo, repo_path)
     # Get list of json and param files
     file_list = [Path(temp_dir, f)
                  for f in os.listdir(temp_dir)
                  if f.endswith('.param') or f.endswith('.json')]
     # Assign output location and names
-    output_dir = Path(__file__).parents[1] / 'hnn_core' / 'param'
+    output_dir = Path(local_path)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
     output_filenames = [Path(output_dir, f.name.split('.')[0])
                         for f in file_list]
 
-    [convert_to_hdf5(file, outfile)
+    [convert_to_json(file, outfile)
      for (file, outfile) in zip(file_list, output_filenames)]
 
     # Delete downloads
@@ -88,8 +92,14 @@ if __name__ == '__main__':
     # hnn param files
     convert_param_files_from_repo(owner='jonescompneurolab',
                                   repo='hnn',
-                                  path='param')
+                                  repo_path='param',
+                                  local_path=(root_path /
+                                              'network_configuration'),
+                                  )
     # hnn-core json files
     convert_param_files_from_repo(owner='jonescompneurolab',
                                   repo='hnn-core',
-                                  path='hnn_core/param')
+                                  repo_path='hnn_core/param',
+                                  local_path=(root_path /
+                                              'network_configuration'),
+                                  )

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,8 +65,8 @@ Changelog
   and :func:`~plot_spikes_raster` now plotted from 0 to tstop. Inputs tmin and tmax are deprecated,
   by `Katharina Duecker`_ in :gh:`769`
 
-- Add feature to convert legacy param and json files to new json format,
-  by `George Dang`_ in :gh:`772`
+- Add function :func:`~hnn_core/params/convert_to_json` to convert legacy param
+  and json files to new json format, by `George Dang`_ in :gh:`772`
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,9 +29,6 @@ Changelog
 
 - Add ability to specify number of cells in :class:`~hnn_core.Network`,
   by `Nick Tolley`_ in :gh:`705`
-
-- Add feature to convert param and json files to HDF5 format, by `George Dang`_
-  in :gh:`723`
   
 - Fixed figure annotation overlap in multiple sub-plots, 
   by `Camilo Diaz`_ in :gh:`741`
@@ -61,12 +58,15 @@ Changelog
 - Added :class:`~hnn_core/viz/NetworkPlotter` to visualize and animate network simulations,
   by `Nick Tolley`_ in :gh:`649`.
 
-- Added GUI feature to include Tonic input drives in simulations, 
+- Added GUI feature to include Tonic input drives in simulations,
   by `Camilo Diaz` :gh:`773`
 
-- :func:`~plot_laminar_lfp`, :func:`~plot_dipole`, :func:`~plot_spikes_hist`, 
+- :func:`~plot_laminar_lfp`, :func:`~plot_dipole`, :func:`~plot_spikes_hist`,
   and :func:`~plot_spikes_raster` now plotted from 0 to tstop. Inputs tmin and tmax are deprecated,
   by `Katharina Duecker`_ in :gh:`769`
+
+- Add feature to convert legacy param and json files to new json format,
+  by `George Dang`_ in :gh:`772`
 
 Bug
 ~~~

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -1,5 +1,5 @@
-from .dipole import simulate_dipole, read_dipole, average_dipoles, Dipole
-from .params import Params, read_params, convert_to_hdf5
+from .dipole import simulate_dipole, read_dipole, average_dipoles, Dipole,_read_dipole_txt
+from .params import Params, read_params, convert_to_json
 from .network import Network, pick_connection
 from .network_models import jones_2009_model, law_2021_model, calcium_model
 from .cell import Cell

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -664,7 +664,7 @@ def compare_dictionaries(d1, d2):
 
 def convert_to_json(params_fname,
                     out_fname,
-                    network_connectivity='jones_2009_model',
+                    model_template='jones_2009_model',
                     include_drives=True,
                     overwrite=True):
     """Converts legacy json or param format to hierarchical json format
@@ -675,7 +675,7 @@ def convert_to_json(params_fname,
         Path to file
     out_fname: str
         Path to output
-    network_connectivity: str or None, default:' jones_2009_model'
+    model_template: str or None, default:' jones_2009_model'
          Options: ['jones_2009_model', 'law_2021_model', 'calcium_model', None]
          Neocortical network model to use. Models are defined in
          network_models. If None, the base Network object with no defined
@@ -696,12 +696,12 @@ def convert_to_json(params_fname,
                        'law_2021_model': law_2021_model,
                        'calcium_model': calcium_model
                        }
-    if network_connectivity:
+    if model_template:
         try:
-            network_model = model_functions[network_connectivity]
+            network_model = model_functions[model_template]
         except KeyError:
             raise KeyError(f'Invalid network connectivity: '
-                           f'"{network_connectivity}"; '
+                           f'"{model_template}"; '
                            f'Valid options: {list(model_functions.keys())}')
     else:
         network_model = Network

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -662,9 +662,9 @@ def compare_dictionaries(d1, d2):
     return d1
 
 
-def convert_to_hdf5(params_fname, out_fname, include_drives=True,
-                    overwrite=True, write_output=False):
-    """Converts json or param format to hdf5
+def convert_to_json(params_fname, out_fname, include_drives=True,
+                    overwrite=True):
+    """Converts legacy json or param format to hierarchical json format
 
     Parameters
     ----------
@@ -676,8 +676,6 @@ def convert_to_hdf5(params_fname, out_fname, include_drives=True,
         Include drives from params file
     overwrite: bool, default=True
         Overwrite file
-    write_output: bool, default=False
-        Write out simulations
     Returns
     -------
     None
@@ -692,17 +690,16 @@ def convert_to_hdf5(params_fname, out_fname, include_drives=True,
     params_suffix = params_fname.suffix.lower().split('.')[-1]
 
     # Add suffix if not supplied
-    if out_fname.suffix != '.hdf5':
-        out_fname = out_fname.with_suffix('.hdf5')
+    if out_fname.suffix != '.json':
+        out_fname = out_fname.with_suffix('.json')
 
     net = Network(params=read_params(params_fname),
                   add_drives_from_params=include_drives,
                   legacy_mode=True if params_suffix == 'param' else False,
                   )
-    net.write(fname=out_fname,
-              overwrite=overwrite,
-              write_output=write_output,
-              )
+    net.write_configuration(fname=out_fname,
+                            overwrite=overwrite,
+                            )
     return
 
 

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -662,7 +662,10 @@ def compare_dictionaries(d1, d2):
     return d1
 
 
-def convert_to_json(params_fname, out_fname, include_drives=True,
+def convert_to_json(params_fname,
+                    out_fname,
+                    network_connectivity='jones_2009_model',
+                    include_drives=True,
                     overwrite=True):
     """Converts legacy json or param format to hierarchical json format
 
@@ -672,6 +675,11 @@ def convert_to_json(params_fname, out_fname, include_drives=True,
         Path to file
     out_fname: str
         Path to output
+    network_connectivity: str or None, default:' jones_2009_model'
+         Options: ['jones_2009_model', 'law_2021_model', 'calcium_model', None]
+         Neocortical network model to use. Models are defined in network_models.
+         If None, the base Network object with no defined network connectivity
+         will be used.
     include_drives: bool, default=True
         Include drives from params file
     overwrite: bool, default=True
@@ -681,6 +689,23 @@ def convert_to_json(params_fname, out_fname, include_drives=True,
     None
     """
     from .network import Network
+    from .network_models import jones_2009_model, law_2021_model, calcium_model
+
+    # Assign network model callables
+    model_functions = {'jones_2009_model': jones_2009_model,
+                       'law_2021_model': law_2021_model,
+                       'calcium_model': calcium_model
+                       }
+    if network_connectivity:
+        try:
+            network_model = model_functions[network_connectivity]
+        except KeyError:
+            raise KeyError(f'Invalid network connectivity: '
+                           f'"{network_connectivity}"; '
+                           f'Valid options: {list(model_functions.keys())}')
+    else:
+        network_model = Network
+
     # Validate inputs
     _validate_type(params_fname, (str, Path), 'params_fname')
     _validate_type(out_fname, (str, Path), 'out_fname')
@@ -693,10 +718,12 @@ def convert_to_json(params_fname, out_fname, include_drives=True,
     if out_fname.suffix != '.json':
         out_fname = out_fname.with_suffix('.json')
 
-    net = Network(params=read_params(params_fname),
-                  add_drives_from_params=include_drives,
-                  legacy_mode=True if params_suffix == 'param' else False,
-                  )
+    net = network_model(params=read_params(params_fname),
+                        add_drives_from_params=include_drives,
+                        legacy_mode=(True if params_suffix == 'param'
+                                     else False),
+                        )
+
     net.write_configuration(fname=out_fname,
                             overwrite=overwrite,
                             )

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -677,9 +677,9 @@ def convert_to_json(params_fname,
         Path to output
     network_connectivity: str or None, default:' jones_2009_model'
          Options: ['jones_2009_model', 'law_2021_model', 'calcium_model', None]
-         Neocortical network model to use. Models are defined in network_models.
-         If None, the base Network object with no defined network connectivity
-         will be used.
+         Neocortical network model to use. Models are defined in
+         network_models. If None, the base Network object with no defined
+         network connectivity will be used.
     include_drives: bool, default=True
         Include drives from params file
     overwrite: bool, default=True

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -215,7 +215,7 @@ def test_cell_response_to_dict(jones_2009_network):
     result2 = _cell_response_to_dict(net, write_output=True)
     assert bool(result2) and isinstance(result2, dict)
 
-    # Check for None if kw supplied
+    # Check for empty dict if kw supplied
     result3 = _cell_response_to_dict(net, write_output=False)
     assert result3 == dict()
 

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -126,7 +126,7 @@ class TestConvertToJson:
         outpath = Path(tmp_path, 'default.json')
         convert_to_json(self.path_default,
                         outpath,
-                        network_connectivity='law_2021_model')
+                        model_template='law_2021_model')
         net_json = read_network_configuration(outpath)
         assert net_json == net_params
 
@@ -141,7 +141,7 @@ class TestConvertToJson:
         outpath = Path(tmp_path, 'default.json')
         convert_to_json(self.path_default,
                         outpath,
-                        network_connectivity='calcium_model')
+                        model_template='calcium_model')
         net_json = read_network_configuration(outpath)
         assert net_json == net_params
 
@@ -156,7 +156,7 @@ class TestConvertToJson:
         outpath = Path(tmp_path, 'default.json')
         convert_to_json(self.path_default,
                         outpath,
-                        network_connectivity=None)
+                        model_template=None)
         net_json = read_network_configuration(outpath)
         assert net_json == net_params
 
@@ -186,7 +186,7 @@ class TestConvertToJson:
         good_path = hnn_core_root
         path_str = str(good_path)
         bad_path = 5
-        bad_network_conn = 'bad_model'
+        bad_model = 'bad_model'
 
         # Valid path and string, but not actual files
         with pytest.raises(
@@ -209,10 +209,10 @@ class TestConvertToJson:
         ):
             convert_to_json(good_path, bad_path)
 
-        # Bad network_connectivity
+        # Bad model_template
         with pytest.raises(
                 KeyError,
                 match="Invalid network connectivity:"
         ):
             convert_to_json(good_path, good_path,
-                            network_connectivity=bad_network_conn)
+                            model_template=bad_model)

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -159,6 +159,8 @@ class TestConvertToJson:
                         model_template=None)
         net_json = read_network_configuration(outpath)
         assert net_json == net_params
+        # Should only have external drive connections defined, n=22
+        assert len(net_json.connectivity) == len(net_params.connectivity) == 22
 
     def test_convert_to_json_legacy(self, tmp_path):
         """Tests conversion of a param legacy file to json"""


### PR DESCRIPTION
This changes the convert_to_hdf5 function to convert_to_json. 
* The function converts legacy flat json and param files to the new hierarchical json format. 
* It also adds network connectivity. By default it uses the Jones 2009 model for the connectivity but supports the other pre-defined network models. No network connectivity can be added by supplying None.

Question:
* Should the default be None instead of the Jones 2009 for adding network connectivity? 