### PR TITLE
[MRG] fix for add_poisson_drive not working with int when cell_specific=True

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,7 @@ If you use HNN-core in your work, please cite our
 .. _precompiled installers: https://nrn.readthedocs.io/en/latest/
 .. _NEURON forum: https://www.neuron.yale.edu/phpbb/
 .. _contributing guide: https://jonescompneurolab.github.io/hnn-core/dev/contributing.html
+.. _governance structure: https://jonescompneurolab.github.io/hnn-core/dev/governance.html
 .. _parallel backend guide: https://jonescompneurolab.github.io/hnn-core/dev/parallel.html
 
 .. |tests| image:: https://github.com/jonescompneurolab/hnn-core/actions/workflows/unix_unit_tests.yml/badge.svg?branch=master

--- a/README.rst
+++ b/README.rst
@@ -197,7 +197,6 @@ If you use HNN-core in your work, please cite our
 .. _precompiled installers: https://nrn.readthedocs.io/en/latest/
 .. _NEURON forum: https://www.neuron.yale.edu/phpbb/
 .. _contributing guide: https://jonescompneurolab.github.io/hnn-core/dev/contributing.html
-.. _governance structure: https://jonescompneurolab.github.io/hnn-core/dev/governance.html
 .. _parallel backend guide: https://jonescompneurolab.github.io/hnn-core/dev/parallel.html
 
 .. |tests| image:: https://github.com/jonescompneurolab/hnn-core/actions/workflows/unix_unit_tests.yml/badge.svg?branch=master

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,6 +13,10 @@ Current
 Changelog
 ~~~~~~~~~
 - Fix bug in :func:`~hnn_core.Network.add_poisson_drive` where an error is
+  thrown when passing an int for rate_constant when ``cell_specific=True``,
+  by `Dylan Daniels`_ in :gh:`818`
+
+- Fix bug in :func:`~hnn_core.Network.add_poisson_drive` where an error is
   thrown when passing a float for rate_constant when ``cell_specific=False``,
   by `Dylan Daniels`_ in :gh:`814`
   

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -745,7 +745,7 @@ class Network:
                                  f"n_drive_cells='n_cells'. Got cell_specific"
                                  f" cell_specific={cell_specific} and "
                                  f"n_drive_cells={n_drive_cells}.")
-        elif isinstance(rate_constant, float):
+        elif isinstance(rate_constant, (float, int)):
             if cell_specific:
                 rate_constant = {cell_type: rate_constant for cell_type in
                                  target_populations}

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -469,6 +469,7 @@ def test_drive_random_state():
 
 @pytest.mark.parametrize("rate_constant,cell_specific,n_drive_cells",
                          [(2, False, 1), (2.0, False, 1),
+                          (2, False, 1), (2.0, False, 1),
                           ])
 def test_add_poisson_drive(setup_net, rate_constant, cell_specific,
                            n_drive_cells):

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -469,7 +469,7 @@ def test_drive_random_state():
 
 @pytest.mark.parametrize("rate_constant,cell_specific,n_drive_cells",
                          [(2, False, 1), (2.0, False, 1),
-                          (2, False, 1), (2.0, False, 1),
+                          (2, True, 'n_cells'), (2.0, True, 'n_cells'),
                           ])
 def test_add_poisson_drive(setup_net, rate_constant, cell_specific,
                            n_drive_cells):


### PR DESCRIPTION
This fix addresses issue #816 and updates the test for adding poisson drives in test_drives.py with additional conditions to check