### PR TITLE
[MRG]: Fixed simulations dropdown list adding loaded data

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1727,7 +1727,7 @@ def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
                 'finished']
 
             sim_names = [sim_name for sim_name in simulation_data
-                               if simulation_data[sim_name]['net'] is not None]
+                         if simulation_data[sim_name]['net'] is not None]
 
             simulations_list_widget.options = sim_names
             simulations_list_widget.value = sim_names[0]

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1971,10 +1971,5 @@ def launch():
     You can pass voila commandline parameters as usual.
     """
     from voila.app import main
-    import debugpy
-    debugpy.listen(5678)
-    print("Waiting for debugger attach")
-    debugpy.wait_for_client()
-
     notebook_path = Path(__file__).parent / 'hnn_widget.ipynb'
     main([str(notebook_path.resolve()), *sys.argv[1:]])

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1726,11 +1726,11 @@ def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
             simulation_status_bar.value = simulation_status_contents[
                 'finished']
 
-            run_simulations = [sim_name for sim_name in simulation_data
+            sim_names = [sim_name for sim_name in simulation_data
                                if simulation_data[sim_name]['net'] is not None]
 
-            simulations_list_widget.options = run_simulations
-            simulations_list_widget.value = run_simulations[0]
+            simulations_list_widget.options = sim_names
+            simulations_list_widget.value = sim_names[0]
 
     viz_manager.reset_fig_config_tabs()
     viz_manager.add_figure()

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1726,10 +1726,11 @@ def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
             simulation_status_bar.value = simulation_status_contents[
                 'finished']
 
-            sim_names = [sim_name for sim_name
-                         in simulation_data]
-            simulations_list_widget.options = sim_names
-            simulations_list_widget.value = sim_names[0]
+            run_simulations = [sim_name for sim_name in simulation_data
+                               if simulation_data[sim_name]['net'] is not None]
+
+            simulations_list_widget.options = run_simulations
+            simulations_list_widget.value = run_simulations[0]
 
     viz_manager.reset_fig_config_tabs()
     viz_manager.add_figure()
@@ -1970,5 +1971,10 @@ def launch():
     You can pass voila commandline parameters as usual.
     """
     from voila.app import main
+    import debugpy
+    debugpy.listen(5678)
+    print("Waiting for debugger attach")
+    debugpy.wait_for_client()
+
     notebook_path = Path(__file__).parent / 'hnn_widget.ipynb'
     main([str(notebook_path.resolve()), *sys.argv[1:]])

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -599,6 +599,13 @@ def test_gui_download_simulation(setup_gui):
     # result is a single csv file
     assert file_extension == ".csv"
 
+    # Check no loaded data is listed in the sims dropdown list to download
+    file1_url = "https://raw.githubusercontent.com/jonescompneurolab/hnn/master/data/MEG_detection_data/S1_SupraT.txt"  # noqa
+    gui._simulate_upload_data(file1_url)
+    download_simulation_list = gui.simulation_list_widget.options
+    assert (len([sim_name for sim_name in download_simulation_list
+                if sim_name == "S1_SupraT"]) == 0)
+
 
 def test_gui_upload_csv_simulation(setup_gui):
     """Test if gui handles uploaded csv data"""


### PR DESCRIPTION
The simulations dropdown list was adding loaded data, and hnn-gui cant export non-simulated data.

solves #824 