### PR TITLE
[MRG] Remove nulled drives during convert to hierarchical json function

### DIFF
--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -735,7 +735,6 @@ def remove_nulled_drives(net):
 
 def convert_to_json(params_fname,
                     out_fname,
-                    model_template='jones_2009_model',
                     include_drives=True,
                     overwrite=True):
     """Converts legacy json or param format to hierarchical json format
@@ -746,11 +745,6 @@ def convert_to_json(params_fname,
         Path to file
     out_fname: str
         Path to output
-    model_template: str or None, default:' jones_2009_model'
-         Options: ['jones_2009_model', 'law_2021_model', 'calcium_model', None]
-         Neocortical network model to use. Models are defined in
-         network_models. If None, the base Network object with no defined
-         network connectivity will be used.
     include_drives: bool, default=True
         Include drives from params file
     overwrite: bool, default=True
@@ -759,23 +753,7 @@ def convert_to_json(params_fname,
     -------
     None
     """
-    from .network import Network
-    from .network_models import jones_2009_model, law_2021_model, calcium_model
-
-    # Assign network model callables
-    model_functions = {'jones_2009_model': jones_2009_model,
-                       'law_2021_model': law_2021_model,
-                       'calcium_model': calcium_model
-                       }
-    if model_template:
-        try:
-            network_model = model_functions[model_template]
-        except KeyError:
-            raise KeyError(f'Invalid network connectivity: '
-                           f'"{model_template}"; '
-                           f'Valid options: {list(model_functions.keys())}')
-    else:
-        network_model = Network
+    from .network_models import jones_2009_model
 
     # Validate inputs
     _validate_type(params_fname, (str, Path), 'params_fname')
