### PR TITLE
[MRG] Replace `np.in1d()` with `np.isin()`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,6 +68,9 @@ Changelog
   and :func:`~plot_spikes_raster` now plotted from 0 to tstop. Inputs tmin and tmax are deprecated,
   by `Katharina Duecker`_ in :gh:`769`
 
+- Use `np.isin()` in place of `np.in1d()` to address numpy deprecation,
+  by `Nick Tolley`_ in :gh:`799
+
 Bug
 ~~~
 - Fix inconsistent connection mapping from drive gids to cell gids, by

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,7 +69,7 @@ Changelog
   by `Katharina Duecker`_ in :gh:`769`
 
 - Use `np.isin()` in place of `np.in1d()` to address numpy deprecation,
-  by `Nick Tolley`_ in :gh:`799
+  by `Nick Tolley`_ in :gh:`799.
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,9 +68,6 @@ Changelog
   and :func:`~plot_spikes_raster` now plotted from 0 to tstop. Inputs tmin and tmax are deprecated,
   by `Katharina Duecker`_ in :gh:`769`
 
-- Use `np.isin()` in place of `np.in1d()` to address numpy deprecation,
-  by `Nick Tolley`_ in :gh:`799.
-
 Bug
 ~~~
 - Fix inconsistent connection mapping from drive gids to cell gids, by
@@ -84,6 +81,9 @@ Bug
 
 - Fix loading of drives in the GUI: drives are now overwritten instead of updated,
   by `Mainak Jas`_ in :gh:`795`.
