### PR TITLE
[MRG] make L5/L2 pyr have different geometry options in GUI

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1489,7 +1489,8 @@ def add_cell_parameters_tab(cell_params_out, cell_pameters_vboxes,
     for cell_type in cell_types:
         layer_parameters = list()
         for layer in cell_parameters_dict.keys():
-            if 'Biophysic' in layer and cell_type[0] not in layer:
+            if ('Biophysic' in layer or 'Geometry' in layer) and \
+                    cell_type[0] not in layer:
                 continue
 
             for parameter in cell_parameters_dict[layer]:
@@ -1700,11 +1701,12 @@ def _init_network_from_widgets(params, dt, tstop, single_simulation_data,
                 cell_type = vbox_key.split()[0]
                 update_function(single_simulation_data['net'], cell_type,
                                 cell_param_list.children)
-                break  # why is this here?
+                # break  # why is this here?
 
     for cell_type in single_simulation_data['net'].cell_types.keys():
         single_simulation_data['net'].cell_types[cell_type]._update_end_pts()
-        single_simulation_data['net'].cell_types[cell_type]._compute_section_mechs()
+        single_simulation_data['net'].cell_types[
+            cell_type]._compute_section_mechs()
 
     if add_drive is False:
         return
@@ -1931,7 +1933,7 @@ def _update_synapse_cell_params(net, cell_param_key, param_list):
     param_indices = [
         (0, 1, 2), (3, 4, 5), (6, 7, 8), (9, 10, 11)]
 
-    # Update Dentrite
+    # Update Dendrite
     for section, indices in zip(synapse_sections, param_indices):
         network_synapses[section]['e'] = cell_params[indices[0]].value
         network_synapses[section]['tau1'] = cell_params[indices[1]].value
@@ -2019,8 +2021,9 @@ def _update_L5_biophysics_cell_params(net, cell_param_key, param_list):
     mechs_params['kca'] = {'gbar_kca': param_list[16].value}
     mechs_params['km'] = {'gbar_km': param_list[17].value}
     mechs_params['cat'] = {'gbar_cat': param_list[18].value}
-    mechs_params['ar'] = {'gbar_ar': partial(_exp_g_at_dist, zero_val=param_list[19].value,
-                                             exp_term=3e-3, offset=0.0)}
+    mechs_params['ar'] = {'gbar_ar': partial(
+        _exp_g_at_dist, zero_val=param_list[19].value,
+        exp_term=3e-3, offset=0.0)}
 
     update_common_dendrite_sections(sections, mechs_params)
 
@@ -2030,7 +2033,7 @@ def update_common_dendrite_sections(sections, mechs_params):
         name for name in sections.keys() if name != 'soma'
     ]
     for section in dendrite_sections:
-        sections[section].mechs.update(mechs_params)
+        sections[section].mechs.update(deepcopy(mechs_params))
 
 
 def _serialize_simulation(log_out, sim_data, simulation_list_widget):

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -55,8 +55,6 @@ cell_parameters_dict = {
         ('Apical Dendrite Trunk diameter', 'micron', 'apicaltrunk_diam'),
         ('Apical Dendrite 1 length', 'micron', 'apical1_L'),
         ('Apical Dendrite 1 diameter', 'micron', 'apical1_diam'),
-        # ('Apical Dendrite 2 length', 'micron', 'apical2_L'),
-        # ('Apical Dendrite 2 diameter', 'micron', 'apical2_diam'),
         ('Apical Dendrite Tuft length', 'micron', 'apicaltuft_L'),
         ('Apical Dendrite Tuft diameter', 'micron', 'apicaltuft_diam'),
         ('Oblique Apical Dendrite length', 'micron', 'apicaloblique_L'),

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1699,7 +1699,7 @@ def _init_network_from_widgets(params, dt, tstop, single_simulation_data,
                 cell_type = vbox_key.split()[0]
                 update_function(single_simulation_data['net'], cell_type,
                                 cell_param_list.children)
-                # break  # why is this here?
+                break  # update needed only once per vbox_key
 
     for cell_type in single_simulation_data['net'].cell_types.keys():
         single_simulation_data['net'].cell_types[cell_type]._update_end_pts()

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -284,12 +284,9 @@ def test_gui_init_network():
     assert np.isclose(_single_simulation['net']._layer_separation, 1307.4)
 
     default_network_configuration = read_params(hnn_core_root / 'param' / 'default.json')
-    net = jones_2009_model(params=default_network_configuration)
-    for section in _single_simulation['net'].cell_types['L5_pyramidal'].sections:
-        print(section)
-        # assert _single_simulation['net'].cell_types['L5_pyramidal'].sections[section].mechs == net.cell_types['L5_pyramidal'].sections[section].mechs
-        assert _single_simulation['net'].cell_types['L5_pyramidal'].sections[section].L == net.cell_types['L5_pyramidal'].sections[section].L
+    net = jones_2009_model(params=default_network_configuration, add_drives_from_params=True)
 
+    assert _single_simulation['net'] == net
 
 @requires_mpi4py
 @requires_psutil

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -12,7 +12,7 @@ import traitlets
 import os
 
 from pathlib import Path
-from hnn_core import Dipole, Network
+from hnn_core import Dipole, Network, read_params, jones_2009_model
 from hnn_core.gui import HNNGUI
 from hnn_core.gui._viz_manager import (_idx2figname,
                                        _plot_types,
@@ -282,6 +282,13 @@ def test_gui_init_network():
     # copied from test_network.py
     assert np.isclose(_single_simulation['net']._inplane_distance, 1.)
     assert np.isclose(_single_simulation['net']._layer_separation, 1307.4)
+
+    default_network_configuration = read_params(hnn_core_root / 'param' / 'default.json')
+    net = jones_2009_model(params=default_network_configuration)
+    for section in _single_simulation['net'].cell_types['L5_pyramidal'].sections:
+        print(section)
+        # assert _single_simulation['net'].cell_types['L5_pyramidal'].sections[section].mechs == net.cell_types['L5_pyramidal'].sections[section].mechs
+        assert _single_simulation['net'].cell_types['L5_pyramidal'].sections[section].L == net.cell_types['L5_pyramidal'].sections[section].L
 
 
 @requires_mpi4py

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -283,10 +283,13 @@ def test_gui_init_network():
     assert np.isclose(_single_simulation['net']._inplane_distance, 1.)
     assert np.isclose(_single_simulation['net']._layer_separation, 1307.4)
 
-    default_network_configuration = read_params(hnn_core_root / 'param' / 'default.json')
-    net = jones_2009_model(params=default_network_configuration, add_drives_from_params=True)
+    default_network_configuration = read_params(
+        hnn_core_root / 'param' / 'default.json')
+    net = jones_2009_model(
+        params=default_network_configuration, add_drives_from_params=True)
 
     assert _single_simulation['net'] == net
+
 
 @requires_mpi4py
 @requires_psutil
@@ -778,7 +781,8 @@ def test_gui_cell_params_widgets(setup_gui):
 
     # Check the if the cell params dictionary has been updated
     cell_params = gui.get_cell_parameters_dict()
-    assert (len(cell_params['Geometry']) == 20)
+    assert (len(cell_params['Geometry L2']) == 20)
+    assert (len(cell_params['Geometry L5']) == 22)
     assert (len(cell_params['Synapses']) == 12)
     assert (len(cell_params['Biophysics L2']) == 10)
     assert (len(cell_params['Biophysics L5']) == 20)


### PR DESCRIPTION
The current implementation of the cell parameter widget skips over a compartment of L5 pyramidal cells

This PR correctly updates the compartment parameters, as well as improves testing to make sure the GUI network matches the API instantiated network