### PR TITLE
[MRG] Fix update gui default dicts

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1099,10 +1099,10 @@ def _get_poisson_widget(name, tstop_widget, layout, style, location, data=None,
         'tstop': 0.0,
         'seedcore': 14,
         'rate_constant': {
-            'L5_pyramidal': 8.5,
-            'L2_pyramidal': 8.5,
-            'L5_basket': 8.5,
-            'L2_basket': 8.5,
+            'L5_pyramidal': 40.,
+            'L2_pyramidal': 40.,
+            'L5_basket': 40.,
+            'L2_basket': 40.,
         }
     }
     if isinstance(data, dict):

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -983,9 +983,7 @@ def _get_cell_specific_widgets(layout, style, location, data=None):
         },
     }
     if isinstance(data, dict):
-        for k in default_data.keys():
-            if k in data and data[k] is not None:
-                default_data[k].update(data[k])
+        default_data = _update_nested_dict(default_data, data)
 
     kwargs = dict(layout=layout, style=style)
     cell_types = ['L5_pyramidal', 'L2_pyramidal', 'L5_basket', 'L2_basket']
@@ -1108,7 +1106,8 @@ def _get_poisson_widget(name, tstop_widget, layout, style, location, data=None,
         }
     }
     if isinstance(data, dict):
-        default_data.update(data)
+        default_data = _update_nested_dict(default_data, data)
+
     tstart = BoundedFloatText(
         value=default_data['tstart'], description='Start time (ms)',
         min=0, max=1e6, layout=layout, style=style)

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -888,6 +888,43 @@ def _prepare_upload_file(path):
     return uploaded_value
 
 
