### PR TITLE
fix: missing n_drive_cells argument during configuration to Network conversion

### DIFF
--- a/hnn_core/hnn_io.py
+++ b/hnn_core/hnn_io.py
@@ -177,6 +177,7 @@ def _read_external_drive(net, drive_data, read_output):
                              sigma=drive_data['dynamics']['sigma'],
                              numspikes=drive_data['dynamics']['numspikes'],
                              location=drive_data['location'],
+                             n_drive_cells=_set_from_cell_specific(drive_data),
                              cell_specific=drive_data['cell_specific'],
                              weights_ampa=drive_data['weights_ampa'],
                              weights_nmda=drive_data['weights_nmda'],


### PR DESCRIPTION
Added `n_drives_cells` argument to `add_evoked_drive` in the `read_external_drive` function used when converting a network configuration file to Network.

split from #808 