@@ -789,11 +767,11 @@ def convert_to_json(params_fname,
     if out_fname.suffix != '.json':
         out_fname = out_fname.with_suffix('.json')
 
-    net = network_model(params=read_params(params_fname),
-                        add_drives_from_params=include_drives,
-                        legacy_mode=(True if params_suffix == 'param'
-                                     else False),
-                        )
+    net = jones_2009_model(params=read_params(params_fname),
+                           add_drives_from_params=include_drives,
+                           legacy_mode=(True if params_suffix == 'param'
+                                        else False),
+                           )
 
     # Remove drives that have null attributes
     net = remove_nulled_drives(net)

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -700,7 +700,6 @@ def remove_nulled_drives(net):
 
     net = deepcopy(net)
     drives_copy = net.external_drives.copy()
-    n_cells = _get_n_cells(net)
 
     extras = dict()
     for drive_name, drive in net.external_drives.items():
@@ -723,7 +722,7 @@ def remove_nulled_drives(net):
             continue
         else:
             # Set n_drive_cells to 'n_cells' if equal to max number of cells
-            if drive['n_drive_cells'] == n_cells:
+            if drive['cell_specific']:
                 drive['n_drive_cells'] = 'n_cells'
             net._attach_drive(drive['name'], drive, drive['weights_ampa'],
                               drive['weights_nmda'], drive['location'],

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -707,10 +707,14 @@ def remove_nulled_drives(net):
 
     net.clear_drives()
     for drive_name, drive in drives_copy.items():
-        # Do not add drive if tstart is > tstop
-        if drive['dynamics'].get('tstart'):
-            if drive['dynamics']['tstart'] > drive['dynamics']['tstop']:
-                continue
+        # Do not add drive if tstart is > tstop, or negative
+        t_start = drive['dynamics'].get('tstart')
+        t_stop = drive['dynamics'].get('tstop')
+        if (t_start is not None and t_stop is not None and
+                ((t_start > t_stop) or
+                 (t_start < 0) or
+                 (t_stop < 0))):
+            continue
         # Do not add if all 0 weights
         elif not _any_positive_weights(drive):
             continue

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -683,8 +683,8 @@ def remove_nulled_drives(net):
     """Removes drives from network if they have been given null parameters.
 
     Legacy param files contained parameter placeholders for non-functional
-    drives. These drives were nulled by assigning values outside typical ranges.
-    This function removes drives on the following conditions:
+    drives. These drives were nulled by assigning values outside typical
+    ranges. This function removes drives on the following conditions:
         1. Start time is larger than stop time
         2. All weights are non-positive
 
@@ -803,6 +803,7 @@ def convert_to_json(params_fname,
                             overwrite=overwrite,
                             )
     return
+
 
 # debug test function
 if __name__ == '__main__':

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -672,13 +672,6 @@ def _any_positive_weights(drive):
         return False
 
 
-def _get_n_cells(net):
-    """ Get number of neocortical cells  """
-    cell_names = net.cell_types.keys()
-    n_cells = max([net.gid_ranges[cell_name].stop for cell_name in cell_names])
-    return n_cells
-
-
 def remove_nulled_drives(net):
     """Removes drives from network if they have been given null parameters.
 

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -694,6 +694,7 @@ def remove_nulled_drives(net):
 
     Returns
     -------
+    net : Network object
 
     """
     from .network import pick_connection

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -107,6 +107,10 @@ def test_remove_nulled_drives(tmp_path):
     assert all([drive not in net_removed.gid_ranges.keys()
                 for drive in drives_removed])
 
+    # position dictionary was updated
+    assert all([drive not in net_removed.pos_dict.keys()
+                for drive in drives_removed])
+
 
 class TestConvertToJson:
     """Tests convert_to_json function"""

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -8,11 +8,9 @@ from urllib.request import urlretrieve
 
 import pytest
 
-from hnn_core import (read_params, Params, convert_to_json,
-                      Network)
+from hnn_core import read_params, Params, convert_to_json
 from hnn_core.hnn_io import read_network_configuration
-from hnn_core.network_models import (jones_2009_model, law_2021_model,
-                                     calcium_model)
+from hnn_core.network_models import jones_2009_model
 from hnn_core.params import remove_nulled_drives
 
 
@@ -176,7 +174,6 @@ class TestConvertToJson:
         good_path = hnn_core_root
         path_str = str(good_path)
         bad_path = 5
-        bad_model = 'bad_model'
 
         # Valid path and string, but not actual files
         with pytest.raises(

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -97,14 +97,17 @@ def test_remove_nulled_drives(tmp_path):
 
     # External drives were removed
     drives_removed = ['bursty1', 'bursty2', 'extgauss', 'extpois']
-    assert all([drive not in net_removed.external_drives.keys() for drive in drives_removed])
+    assert all([drive not in net_removed.external_drives.keys()
+                for drive in drives_removed])
 
     # Connections were removed
-    conn_src_types = set([conn['src_type'] for conn in net_removed.connectivity])
+    conn_src_types = set([conn['src_type']
+                          for conn in net_removed.connectivity])
     assert all([drive not in conn_src_types for drive in drives_removed])
 
     # gid ranges were updated
-    assert all([drive not in net_removed.gid_ranges.keys() for drive in drives_removed])
+    assert all([drive not in net_removed.gid_ranges.keys()
+                for drive in drives_removed])
 
 
 class TestConvertToJson:

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -160,11 +160,15 @@ class TestConvertToJson:
                                       legacy_mode=True
                                       )
 
-        # Write json and check if constructed network is equal
+        # Write json and check if constructed network is correct
         outpath = Path(tmp_path, 'default.json')
         convert_to_json(params_base_fname, outpath)
         net_json = read_network_configuration(outpath)
-        assert net_json == net_params
+        # Nulled drives are removed, so they should not be equal
+        assert net_json != net_params
+        assert len(net_json.external_drives) == 3
+        assert len(net_json.connectivity) == 39
+        assert len(net_json.gid_ranges) == 7
 
     def test_convert_to_json_bad_type(self):
         """Tests type validation in convert_to_json function"""

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -146,53 +146,6 @@ class TestConvertToJson:
                         )
         assert outpath_no_ext.with_suffix('.json').exists()
 
-    def test_law_network_connectivity(self, tmp_path):
-        """Tests conversion with Law 2021 network connectivity model"""
-
-        net_params = law_2021_model(read_params(self.path_default),
-                                    add_drives_from_params=True,
-                                    )
-
-        # Write json and check if constructed network is equal
-        outpath = Path(tmp_path, 'default.json')
-        convert_to_json(self.path_default,
-                        outpath,
-                        model_template='law_2021_model')
-        net_json = read_network_configuration(outpath)
-        assert net_json == net_params
-
-    def test_calcium_network_connectivity(self, tmp_path):
-        """Tests conversion with calcium network connectivity model"""
-
-        net_params = calcium_model(read_params(self.path_default),
-                                   add_drives_from_params=True,
-                                   )
-
-        # Write json and check if constructed network is equal
-        outpath = Path(tmp_path, 'default.json')
-        convert_to_json(self.path_default,
-                        outpath,
-                        model_template='calcium_model')
-        net_json = read_network_configuration(outpath)
-        assert net_json == net_params
-
-    def test_no_network_connectivity(self, tmp_path):
-        """Tests conversion with no network connectivity model"""
-
-        net_params = Network(read_params(self.path_default),
-                             add_drives_from_params=True,
-                             )
-
-        # Write json and check if constructed network is equal
-        outpath = Path(tmp_path, 'default.json')
-        convert_to_json(self.path_default,
-                        outpath,
-                        model_template=None)
-        net_json = read_network_configuration(outpath)
-        assert net_json == net_params
-        # Should only have external drive connections defined, n=22
-        assert len(net_json.connectivity) == len(net_params.connectivity) == 22
-
     def test_convert_to_json_legacy(self, tmp_path):
         """Tests conversion of a param legacy file to json"""
 
@@ -241,11 +194,3 @@ class TestConvertToJson:
                 match="out_fname must be an instance of str or Path"
         ):
             convert_to_json(good_path, bad_path)
-
-        # Bad model_template
-        with pytest.raises(
-                KeyError,
-                match="Invalid network connectivity:"
-        ):
-            convert_to_json(good_path, good_path,
-                            model_template=bad_model)


### PR DESCRIPTION
Updated the hierarchical json conversion script to prune nulled drives. Legacy param files had placeholders for several drives. If unused, values out of typical ranges were specified to null those drives. Typically this occurs when a start time is set greater than the stop time or if weights are set it negatives or 0s. The hierarchical json format will not include drives with bad parameters. 

Summary of Changes: 
* Added logic to remove drives that did not have at least 1 positive weight or had invalid _tstop_ and _tstart_ values. 
* Removed _model_template_ argument from `convert_to_json` and associated tests - After discussion that we are using this function internally to convert tutorial files. And they will all be the jones2009 model. 


**Questions**
1. Are the filters for nulled drives correct/complete? 
    * Check for start < stop 
    * Checks nmda and amps weights for at least one >0 value