### PR TITLE
fix: GUI removed connection probability assignment 

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1649,8 +1649,6 @@ def _init_network_from_widgets(params, dt, tstop, single_simulation_data,
                 conn_idx = conn_indices[0]
                 single_simulation_data['net'].connectivity[conn_idx][
                     'nc_dict']['A_weight'] = vbox_key.children[1].value
-                single_simulation_data['net'].connectivity[conn_idx][
-                    'probability'] = vbox_key.children[2].value
 
     # Update cell params
 


### PR DESCRIPTION
Removed connection probability assignment in `_init_network_from_widgets`

This was removed because there is not a probability widget. Also, just updating the probability value  does not update underlying gid pairs using the probability. A setter will have to be created for the assignment to update the appropriate connection properties. This is planned future work. 