### PR TITLE
[MRG] read_network_configuration not clearing drive connections

### DIFF
--- a/hnn_core/hnn_io.py
+++ b/hnn_core/hnn_io.py
@@ -167,10 +167,8 @@ def _set_from_cell_specific(drive_data):
     return drive_data['n_drive_cells']
 
 
-def _read_external_drive(net, drive_data, read_drives, read_output):
+def _read_external_drive(net, drive_data, read_output):
     """Adds drives encoded in json data to a Network"""
-    if not read_drives:
-        return None
 
     if (drive_data['type'] == 'evoked') or (drive_data['type'] == 'gaussian'):
         # Skipped n_drive_cells here
@@ -439,7 +437,7 @@ def read_network_configuration(fname, read_drives=True):
                                         net_data['external_drives'])
     for key in external_drive_data.keys():
         _read_external_drive(net, external_drive_data[key],
-                             read_output=False, read_drives=read_drives)
+                             read_output=False)
     # Set external biases
     net.external_biases = net_data['external_biases']
     # Set connectivity
@@ -450,5 +448,8 @@ def read_network_configuration(fname, read_drives=True):
     net.threshold = net_data['threshold']
     # Set delay
     net.delay = net_data['delay']
+
+    if not read_drives:
+        net.clear_drives()
 
     return net

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -323,6 +323,19 @@ def test_read_configuration_json(jones_2009_network):
                                      )
     assert net == jones_2009_network
 
+    # Read without drives
+    net_no_drives = read_network_configuration(
+        Path(assets_path, 'jones2009_3x3_drives.json'),
+        read_drives=False
+    )
+    # Check there are no external drives
+    assert len(net_no_drives.external_drives) == 0
+    # Check there are no external drive connections
+    connection_src_types = [connection['src_type']
+                            for connection in net_no_drives.connectivity]
+    assert not any([src_type in net.external_drives.keys()
+                    for src_type in connection_src_types])
+
 
 def test_read_incorrect_format(tmp_path):
     """Test that error raise when the json do not have a Network label."""


### PR DESCRIPTION
Reading network configurations from hierarchical json with `read_drives=False` was only clearing the external_drives and not the drive connectivities in the network connectivity information. This fix corrects that issue.