### PR TITLE
[MRG] Fix seeding for drive cell event times

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -91,6 +91,9 @@ Bug
 - Use `np.isin()` in place of `np.in1d()` to address numpy deprecation,
   by `Nick Tolley`_ in :gh:`799.
 
+- Fix drive seeding so that event times are unique across multiple trials,
+  by `Nick Tolley`_ in :gh:`810`.
+
 API
 ~~~
 - :func:`~hnn_core.CellResponse.write` and :func:`~hnn_core.Cell_response.read_spikes`

--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -231,7 +231,8 @@ def _get_prng(seed, gid):
 
 
 def _drive_cell_event_times(drive_type, dynamics, tstop, target_type='any',
-                            trial_idx=0, drive_cell_gid=0, event_seed=0):
+                            trial_idx=0, drive_cell_gid=0, event_seed=0,
+                            trial_seed_offset=0):
     """Generate event times for one artificial drive cell based on dynamics.
 
     Parameters
@@ -256,13 +257,15 @@ def _drive_cell_event_times(drive_type, dynamics, tstop, target_type='any',
         Optional gid of current artificial cell (used for seeding)
     event_seed : int
         Optional initial seed for random number generator.
+    trial_seed_offset : int
+        Seed is incremented by this amount for each trial.
 
     Returns
     -------
     event_times : list
         The event times at which spikes occur.
     """
-    prng, prng2 = _get_prng(seed=event_seed + trial_idx,
+    prng, prng2 = _get_prng(seed=event_seed + trial_idx * trial_seed_offset,
                             gid=drive_cell_gid)
 
     # check drive name validity, allowing substring matches

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1097,6 +1097,7 @@ class Network:
                 for drive_cell_gid in self.gid_ranges[drive['name']]:
                     drive_cell_gid_offset = (drive_cell_gid -
                                              self.gid_ranges[drive['name']][0])
+                    trial_seed_offset = self._n_gids
                     if drive['cell_specific']:
                         # loop over drives (one for each target cell
                         # population) and create event times
@@ -1113,7 +1114,8 @@ class Network:
                                 trial_idx=trial_idx,
                                 drive_cell_gid=drive_cell_gid_offset,
                                 event_seed=drive['event_seed'],
-                                tstop=tstop)
+                                tstop=tstop,
+                                trial_seed_offset=trial_seed_offset)
                             )
                     else:
                         src_event_times = _drive_cell_event_times(
@@ -1123,7 +1125,8 @@ class Network:
                             target_type='any',
                             trial_idx=trial_idx,
                             drive_cell_gid=drive_cell_gid_offset,
-                            event_seed=drive['event_seed'])
+                            event_seed=drive['event_seed'],
+                            trial_seed_offset=trial_seed_offset)
                         event_times.append(src_event_times)
                 # 'events': nested list (n_trials x n_drive_cells x n_events)
                 self.external_drives[

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -113,7 +113,7 @@ def test_drive_seeds(setup_net):
     trial2_spikes = np.array(sorted(
         net.external_drives['prox']['events'][1]))
     # No two spikes should be perfectly identical across seeds
-    assert ~np.any(trial1_spikes == trial2_spikes)
+    assert ~np.any(np.allclose(trial1_spikes, trial2_spikes))
 
 
 def test_add_drives():

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -109,9 +109,9 @@ def test_drive_seeds(setup_net):
 
     _ = simulate_dipole(net, tstop=100, dt=0.5, n_trials=2)
     trial1_spikes = np.array(sorted(
-        net.external_drives['prox']['events'][0])).squeeze()
+        net.external_drives['prox']['events'][0]))
     trial2_spikes = np.array(sorted(
-        net.external_drives['prox']['events'][1])).squeeze()
+        net.external_drives['prox']['events'][1]))
     # No two spikes should be perfectly identical across seeds
     assert ~np.any(trial1_spikes == trial2_spikes)
 

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -5,7 +5,6 @@ import pytest
 import os.path as op
 
 import numpy as np
-import pytest
 
 import hnn_core
 from hnn_core import Network, read_params
@@ -16,6 +15,7 @@ from hnn_core.network_models import jones_2009_model
 from hnn_core import simulate_dipole
 hnn_core_root = op.dirname(hnn_core.__file__)
 
+
 @pytest.fixture
 def setup_net():
     hnn_core_root = op.dirname(hnn_core.__file__)
@@ -24,6 +24,7 @@ def setup_net():
     net = jones_2009_model(params, mesh_shape=(3, 3))
 
     return net
+
 
 def test_external_drive_times():
     """Test the different external drives."""


### PR DESCRIPTION
Closes #414. Instead of incrementing a seed by +1 for each trial, the seed is incremented by the total number of cells in the network.