### PR TITLE
[MRG] fix GUI MPI test

### DIFF
--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -383,6 +383,7 @@ def test_gui_run_simulation_mpi(setup_gui):
     dpls = gui.simulation_data[default_name]['dpls']
     assert isinstance(gui.simulation_data[default_name]["net"], Network)
     assert isinstance(dpls, list)
+    assert len(dpls) > 0
     assert all([isinstance(dpl, Dipole) for dpl in dpls])
     plt.close('all')
 

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -373,12 +373,17 @@ def test_gui_init_network(setup_gui):
 
 @requires_mpi4py
 @requires_psutil
-def test_gui_run_simulation_mpi(setup_gui):
+def test_gui_run_simulation_mpi():
     """Test if run button triggers simulation with MPIBackend."""
-    gui = setup_gui
+    gui = HNNGUI()
+    _ = gui.compose()
 
+    gui.widget_tstop.value = 70
+    gui.widget_dt.value = 0.5
     gui.widget_backend_selection.value = "MPI"
+    gui.widget_ntrials.value = 2
     gui.run_button.click()
+
     default_name = gui.widget_simulation_name.value
     dpls = gui.simulation_data[default_name]['dpls']
     assert isinstance(gui.simulation_data[default_name]["net"], Network)


### PR DESCRIPTION
Updated `test_gui_run_simulation_mpi`.  The test was not actually testing if any dipoles were constructed. 

* Added assert that the dipole list is not empty 
* Updated the function to use the default network instead of gui test fixture (smaller mesh grid) because it was not working with MPI.  Presumably because the smaller network used in the fixture was not compatible with the parameterization of multiprocessing subprocess call.
    *  We were encountering an error at the `h.finitialize` step of `network_builder`>`_simulate_single_trial` when using the fixture network. The error was within neuron: "NEURON: mindelay is 0 (or less than dt for fixed step method)".
