### PR TITLE
[MRG] Simulate upload from local

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -794,15 +794,15 @@ class HNNGUI:
 
     # below are a series of methods that are used to manipulate the GUI
     def _simulate_upload_data(self, file_url):
-        uploaded_value = _prepare_upload_file_from_url(file_url)
+        uploaded_value = _prepare_upload_file(file_url)
         self.load_data_button.set_trait('value', uploaded_value)
 
     def _simulate_upload_connectivity(self, file_url):
-        uploaded_value = _prepare_upload_file_from_url(file_url)
+        uploaded_value = _prepare_upload_file(file_url)
         self.load_connectivity_button.set_trait('value', uploaded_value)
 
     def _simulate_upload_drives(self, file_url):
-        uploaded_value = _prepare_upload_file_from_url(file_url)
+        uploaded_value = _prepare_upload_file(file_url)
         self.load_drives_button.set_trait('value', uploaded_value)
 
     def _simulate_left_tab_click(self, tab_title):

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -881,7 +881,7 @@ def _prepare_upload_file(path):
     """
     try:
         uploaded_value = _prepare_upload_file_from_local(path)
-    except FileNotFoundError:
+    except (FileNotFoundError, OSError):
         uploaded_value = _prepare_upload_file_from_url(path)
 
     return uploaded_value

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -876,7 +876,7 @@ def _prepare_upload_file(path):
     """ Simulates output of the FileUpload widget for testing.
 
     Unit tests for the GUI simulate user upload of files. File source can
