### PR TITLE
[MRG] ENH: `BatchSimulate` Class

### DIFF
--- a/examples/howto/plot_batch_simulate.py
+++ b/examples/howto/plot_batch_simulate.py
@@ -110,27 +110,32 @@ simulation_results = batch_simulation.run(param_grid,
 # backend='dask' if installed
 print("Simulation results:", simulation_results)
 ###############################################################################
-# Extract and Plot Results
-###############################################################################
+# This plot shows an overlay of all smoothed dipole waveforms from the
+# batch simulation. Each line represents a different set of parameters,
+# allowing us to visualize the range of responses across the parameter space.
 
-# Extract and overlay dipole waveforms
+
 dpl_waveforms = []
 for data_list in simulation_results['simulated_data']:
     for data in data_list:
-        dpl_waveforms.append(data['dpl'][0].data['agg'].copy().smooth(30))
+        window_len = 30
+        dpl_smooth = data['dpl'][0].copy().smooth(window_len)
+        dpl_waveforms.append(dpl_smooth.data['agg'])
 
 plt.figure(figsize=(10, 6))
 for waveform in dpl_waveforms:
-    plt.plot(waveform, alpha=0.5)
+    plt.plot(waveform, alpha=0.5, linewidth=3)
 plt.title('Overlay of Dipole Waveforms')
 plt.xlabel('Time (ms)')
 plt.ylabel('Dipole Amplitude (nAm)')
 plt.grid(True)
 plt.tight_layout()
-plt.savefig("image.png")
 plt.show()
+###############################################################################
+# This plot displays the minimum and maximum dipole peaks across
+# different synaptic strengths. This allows us to see how the range of
+# dipole activity changes as we vary the synaptic strength parameter.
 
-# Extract min and max peaks for plotting
 min_peaks, max_peaks, param_values = [], [], []
 for summary_list, data_list in zip(simulation_results['summary_statistics'],
                                    simulation_results['simulated_data']):

--- a/examples/howto/plot_batch_simulate.py
+++ b/examples/howto/plot_batch_simulate.py
@@ -86,7 +86,8 @@ def summary_func(results):
     """
     summary_stats = []
     for result in results:
-        dpl_data = result['dpl'][0].data['agg']
+        dpl_smooth = result['dpl'][0].copy().smooth(window_len=30)
+        dpl_data = dpl_smooth.data['agg']
         min_peak = np.min(dpl_data)
         max_peak = np.max(dpl_data)
         summary_stats.append({'min_peak': min_peak, 'max_peak': max_peak})
@@ -152,5 +153,6 @@ plt.ylabel('Dipole Peak Magnitude')
 plt.title('Min and Max Dipole Peaks across Simulations')
 plt.legend()
 plt.grid(True)
+plt.xscale('log')
 plt.tight_layout()
 plt.show()

--- a/examples/howto/plot_batch_simulate.py
+++ b/examples/howto/plot_batch_simulate.py
@@ -37,9 +37,6 @@ def set_params(param_values, net=None):
     net : instance of Network, optional
         If None, a new network is created using the specified model type.
     """
-    if net is None:
-        net = jones_2009_model()
-
     weights_ampa = {'L2_basket': param_values['weight_basket'],
                     'L2_pyramidal': param_values['weight_pyr'],
                     'L5_basket': param_values['weight_basket'],
@@ -102,7 +99,8 @@ def summary_func(results):
 
 
 # Run the batch simulation and collect the results.
-batch_simulation = BatchSimulate(set_params=set_params,
+batch_simulation = BatchSimulate(net=jones_2009_model(mesh_shape=(3, 3)),
+                                 set_params=set_params,
                                  summary_func=summary_func)
 simulation_results = batch_simulation.run(param_grid,
                                           n_jobs=n_jobs,

--- a/examples/howto/plot_batch_simulate.py
+++ b/examples/howto/plot_batch_simulate.py
@@ -118,8 +118,7 @@ print("Simulation results:", simulation_results)
 dpl_waveforms = []
 for data_list in simulation_results['simulated_data']:
     for data in data_list:
-        window_len = 30
-        dpl_smooth = data['dpl'][0].copy().smooth(window_len)
+        dpl_smooth = data['dpl'][0].copy().smooth(window_len=30)
         dpl_waveforms.append(dpl_smooth.data['agg'])
 
 plt.figure(figsize=(10, 6))

--- a/examples/howto/plot_batch_simulate.py
+++ b/examples/howto/plot_batch_simulate.py
@@ -99,7 +99,8 @@ def summary_func(results):
 
 
 # Run the batch simulation and collect the results.
-batch_simulation = BatchSimulate(net=jones_2009_model(mesh_shape=(3, 3)),
+net = jones_2009_model(mesh_shape=(3, 3))
+batch_simulation = BatchSimulate(net=net,
                                  set_params=set_params,
                                  summary_func=summary_func)
 simulation_results = batch_simulation.run(param_grid,

--- a/examples/howto/plot_batch_simulate.py
+++ b/examples/howto/plot_batch_simulate.py
@@ -117,7 +117,7 @@ print("Simulation results:", simulation_results)
 dpl_waveforms = []
 for data_list in simulation_results['simulated_data']:
     for data in data_list:
-        dpl_waveforms.append(data['dpl'][0].data['agg'])
+        dpl_waveforms.append(data['dpl'][0].data['agg'].copy().smooth(30))
 
 plt.figure(figsize=(10, 6))
 for waveform in dpl_waveforms:

--- a/examples/howto/plot_batch_simulate.py
+++ b/examples/howto/plot_batch_simulate.py
@@ -113,7 +113,6 @@ print("Simulation results:", simulation_results)
 # batch simulation. Each line represents a different set of parameters,
 # allowing us to visualize the range of responses across the parameter space.
 
-
 dpl_waveforms = []
 for data_list in simulation_results['simulated_data']:
     for data in data_list:

--- a/examples/howto/plot_batch_simulate.py
+++ b/examples/howto/plot_batch_simulate.py
@@ -62,8 +62,8 @@ def set_params(param_values, net=None):
 
 
 param_grid = {
-    'weight_basket': np.logspace(-4 - 1, 5),
-    'weight_pyr': np.logspace(-4, -1, 5)
+    'weight_basket': np.logspace(-4 - 1, 10),
+    'weight_pyr': np.logspace(-4, -1, 10)
 }
 
 ###############################################################################
@@ -113,18 +113,37 @@ print("Simulation results:", simulation_results)
 # Extract and Plot Results
 ###############################################################################
 
+# Extract and overlay dipole waveforms
+dpl_waveforms = []
+for data_list in simulation_results['simulated_data']:
+    for data in data_list:
+        dpl_waveforms.append(data['dpl'][0].data['agg'])
+
+plt.figure(figsize=(10, 6))
+for waveform in dpl_waveforms:
+    plt.plot(waveform, alpha=0.5)
+plt.title('Overlay of Dipole Waveforms')
+plt.xlabel('Time (ms)')
+plt.ylabel('Dipole Amplitude (nAm)')
+plt.grid(True)
+plt.tight_layout()
+plt.savefig("image.png")
+plt.show()
+
 # Extract min and max peaks for plotting
-min_peaks, max_peaks = [], []
-for summary_list in simulation_results['summary_statistics']:
-    for summary in summary_list:
+min_peaks, max_peaks, param_values = [], [], []
+for summary_list, data_list in zip(simulation_results['summary_statistics'],
+                                   simulation_results['simulated_data']):
+    for summary, data in zip(summary_list, data_list):
         min_peaks.append(summary['min_peak'])
         max_peaks.append(summary['max_peak'])
+        param_values.append(data['param_values']['weight_basket'])
 
 # Plotting
 plt.figure(figsize=(10, 6))
-plt.plot(min_peaks, label='Min Dipole Peak')
-plt.plot(max_peaks, label='Max Dipole Peak')
-plt.xlabel('Simulation Index')
+plt.plot(param_values, min_peaks, label='Min Dipole Peak')
+plt.plot(param_values, max_peaks, label='Max Dipole Peak')
+plt.xlabel('Synaptic Strength (nS)')
 plt.ylabel('Dipole Peak Magnitude')
 plt.title('Min and Max Dipole Peaks across Simulations')
 plt.legend()

--- a/examples/howto/plot_batch_simulate.py
+++ b/examples/howto/plot_batch_simulate.py
@@ -115,10 +115,10 @@ print("Simulation results:", simulation_results)
 
 # Extract min and max peaks for plotting
 min_peaks, max_peaks = [], []
-for res in simulation_results:
-    summary_stats = res[0]
-    min_peaks.append(summary_stats['min_peak'])
-    max_peaks.append(summary_stats['max_peak'])
+for summary_list in simulation_results['summary_statistics']:
+    for summary in summary_list:
+        min_peaks.append(summary['min_peak'])
+        max_peaks.append(summary['max_peak'])
 
 # Plotting
 plt.figure(figsize=(10, 6))

--- a/hnn_core/batch_simulate.py
+++ b/hnn_core/batch_simulate.py
@@ -179,9 +179,15 @@ class BatchSimulate(object):
         Returns
         -------
         results : dict
-            Dictionary containing summary statistics and simulation data
-            if return_output is True and clear_cache is False. Otherwise,
-            a dictionary containing only summary statistics.
+            Dictionary containing 'summary_statistics' and optionally
+            'simulated_data'.
+            'simulated_data' may include keys: 'dpl', 'lfp', 'spikes',
+            'voltages', 'param_values', 'net', 'times'.
+
+        Notes
+        -----
+        Return content depends on summary_func, return_output, and
+        clear_cache settings.
 
         """
         _validate_type(param_grid, types=(dict,), item_name='param_grid')

--- a/hnn_core/tests/test_batch_simulate.py
+++ b/hnn_core/tests/test_batch_simulate.py
@@ -8,6 +8,7 @@ import numpy as np
 import os
 
 from hnn_core.batch_simulate import BatchSimulate
+from hnn_core import jones_2009_model
 
 
 @pytest.fixture
@@ -32,7 +33,8 @@ def batch_simulate_instance(tmp_path):
                              weights_ampa=weights_ampa,
                              synaptic_delays=synaptic_delays)
 
-    return BatchSimulate(set_params=set_params,
+    net = jones_2009_model()
+    return BatchSimulate(net=net, set_params=set_params,
                          tstop=1.,
                          save_folder=tmp_path,
                          batch_size=3)
@@ -70,6 +72,9 @@ def test_parameter_validation():
     with pytest.raises(TypeError, match='set_params must be'):
         BatchSimulate(set_params='invalid')
 
+    with pytest.raises(TypeError, match="net must be"):
+        BatchSimulate(net="invalid_network", set_params=lambda x: x)
+
 
 def test_generate_param_combinations(batch_simulate_instance, param_grid):
     """Test generating parameter combinations."""
@@ -96,6 +101,7 @@ def test_run_single_sim(batch_simulate_instance):
     assert 'dpl' in result
     assert 'param_values' in result
     assert result['param_values'] == param_values
+    assert isinstance(result['net'], type(batch_simulate_instance.net))
 
 
 def test_simulate_batch(batch_simulate_instance, param_grid):


### PR DESCRIPTION
A follow-up PR to extend and refine the functionality of `BatchSimulate`.

- [x] Add options to specify which simulation results should be saved (dipole, spiking, LFP, voltages, currents, and calcium)
- [x] Add ability to save parameter values alongside simulation results
- [x] Add plot to example the shows dipole waveforms overlaid
- [x] Update x-axis on example to show the parameter value being varied (i.e. "Synaptic Strength (nS)")

- Linkcheck fails when BatchSimulate is added to the hnn_core __init__
 >  [To-do for me: figure out why linkcheck fails when BatchSimulate is added to the hnn_core __init__](https://github.com/jonescompneurolab/hnn-core/pull/811#issuecomment-2236774984)