### PR TITLE
[MRG] GUI load confirmation message

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1622,6 +1622,8 @@ def on_upload_params_change(change, tstop, dt, log_out, drive_boxes,
                               drive_boxes, tstop, layout)
         else:
             raise ValueError
+
+        print(f"Loaded {load_type} from {param_dict['name']}")
     # Resets file counter to 0
     change['owner'].set_trait('value', ([]))
     return params


### PR DESCRIPTION
Added a confirmation message when connectivity or drives are loaded from file. 


<img width="584" alt="Screenshot 2024-07-31 at 5 06 42 PM" src="https://github.com/user-attachments/assets/498280ab-9ac6-443d-b678-18ced7b04177">
