### PR TITLE
[MRG] Fix hnn-core homepage links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,8 +166,8 @@ Bug reports
 ===========
 
 Use the `github issue tracker <https://github.com/jonescompneurolab/hnn-core/issues>`_ to
-report bugs. For user questions and scientific discussions, please join the
-`HNN Google group <https://groups.google.com/g/hnnsolver>`_.
+report bugs. For user questions and scientific discussions, please see our
+`GitHub Discussions page <https://github.com/jonescompneurolab/hnn-core/discussions>`_.
 
 Interested in Contributing?
 ===========================
@@ -178,11 +178,6 @@ Governance Structure
 ====================
 
 Read our `governance structure`_.
-
-Roadmap
-=======
-
-Read our `roadmap`_.
 
 Citing
 ======

--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,7 @@ If you use HNN-core in your work, please cite our
 .. _precompiled installers: https://nrn.readthedocs.io/en/latest/
 .. _NEURON forum: https://www.neuron.yale.edu/phpbb/
 .. _contributing guide: https://jonescompneurolab.github.io/hnn-core/dev/contributing.html
+.. _governance structure: https://jonescompneurolab.github.io/hnn-core/dev/governance.html
 .. _parallel backend guide: https://jonescompneurolab.github.io/hnn-core/dev/parallel.html
 
 .. |tests| image:: https://github.com/jonescompneurolab/hnn-core/actions/workflows/unix_unit_tests.yml/badge.svg?branch=master


### PR DESCRIPTION
Added link to governance structure
Removed broken link to roadmap
Updated link in Bug Reports to point to Discussions instead of the Google Group