+
+- Use `np.isin()` in place of `np.in1d()` to address numpy deprecation,
+  by `Nick Tolley`_ in :gh:`799.
 
 API
 ~~~

--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -180,7 +180,7 @@ class CellResponse(object):
         vsoma_slice = list()
         isoma_slice = list()
         for trial_idx in range(n_trials):
-            gid_mask = np.in1d(self._spike_gids[trial_idx], gid_item)
+            gid_mask = np.isin(self._spike_gids[trial_idx], gid_item)
             times_trial = np.array(
                 self._spike_times[trial_idx])[gid_mask].tolist()
             gids_trial = np.array(
@@ -258,7 +258,7 @@ class CellResponse(object):
             spike_types_trial = np.empty_like(self._spike_times[trial_idx],
                                               dtype='<U36')
             for gidtype, gids in gid_ranges.items():
-                spike_gids_mask = np.in1d(self._spike_gids[trial_idx], gids)
+                spike_gids_mask = np.isin(self._spike_gids[trial_idx], gids)
                 spike_types_trial[spike_gids_mask] = gidtype
             spike_types += [list(spike_types_trial)]
         self._spike_types = spike_types
@@ -309,11 +309,11 @@ class CellResponse(object):
 
             trial_data = zip(self._spike_types, self._spike_gids)
             for trial_idx, (spike_types, spike_gids) in enumerate(trial_data):
-                trial_type_mask = np.in1d(spike_types, cell_type)
+                trial_type_mask = np.isin(spike_types, cell_type)
                 gids, gid_counts = np.unique(np.array(
                     spike_gids)[trial_type_mask], return_counts=True)
 
-                gid_spike_rate[trial_idx, np.in1d(cell_type_gids, gids)] = (
+                gid_spike_rate[trial_idx, np.isin(cell_type_gids, gids)] = (
                     gid_counts / (tstop - tstart)) * 1000
 
             if mean_type == 'all':

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -24,8 +24,7 @@ from hnn_core import (JoblibBackend, MPIBackend, jones_2009_model, read_params,
 from hnn_core.gui._logging import logger
 from hnn_core.gui._viz_manager import _VizManager, _idx2figname
 from hnn_core.network import pick_connection
-from hnn_core.params import (_extract_drive_specs_from_hnn_params, _read_json,
-                             _read_legacy_params)
+from hnn_core.params import _extract_drive_specs_from_hnn_params
 from hnn_core.dipole import _read_dipole_txt
 
 import base64
@@ -1227,8 +1226,8 @@ def add_connectivity_tab(params, connectivity_out,
     return net
 
 
-def add_drive_tab(params, log_out, drives_out, drive_widgets, drive_boxes, tstop,
-                  layout):
+def add_drive_tab(params, log_out, drives_out, drive_widgets, drive_boxes,
+                  tstop, layout):
     net = jones_2009_model(params)
 
     drive_specs = _extract_drive_specs_from_hnn_params(
@@ -1277,8 +1276,8 @@ def load_drive_and_connectivity(params, log_out, drives_out,
         # Add connectivity
         add_connectivity_tab(params, connectivity_out, connectivity_textfields)
         # Add drives
-        add_drive_tab(params, log_out, drives_out, drive_widgets, drive_boxes, tstop,
-                      layout)
+        add_drive_tab(params, log_out, drives_out, drive_widgets, drive_boxes,
+                      tstop, layout)
 
 
 def on_upload_data_change(change, data, viz_manager, log_out):
@@ -1339,8 +1338,8 @@ def on_upload_params_change(change, tstop, dt, log_out, drive_boxes,
         add_connectivity_tab(params, connectivity_out, connectivity_textfields)
     elif load_type == 'drives':
         with log_out:
-            add_drive_tab(params, log_out, drives_out, drive_widgets, drive_boxes, tstop,
-                          layout)
+            add_drive_tab(params, log_out, drives_out, drive_widgets,
+                          drive_boxes, tstop, layout)
     else:
         raise ValueError
     # Resets file counter to 0

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1299,7 +1299,7 @@ class Network:
         gid_pairs = dict()
         for src_gid, target_src_pair in zip(src_gids, target_gids):
             if not allow_autapses:
-                mask = np.in1d(target_src_pair, src_gid, invert=True)
+                mask = np.isin(target_src_pair, src_gid, invert=True)
                 target_src_pair = np.array(target_src_pair)[mask].tolist()
             gid_pairs[src_gid] = target_src_pair
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -412,7 +412,7 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
         spike_types_data = np.array([])
 
     unique_types = np.unique(spike_types_data)
-    spike_types_mask = {s_type: np.in1d(spike_types_data, s_type)
+    spike_types_mask = {s_type: np.isin(spike_types_data, s_type)
                         for s_type in unique_types}
     cell_types = ['L5_pyramidal', 'L5_basket', 'L2_pyramidal', 'L2_basket']
     input_types = np.setdiff1d(unique_types, cell_types)
@@ -1018,7 +1018,7 @@ def plot_connectivity_matrix(net, conn_idx, ax=None, show_weight=True,
 
     for src_gid, target_src_pair in conn['gid_pairs'].items():
         src_idx = np.where(src_range == src_gid)[0][0]
-        target_indeces = np.where(np.in1d(target_range, target_src_pair))[0]
+        target_indeces = np.where(np.isin(target_range, target_src_pair))[0]
         for target_idx in target_indeces:
             src_pos = src_type_pos[src_idx]
             target_pos = target_type_pos[target_idx]
@@ -1068,7 +1068,7 @@ def _update_target_plot(ax, conn, src_gid, src_type_pos, target_type_pos,
     # Extract indices to get position in network
     # Index in gid range aligns with net.pos_dict
     target_src_pair = conn['gid_pairs'][src_gid]
-    target_indeces = np.where(np.in1d(target_range, target_src_pair))[0]
+    target_indeces = np.where(np.isin(target_range, target_src_pair))[0]
 
     src_idx = np.where(src_range == src_gid)[0][0]
     src_pos = src_type_pos[src_idx]
@@ -1155,7 +1155,7 @@ def plot_cell_connectivity(net, conn_idx, src_gid=None, axes=None,
     src_range = np.array(net.gid_ranges[conn['src_type']])
 
     valid_src_gids = list(net.connectivity[conn_idx]['gid_pairs'].keys())
-    src_pos_valid = src_type_pos[np.in1d(src_range, valid_src_gids)]
+    src_pos_valid = src_type_pos[np.isin(src_range, valid_src_gids)]
 
     if src_gid is None:
         src_gid = valid_src_gids[0]


### PR DESCRIPTION
Problem raised in #794 that numpy version 2.0.0 has deprecated `np.in1d()`