-    either be locally or from a URL. This function returns the data structure
+    either be local or from a URL. This function returns the data structure
     of the ipywidget FileUpload widget, a list of dictionaries with file
     attributes.
     """

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -5,6 +5,7 @@
 import codecs
 import io
 import logging
+import mimetypes
 import multiprocessing
 import sys
 import urllib.parse
@@ -834,6 +835,22 @@ class HNNGUI:
         self._simulate_left_tab_click("Visualization")
         action = getattr(self.viz_manager, f"_simulate_{action_name}")
         action(*args, **kwargs)
+
+
+def _prepare_upload_file_from_local(path):
+    with open(path, 'rb') as file:
+        content = memoryview(file.read())
+    last_modified = datetime.fromtimestamp(path.stat().st_mtime)
+
+    upload_structure = [{
+        'name': path.name,
+        'type': mimetypes.guess_type(path)[0],
+        'size': path.stat().st_size,
+        'content': content,
+        'last_modified': last_modified
+    }]
+
+    return upload_structure
 
 
 def _prepare_upload_file_from_url(file_url):

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -871,6 +871,22 @@ def _prepare_upload_file_from_url(file_url):
     return upload_structure
 
 
+def _prepare_upload_file(path):
+    """ Simulates output of the FileUpload widget for testing.
+
+    Unit tests for the GUI simulate user upload of files. File source can
+    either be locally or from a URL. This function returns the data structure
+    of the ipywidget FileUpload widget, a list of dictionaries with file
+    attributes.
+    """
+    try:
+        uploaded_value = _prepare_upload_file_from_local(path)
+    except FileNotFoundError:
+        uploaded_value = _prepare_upload_file_from_url(path)
+
+    return uploaded_value
+
+
 def create_expanded_button(description, button_style, layout, disabled=False,
                            button_color="#8A2BE2"):
     return Button(description=description, button_style=button_style,

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -838,6 +838,7 @@ class HNNGUI:
 
 
 def _prepare_upload_file_from_local(path):
+    path = Path(path)
     with open(path, 'rb') as file:
         content = memoryview(file.read())
     last_modified = datetime.fromtimestamp(path.stat().st_mtime)

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -854,19 +854,21 @@ def _prepare_upload_file_from_local(path):
 
 
 def _prepare_upload_file_from_url(file_url):
-    params_name = file_url.split("/")[-1]
+    file_name = file_url.split("/")[-1]
     data = urllib.request.urlopen(file_url)
-    content = b""
+    content = bytearray()
     for line in data:
-        content += line
+        content.extend(line)
 
-    return [{
-        'name': params_name,
-        'type': 'application/json',
+    upload_structure = [{
+        'name': file_name,
+        'type': mimetypes.guess_type(file_url)[0],
         'size': len(content),
-        'content': content,
+        'content': memoryview(content),
         'last_modified': datetime.now()
     }]
+
+    return upload_structure
 
 
 def create_expanded_button(description, button_style, layout, disabled=False,

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -65,7 +65,8 @@ def test_prepare_upload_file():
     assert (content_from_url['type'] ==
             content_from_local['type'] ==
             'application/json')
-    assert content_from_url['size'] == content_from_local['size']
+    assert content_from_url.get('size')
+    assert content_from_local.get('size')
     assert content_from_url['content'] == content_from_local['content']
 
 

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1,6 +1,9 @@
 # Authors: Huzi Cheng <hzcheng15@icloud.com>
 #          Camilo Diaz <camilo_diaz@brown.edu>
 #          George Dang <george_dang@brown.edu>
+import codecs
+import io
+import json
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
@@ -53,6 +56,11 @@ def test_gui_load_params():
 
 def test_prepare_upload_file():
     """Tests that input files from local or url sources import correctly"""
+    def _import_json(content):
+        decode = codecs.decode(content, encoding="utf-8")
+        json_content = json.load(io.StringIO(decode))
+        return json_content
+
     url = "https://raw.githubusercontent.com/jonescompneurolab/hnn-core/master/hnn_core/param/default.json"  # noqa
     file = Path(hnn_core_root, 'param', 'default.json')
 
@@ -65,9 +73,15 @@ def test_prepare_upload_file():
     assert (content_from_url['type'] ==
             content_from_local['type'] ==
             'application/json')
+    # Check that the size attribute is present. Cannot do an equivalency check
+    # because file systems may add additional when saving to disk.
     assert content_from_url.get('size')
     assert content_from_local.get('size')
-    assert content_from_url['content'] == content_from_local['content']
+
+    # Check that the content is the same when imported as dict
+    dict_from_url = _import_json(content_from_url.get('content'))
+    dict_from_local = _import_json(content_from_local.get('content'))
+    assert dict_from_url == dict_from_local
 
 
 def test_gui_upload_params():
@@ -86,8 +100,8 @@ def test_gui_upload_params():
     original_tstep = gui.widget_dt.value
     gui.widget_dt.value = 1
     # simulate upload default.json
-    file1_url = "https://raw.githubusercontent.com/jonescompneurolab/hnn-core/master/hnn_core/param/default.json" # noqa
-    file2_url = "https://raw.githubusercontent.com/jonescompneurolab/hnn-core/master/hnn_core/param/gamma_L5weak_L2weak.json" # noqa
+    file1_url = "https://raw.githubusercontent.com/jonescompneurolab/hnn-core/master/hnn_core/param/default.json"  # noqa
+    file2_url = "https://raw.githubusercontent.com/jonescompneurolab/hnn-core/master/hnn_core/param/gamma_L5weak_L2weak.json"  # noqa
     gui._simulate_upload_connectivity(file1_url)
     gui._simulate_upload_drives(file1_url)
 
@@ -190,7 +204,7 @@ def test_gui_change_connectivity():
 
                 # test if the new value is reflected in the network
                 assert _single_simulation['net'].connectivity[conn_idx][
-                    'nc_dict']['A_weight'] == w_val
+                           'nc_dict']['A_weight'] == w_val
     plt.close('all')
 
 
@@ -298,13 +312,13 @@ def test_non_unique_name_error(setup_gui):
     assert isinstance(gui.simulation_data[sim_name]["net"], Network)
     assert isinstance(dpls, list)
     assert gui._simulation_status_bar.value == \
-        gui._simulation_status_contents['finished']
+           gui._simulation_status_contents['finished']
 
     gui.widget_simulation_name.value = sim_name
     gui.run_button.click()
     assert len(gui.simulation_data) == 1
     assert gui._simulation_status_bar.value == \
-        gui._simulation_status_contents['failed']
+           gui._simulation_status_contents['failed']
     plt.close('all')
 
 
@@ -624,7 +638,7 @@ def test_gui_download_simulation(setup_gui):
     gui._simulate_upload_data(file1_url)
     download_simulation_list = gui.simulation_list_widget.options
     assert (len([sim_name for sim_name in download_simulation_list
-                if sim_name == "S1_SupraT"]) == 0)
+                 if sim_name == "S1_SupraT"]) == 0)
 
 
 def test_gui_upload_csv_simulation(setup_gui):

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -65,9 +65,7 @@ def test_prepare_upload_file():
     assert (content_from_url['type'] ==
             content_from_local['type'] ==
             'application/json')
-    assert (content_from_url['size'] ==
-            content_from_local['size'] ==
-            6941)
+    assert content_from_url['size'] == content_from_local['size']
     assert content_from_url['content'] == content_from_local['content']
 
 

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -75,8 +75,8 @@ def test_prepare_upload_file():
             'application/json')
     # Check that the size attribute is present. Cannot do an equivalency check
     # because file systems may add additional when saving to disk.
-    assert content_from_url.get('size')
-    assert content_from_local.get('size')
+    assert 'size' in content_from_url
+    assert 'size' in content_from_local
 
     # Check that the content is the same when imported as dict
     dict_from_url = _import_json(content_from_url.get('content'))

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -203,8 +203,8 @@ def test_gui_change_connectivity():
                                            add_drive=False)
 
                 # test if the new value is reflected in the network
-                assert _single_simulation['net'].connectivity[conn_idx][
-                           'nc_dict']['A_weight'] == w_val
+                assert (_single_simulation['net'].connectivity[conn_idx]
+                        ['nc_dict']['A_weight'] == w_val)
     plt.close('all')
 
 

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -15,8 +15,9 @@ from hnn_core.gui._viz_manager import (_idx2figname,
                                        _plot_types,
                                        _no_overlay_plot_types,
                                        unlink_relink)
-from hnn_core.gui.gui import _init_network_from_widgets
-from hnn_core.gui.gui import serialize_simulation
+from hnn_core.gui.gui import (_init_network_from_widgets,
+                              _prepare_upload_file,
+                              serialize_simulation)
 from hnn_core.network import pick_connection
 from hnn_core.network_models import jones_2009_model
 from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
@@ -48,6 +49,26 @@ def test_gui_load_params():
     print(gui.params)
     print(gui.params['L2Pyr*'])
     plt.close('all')
+
+
+def test_prepare_upload_file():
+    """Tests that input files from local or url sources import correctly"""
+    url = "https://raw.githubusercontent.com/jonescompneurolab/hnn-core/master/hnn_core/param/default.json"  # noqa
+    file = Path(hnn_core_root, 'param', 'default.json')
+
+    content_from_url = _prepare_upload_file(url)[0]
+    content_from_local = _prepare_upload_file(file)[0]
+
+    assert (content_from_url['name'] ==
+            content_from_local['name'] ==
+            'default.json')
+    assert (content_from_url['type'] ==
+            content_from_local['type'] ==
+            'application/json')
+    assert (content_from_url['size'] ==
+            content_from_local['size'] ==
+            6941)
+    assert content_from_url['content'] == content_from_local['content']
 
 
 def test_gui_upload_params():


### PR DESCRIPTION
Creates the ability to use local files for simulating GUI file uploads for unit-testing. Previously there was only the ability to load from URL sources. This will allow the use of local files so developers are not required an internet connection to run tests and to make use of default configuration files that are included in the repo.

Extracted from #808 