### PR TITLE
[MAINT] GUI -Fix Update simulation type dropdown list

### DIFF
--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -590,7 +590,7 @@ def _get_ax_control(widgets, data, fig_idx, fig, ax):
                                         data)
 
     def _on_plot_type_change(new_plot_type):
-        return plot_type_coupled_change(new_plot_type, target_data_selection)
+        return plot_type_coupled_change(new_plot_type.new, target_data_selection)
 
     simulation_selection.observe(_on_sim_data_change, 'value')
     target_data_selection.observe(_on_target_comparison_change, 'value')
@@ -836,12 +836,6 @@ class _VizManager:
 
     def reset_fig_config_tabs(self, template_name=None):
         """Reset the figure config tabs with most recent simulation data."""
-        simulation_names = tuple(self.data['simulations'].keys())
-        for tab in self.axes_config_tabs.children:
-            controls = tab.children[1]
-            for ax_control in controls.children:
-                simulation_selection = ax_control.children[0]
-                simulation_selection.options = simulation_names
         # recover the default layout
         if template_name is None:
             template_name = list(fig_templates.keys())[0]

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -845,7 +845,7 @@ class _VizManager:
                 simulation_data_selection = ax_control.children[1]
                 simulation_data_selection.options = simulation_names
 
-                # Update the options for the simulation to compare dropdown
+                # Update the options for the data to compare dropdown
                 simulation_to_compare = ax_control.children[4]
                 simulation_to_compare.options = simulation_names
 

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -837,6 +837,18 @@ class _VizManager:
 
     def reset_fig_config_tabs(self, template_name=None):
         """Reset the figure config tabs with most recent simulation data."""
+        simulation_names = tuple(self.data['simulations'].keys())
+        for tab in self.axes_config_tabs.children:
+            controls = tab.children[1]
+            for ax_control in controls.children:
+                # Update the options for the simulation data selection dropdown
+                simulation_data_selection = ax_control.children[1]
+                simulation_data_selection.options = simulation_names
+
+                # Update the options for the simulation to compare dropdown
+                simulation_to_compare = ax_control.children[4]
+                simulation_to_compare.options = simulation_names
+
         # recover the default layout
         if template_name is None:
             template_name = list(fig_templates.keys())[0]

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -590,7 +590,8 @@ def _get_ax_control(widgets, data, fig_idx, fig, ax):
                                         data)
 
     def _on_plot_type_change(new_plot_type):
-        return plot_type_coupled_change(new_plot_type.new, target_data_selection)
+        return plot_type_coupled_change(new_plot_type.new,
+                                        target_data_selection)
 
     simulation_selection.observe(_on_sim_data_change, 'value')
     target_data_selection.observe(_on_target_comparison_change, 'value')

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -750,7 +750,7 @@ def test_fig_tabs_dropdown_lists(setup_gui):
 
     gui.widget_ntrials.value = 1
 
-    # Initiate 1rs simulation
+    # Initiate 1st simulation
     sim_name = "sim1"
     gui.widget_simulation_name.value = sim_name
 
@@ -770,9 +770,12 @@ def test_fig_tabs_dropdown_lists(setup_gui):
         for ax_control in controls.children:
             assert ax_control.children[1].description == "Simulation Data:"
             sim_names = ax_control.children[1].options
+            # Check that dropdown has been updated with all simulation names
             assert all(sim in sim_names for sim in [sim_name, sim_name2])
 
             assert ax_control.children[4].description == "Data to Compare:"
 
+            # Check the data to compare dropdown is enable for
+            # non "input histograms" plot type
             if ax_control.children[0].value != "input histogram":
                 assert not ax_control.children[4].disabled

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -741,3 +741,38 @@ def test_gui_cell_params_widgets(setup_gui):
     assert (len(cell_params['Synapses']) == 12)
     assert (len(cell_params['Biophysics L2']) == 10)
     assert (len(cell_params['Biophysics L5']) == 20)
+
+
+def test_fig_tabs_dropdown_lists(setup_gui):
+    """Test the GUI download simulation pipeline."""
+
+    gui = setup_gui
+
+    gui.widget_ntrials.value = 1
+
+    # Initiate 1rs simulation
+    sim_name = "sim1"
+    gui.widget_simulation_name.value = sim_name
+
+    # Run simulation
+    gui.run_button.click()
+
+    # Initiate 2nd simulation
+    sim_name2 = "sim2"
+    gui.widget_simulation_name.value = sim_name2
+
+    # Run simulation
+    gui.run_button.click()
+
+    viz_tabs = gui.viz_manager.axes_config_tabs.children
+    for tab in viz_tabs:
+        controls = tab.children[1]
+        for ax_control in controls.children:
+            assert ax_control.children[1].description == "Simulation Data:"
+            sim_names = ax_control.children[1].options
+            assert all(sim in sim_names for sim in [sim_name, sim_name2])
+
+            assert ax_control.children[4].description == "Data to Compare:"
+
+            if ax_control.children[0].value != "input histogram":
+                assert not ax_control.children[4].disabled


### PR DESCRIPTION
This PR will fix #826 .  In the visualization tab, the simulation type dropdown list values are overwritten with simulation names, disabling the `data to compare` dropdown list and creating more bugs.

It is related to PR #543  and [this](https://github.com/jonescompneurolab/hnn-core/pull/543/commits/f6eaf0b0141256e6889f81a6b195c65dba7b68cf) commit 