### PR TITLE
[MAINT] Fixing Unit Tests for Python 3.11 and 3.12 support

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -13,7 +13,7 @@
       strategy:
         matrix:
           os: [ubuntu-latest,macos-latest]
-          python-version: [3.8, 3.9, '3.10', 3.11]
+          python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
 
       steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -13,7 +13,7 @@
       strategy:
         matrix:
           os: [ubuntu-latest,macos-latest]
-          python-version: [3.8, 3.9, '3.10']
+          python-version: [3.8, 3.9, '3.10', 3.11]
 
       steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -13,7 +13,7 @@
       strategy:
         matrix:
           os: [ubuntu-latest,macos-latest]
-          python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
+          python-version: [3.8, 3.11, 3.12]
 
       steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python-version: [3.8, 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v4

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -156,18 +156,18 @@ class HNNGUI:
             "btn_full_w": Layout(height=f"{button_height}px", width='100%'),
             "del_fig_btn": Layout(height=f"{button_height}px", width='auto'),
             "log_out": Layout(border='1px solid gray',
-                              height=f"{log_window_height-10}px",
+                              height=f"{log_window_height - 10}px",
                               overflow='auto'),
             "viz_config": Layout(width='99%'),
-            "simulations_list": Layout(width=f'{left_sidebar_width-50}px'),
+            "simulations_list": Layout(width=f'{left_sidebar_width - 50}px'),
             "visualization_window": Layout(
-                width=f"{viz_win_width-10}px",
-                height=f"{main_content_height-10}px",
+                width=f"{viz_win_width - 10}px",
+                height=f"{main_content_height - 10}px",
                 border='1px solid gray',
                 overflow='scroll'),
             "visualization_output": Layout(
-                width=f"{viz_win_width-50}px",
-                height=f"{main_content_height-100}px",
+                width=f"{viz_win_width - 50}px",
+                height=f"{main_content_height - 100}px",
                 border='1px solid gray',
                 overflow='scroll'),
             "left_sidebar": Layout(width=f"{left_sidebar_width}px",
@@ -179,7 +179,7 @@ class HNNGUI:
                                     flex_wrap="wrap",
                                     ),
             "config_box": Layout(width=f"{left_sidebar_width}px",
-                                 height=f"{config_box_height-100}px"),
+                                 height=f"{config_box_height - 100}px"),
             "drive_widget": Layout(width="auto"),
             "drive_textbox": Layout(width='270px', height='auto'),
             # simulation status related
@@ -1566,7 +1566,7 @@ def _create_zip(csv_data_list, simulation_name):
     with io.BytesIO() as zip_buffer:
         with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
             for index, csv_data in enumerate(csv_data_list):
-                zf.writestr(f'{simulation_name}_{index+1}.csv', csv_data)
+                zf.writestr(f'{simulation_name}_{index + 1}.csv', csv_data)
         zip_buffer.seek(0)
         return zip_buffer.read()
 

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -76,7 +76,7 @@ def test_external_drive_times():
     events_per_cycle = 5
     cycle_events_isi = 20
     with pytest.raises(ValueError,
-                       match=r'Burst duration (?s).* cannot be greater than'):
+                       match=r'(?s)Burst duration .* cannot be greater than'):
         _create_bursty_input(t0=t0, t0_stdev=t0_stdev,
                              tstop=tstop, f_input=f_input,
                              events_jitter_std=events_jitter_std,
@@ -339,7 +339,7 @@ def test_add_drives():
         net.add_bursty_drive('bursty_drive', tstart=10, tstop=1,
                              location='distal', burst_rate=10)
 
-    msg = (r'Burst duration (?s).* cannot be greater than '
+    msg = (r'(?s)Burst duration .* cannot be greater than '
            'burst period')
     with pytest.raises(ValueError, match=msg):
         net.add_bursty_drive('bursty_drive', location='distal',

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -42,7 +42,7 @@ def test_extracellular_api():
 
     rec_arr = ExtracellularArray(electrode_pos)
 
-    # Added second string in the match pattern due to changes in python >=3.11 
+    # Added second string in the match pattern due to changes in python >=3.11
     # AttributeError message changed to "property X of object Y has no setter"
     with pytest.raises(AttributeError,
                        match="has no setter|can't set attribute"):

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -41,9 +41,11 @@ def test_extracellular_api():
     # all remaining input arguments checked by ExtracellularArray
 
     rec_arr = ExtracellularArray(electrode_pos)
-    with pytest.raises(AttributeError, match="has no setter|can't set attribute"):
+    with pytest.raises(AttributeError,
+                       match="has no setter|can't set attribute"):
         rec_arr.times = [1, 2, 3]
-    with pytest.raises(AttributeError, match="has no setter|can't set attribute"):
+    with pytest.raises(AttributeError,
+                       match="has no setter|can't set attribute"):
         rec_arr.voltages = [1, 2, 3]
     with pytest.raises(TypeError, match="trial index must be int"):
         _ = rec_arr['0']

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -41,9 +41,9 @@ def test_extracellular_api():
     # all remaining input arguments checked by ExtracellularArray
 
     rec_arr = ExtracellularArray(electrode_pos)
-    with pytest.raises(AttributeError, match="has no setter"):
+    with pytest.raises(AttributeError, match="has no setter|can't set attribute"):
         rec_arr.times = [1, 2, 3]
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError, match="has no setter|can't set attribute"):
         rec_arr.voltages = [1, 2, 3]
     with pytest.raises(TypeError, match="trial index must be int"):
         _ = rec_arr['0']

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -41,7 +41,7 @@ def test_extracellular_api():
     # all remaining input arguments checked by ExtracellularArray
 
     rec_arr = ExtracellularArray(electrode_pos)
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError, match="has no setter"):
         rec_arr.times = [1, 2, 3]
     with pytest.raises(AttributeError, match="can't set attribute"):
         rec_arr.voltages = [1, 2, 3]

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -41,6 +41,9 @@ def test_extracellular_api():
     # all remaining input arguments checked by ExtracellularArray
 
     rec_arr = ExtracellularArray(electrode_pos)
+
+    # Added second string in the match pattern due to changes in python >=3.11 
+    # AttributeError message changed to "property X of object Y has no setter"
     with pytest.raises(AttributeError,
                        match="has no setter|can't set attribute"):
         rec_arr.times = [1, 2, 3]


### PR DESCRIPTION
For now we decided to test the 2 latest versions and oldest supported version of python on mac, Linux, and windows for all PRs. A full-matrix test of all supported python versions performed at a longer frequency is still being considered. 

This PR is aimed to fix incompatibilities found in the tests against python 3.11 and 3.12
