### PR TITLE
[MRG] Poisson drive tests and bug fix for #662

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,8 +12,8 @@ Current
 
 Changelog
 ~~~~~~~~~
-- Fix bug in :func:`~hnn_core/network/add_poisson_drive` where an error is
-  thrown when passing a float for rate_constant when cell_specific=False,
+- Fix bug in :func:`~hnn_core.Network.add_poisson_drive` where an error is
+  thrown when passing a float for rate_constant when ``cell_specific=False``,
   by `Dylan Daniels`_ in :gh:`814`
   
 - Add ability to customize plot colors for each cell section in

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,6 +12,10 @@ Current
 
 Changelog
 ~~~~~~~~~
+- Fix bug in :func:`~hnn_core/network/add_poisson_drive` where an error is
+  thrown when passing a float for rate_constant when cell_specific=False,
+  by `Dylan Daniels`_ in :gh:`814`
+  
 - Add ability to customize plot colors for each cell section in
   :func:`~hnn_core.Cell.plot_morphology`, by `Nick Tolley`_ in :gh:`646`
   

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -748,7 +748,7 @@ class Network:
         elif isinstance(rate_constant, float):
             if cell_specific:
                 rate_constant = {cell_type: rate_constant for cell_type in
-                                target_populations}
+                                 target_populations}
 
         drive = _NetworkDrive()
         drive['type'] = 'poisson'

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -746,8 +746,9 @@ class Network:
                                  f" cell_specific={cell_specific} and "
                                  f"n_drive_cells={n_drive_cells}.")
         elif isinstance(rate_constant, float):
-            rate_constant = {cell_type: rate_constant for cell_type in
-                             target_populations}
+            if cell_specific:
+                rate_constant = {cell_type: rate_constant for cell_type in
+                                target_populations}
 
         drive = _NetworkDrive()
         drive['type'] = 'poisson'

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -467,18 +467,23 @@ def test_drive_random_state():
             net.external_drives['evprox2']['events'])
 
 
-def test_non_cellspecific_pois_rate(setup_net):
+@pytest.mark.parametrize("rate_constant,cell_specific,n_drive_cells",
+                         [(2, False, 1), (2.0, False, 1),
+                          (2, True, 'n_cells'), (2.0, True, 'n_cells'),
+                          ])
+def test_non_cellspecific_pois_rate(setup_net, rate_constant,
+                                    cell_specific, n_drive_cells):
     """Testing rate constant when adding non-cell-specific poisson drive"""
 
     net = setup_net
-    rate_constant = 2.0
 
     weights_ampa_noise = {'L2_basket': 0.01, 'L2_pyramidal': 0.002,
                         'L5_pyramidal': 0.02}
     
     net.add_poisson_drive('noise_global', rate_constant=rate_constant,
-                        location='distal', weights_ampa=weights_ampa_noise,space_constant=100, n_drive_cells=1,
-                        cell_specific=False)
+                        location='distal', weights_ampa=weights_ampa_noise,
+                        space_constant=100, n_drive_cells=n_drive_cells,
+                        cell_specific=cell_specific)
 
-    assert rate_constant == net.external_drives['noise_global']['dynamics']['rate_constant']
+    simulate_dipole(net, tstop=5)
     

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -470,19 +470,17 @@ def test_drive_random_state():
 @pytest.mark.parametrize("rate_constant,cell_specific,n_drive_cells",
                          [(2, False, 1), (2.0, False, 1),
                           ])
-def test_add_poisson_drive(setup_net, rate_constant,
-                                    cell_specific, n_drive_cells):
+def test_add_poisson_drive(setup_net, rate_constant, cell_specific,
+                           n_drive_cells):
     """Testing rate constant when adding non-cell-specific poisson drive"""
-
     net = setup_net
 
     weights_ampa_noise = {'L2_basket': 0.01, 'L2_pyramidal': 0.002,
-                        'L5_pyramidal': 0.02}
-    
+                          'L5_pyramidal': 0.02}
+
     net.add_poisson_drive('noise_global', rate_constant=rate_constant,
-                        location='distal', weights_ampa=weights_ampa_noise,
-                        space_constant=100, n_drive_cells=n_drive_cells,
-                        cell_specific=cell_specific)
+                          location='distal', weights_ampa=weights_ampa_noise,
+                          space_constant=100, n_drive_cells=n_drive_cells,
+                          cell_specific=cell_specific)
 
     simulate_dipole(net, tstop=5)
-    

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -469,7 +469,6 @@ def test_drive_random_state():
 
 @pytest.mark.parametrize("rate_constant,cell_specific,n_drive_cells",
                          [(2, False, 1), (2.0, False, 1),
-                          (2, True, 'n_cells'), (2.0, True, 'n_cells'),
                           ])
 def test_add_poisson_drive(setup_net, rate_constant,
                                     cell_specific, n_drive_cells):

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -471,7 +471,7 @@ def test_drive_random_state():
                          [(2, False, 1), (2.0, False, 1),
                           (2, True, 'n_cells'), (2.0, True, 'n_cells'),
                           ])
-def test_non_cellspecific_pois_rate(setup_net, rate_constant,
+def test_add_poisson_drive(setup_net, rate_constant,
                                     cell_specific, n_drive_cells):
     """Testing rate constant when adding non-cell-specific poisson drive"""
 

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -465,3 +465,20 @@ def test_drive_random_state():
     net._instantiate_drives(tstop=170.)
     assert (net.external_drives['evprox1']['events'] ==
             net.external_drives['evprox2']['events'])
+
+
+def test_non_cellspecific_pois_rate(setup_net):
+    """Testing rate constant when adding non-cell-specific poisson drive"""
+
+    net = setup_net
+    rate_constant = 2.0
+
+    weights_ampa_noise = {'L2_basket': 0.01, 'L2_pyramidal': 0.002,
+                        'L5_pyramidal': 0.02}
+    
+    net.add_poisson_drive('noise_global', rate_constant=rate_constant,
+                        location='distal', weights_ampa=weights_ampa_noise,space_constant=100, n_drive_cells=1,
+                        cell_specific=False)
+
+    assert rate_constant == net.external_drives['noise_global']['dynamics']['rate_constant']
+    


### PR DESCRIPTION
This addresses issue #662 and includes a test for adding poisson drives to test_drives.py.

The test also yields an error with {"rate_constant" = 2, "cell_specific"=True, "n_drive_cells" = "n_cells"}, but not with {"rate_constant" = 2.0, "cell_specific"=True, "n_drive_cells" = "n_cells"}. I'll open a separate bug for this?

Test output:
```
        event_times = np.array([])
        if drive_type == 'poisson':
            if target_type == 'any':
                rate_constant = dynamics['rate_constant']
>           elif target_type in dynamics['rate_constant']:
E           TypeError: argument of type 'int' is not iterable

hnn_core/drives.py:284: TypeError
```
