### PR TITLE
MAINT: Fixed load data button size

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -238,6 +238,7 @@ class HNNGUI:
         self.load_data_button = FileUpload(
             accept='.txt,.csv', multiple=False,
             style={'button_color': self.layout['theme_color']},
+            layout=self.layout['btn'],
             description='Load data',
             button_style='success')
 


### PR DESCRIPTION
Just a quick fix on the load data button style.

![image](https://github.com/jonescompneurolab/hnn-core/assets/16551165/aafe0eba-a291-4f38-8d6b-3cc42f884ade)