+def _update_nested_dict(original, new, skip_none=True):
+    """ Updates dictionary values from another dictionary
+
+    Will update nested dictionaries in the structure. New items from the
+    update dictionary are added and omitted items are retained from the
+    original dictionary. By default, will not pass None values from the update
+    dictionary.
+
+    Parameters
+    ----------
+    original : dict
+        Dictionary to update
+    new : dict
+        Dictionary with new values for updating
+    skip_none : bool, default True
+        None values in the new dictionary are not passed to the updated
+        dictionary by when True. If False None values will be passed to the
+        updated dictionary.
+
+    Returns
+    -------
+
+    """
+    updated = original.copy()
+    for key, value in new.items():
+        if (isinstance(value, dict) and
+                key in updated and
+                isinstance(updated[key], dict)):
+            updated[key] = _update_nested_dict(updated[key], value, skip_none)
+        elif value or not skip_none:
+            updated[key] = value
+        else:
+            pass
+
+    return updated
+
+
 def create_expanded_button(description, button_style, layout, disabled=False,
                            button_color="#8A2BE2"):
     return Button(description=description, button_style=button_style,

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -907,7 +907,7 @@ def _update_nested_dict(original, new, skip_none=True):
         dictionary by when True. If False None values will be passed to the
         updated dictionary.
 
-    Returns
+    Returns dict
     -------
 
     """

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -917,7 +917,7 @@ def _update_nested_dict(original, new, skip_none=True):
                 key in updated and
                 isinstance(updated[key], dict)):
             updated[key] = _update_nested_dict(updated[key], value, skip_none)
-        elif value or not skip_none:
+        elif (value is not None) or (not skip_none):
             updated[key] = value
         else:
             pass

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -20,6 +20,7 @@ from hnn_core.gui._viz_manager import (_idx2figname,
                                        unlink_relink)
 from hnn_core.gui.gui import (_init_network_from_widgets,
                               _prepare_upload_file,
+                              _update_nested_dict,
                               serialize_simulation)
 from hnn_core.network import pick_connection
 from hnn_core.network_models import jones_2009_model
@@ -779,3 +780,50 @@ def test_fig_tabs_dropdown_lists(setup_gui):
             # non "input histograms" plot type
             if ax_control.children[0].value != "input histogram":
                 assert not ax_control.children[4].disabled
+
+
+def test_update_nested_dict():
+    """Tests nested dictionary updates changes values appropriately."""
+    original = {'a': 0,
+                'b': {'a2': 0, 'b2': 0},
+                }
+
+    # Changes at each level
+    changes = {'a': 1,
+               'b': {'a2': 1, 'b2': 0},
+               }
+    updated = _update_nested_dict(original, changes)
+    expected = changes
+    assert updated == expected
+
+    # Omitted items should not be changed from in the original
+    omission = {'a': 1,
+                'b': {'a2': 0},
+                }
+    expected = {'a': 1,
+                'b': {'a2': 0, 'b2': 0},
+                }
+    updated = _update_nested_dict(original, omission)
+    assert updated == expected
+
+    # Additional items should be added
+    addition = {'a': 1,
+                'b': {'a2': 0, 'b2': 0, 'c2': 1},
+                'c': 1,
+                }
+    expected = addition
+    updated = _update_nested_dict(original, addition)
+    assert updated == expected
+
+    # Test passing of None values
+    has_none = {'a': 0,
+                'b': {'a2': None, 'b2': 0},
+                }
+    # Default behavior will not pass in None values to the update
+    expected = original  # No change expected
+    updated = _update_nested_dict(original, has_none)
+    assert updated == expected
+    # Skip_none set of False will pass in None values to the update
+    updated = _update_nested_dict(original, has_none, skip_none=False)
+    expected = has_none
+    assert updated == expected

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -784,40 +784,54 @@ def test_fig_tabs_dropdown_lists(setup_gui):
 
 def test_update_nested_dict():
     """Tests nested dictionary updates values appropriately."""
-    original = {'a': 0,
-                'b': {'a2': 0, 'b2': 0},
+    original = {'a': 1,
+                'b': {'a2': 0,
+                      'b2': {'a3': 0
+                             }
+                      },
                 }
 
     # Changes at each level
-    changes = {'a': 1,
-               'b': {'a2': 1, 'b2': 0},
+    changes = {'a': 2,
+               'b': {'a2': 1,
+                     'b2': {'a3': 1
+                            }
+                     },
                }
     updated = _update_nested_dict(original, changes)
     expected = changes
     assert updated == expected
 
     # Omitted items should not be changed from in the original
-    omission = {'a': 1,
+    omission = {'a': 2,
                 'b': {'a2': 0},
                 }
-    expected = {'a': 1,
-                'b': {'a2': 0, 'b2': 0},
+    expected = {'a': 2,
+                'b': {'a2': 0,
+                      'b2': {'a3': 0
+                             }
+                      },
                 }
     updated = _update_nested_dict(original, omission)
     assert updated == expected
 
     # Additional items should be added
-    addition = {'a': 1,
-                'b': {'a2': 0, 'b2': 0, 'c2': 1},
-                'c': 1,
+    addition = {'a': 2,
+                'b': {'a2': 0,
+                      'b2': {'a3': 0,
+                             'b3': 0,
+                             },
+                      'c2': 1
+                      },
+                'c': 1
                 }
     expected = addition
     updated = _update_nested_dict(original, addition)
     assert updated == expected
 
     # Test passing of None values
-    has_none = {'a': 0,
-                'b': {'a2': None, 'b2': 0},
+    has_none = {'a': 1,
+                'b': {'a2': None},
                 }
     # Default behavior will not pass in None values to the update
     expected = original  # No change expected
@@ -825,5 +839,24 @@ def test_update_nested_dict():
     assert updated == expected
     # Skip_none set of False will pass in None values to the update
     updated = _update_nested_dict(original, has_none, skip_none=False)
-    expected = has_none
+    expected = {'a': 1,
+                'b': {'a2': None,
+                      'b2': {'a3': 0
+                             }
+                      },
+                }
+    assert updated == expected
+
+    # Values that evaluate to False that but are not None type should be passed
+    # to the updated dict by default.
+    has_nulls = {'a': 0,
+                 'b': {'a2': np.nan,
+                       'b2': {'a3': False,
+                              'b3': ''
+                              }
+                       },
+                 }
+    # Skip_none set of False will pass in None values to the update
+    updated = _update_nested_dict(original, has_nulls)
+    expected = has_nulls
     assert updated == expected

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -783,7 +783,7 @@ def test_fig_tabs_dropdown_lists(setup_gui):
 
 
 def test_update_nested_dict():
-    """Tests nested dictionary updates changes values appropriately."""
+    """Tests nested dictionary updates values appropriately."""
     original = {'a': 0,
                 'b': {'a2': 0, 'b2': 0},
                 }


### PR DESCRIPTION
Dictionaries that are nested within dictionaries are not updated with the update method. A recursive function was added to search for dictionary keys of nested dictionaries for updating. This is used for updating default values for GUI widgets. 

Changes:
* Added a recursive update function that will search nested dictionaries for keys to update
* Updated default values for poisson widget

split from #808 