### PR TITLE
[MRG] Fix GUI MPI available cores

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -348,7 +348,7 @@ class HNNGUI:
 
         # Number of available cores
         [self.n_cores, _] = _determine_cores_hwthreading(
-            enable_hwthreading=False,
+            use_hwthreading_if_found=False,
             sensible_default_cores=True,
         )
 
@@ -2094,11 +2094,15 @@ def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
 
         print("start simulation")
         if backend_selection.value == "MPI":
+            # 'use_hwthreading_if_found' and 'sensible_default_cores' have
+            # already been set elsewhere, and do not need to be re-set here.
+            # Hardware-threading and oversubscription will always be disabled
+            # to prevent edge cases in the GUI.
             backend = MPIBackend(
                 n_procs=n_jobs.value,
                 mpi_cmd=mpi_cmd.value,
-                hwthreading=False,
-                oversubscribe=False,
+                override_hwthreading_option=False,
+                override_oversubscribe_option=False,
             )
         else:
             backend = JoblibBackend(n_jobs=n_jobs.value)

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -2076,7 +2076,10 @@ def _init_network_from_widgets(params, dt, tstop, single_simulation_data,
 
 
 def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
-                       all_data, dt, tstop, ntrials, backend_selection,
+                       all_data, dt, tstop,
+                       fig_default_params, widget_default_smoothing,
+                       widget_min_frequency, widget_max_frequency,
+                       ntrials, backend_selection,
                        mpi_cmd, n_jobs, params, simulation_status_bar,
                        simulation_status_contents, connectivity_textfields,
                        viz_manager, simulations_list_widget,

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -2083,7 +2083,7 @@ def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
         print("start simulation")
         if backend_selection.value == "MPI":
             backend = MPIBackend(
-                n_procs=n_cores - 1,
+                n_procs=n_jobs.value,
                 mpi_cmd=mpi_cmd.value)
         else:
             backend = JoblibBackend(n_jobs=n_jobs.value)
@@ -2391,7 +2391,7 @@ def handle_backend_change(backend_type, backend_config, mpi_cmd, n_jobs):
     backend_config.clear_output()
     with backend_config:
         if backend_type == "MPI":
-            display(mpi_cmd)
+            display(VBox(children=[n_jobs, mpi_cmd]))
         elif backend_type == "Joblib":
             display(n_jobs)
 

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -2041,11 +2041,8 @@ def _init_network_from_widgets(params, dt, tstop, single_simulation_data,
 
 
 def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
-                       all_data, dt, tstop,
-                       fig_default_params, widget_default_smoothing,
-                       widget_min_frequency, widget_max_frequency,
-                       ntrials, backend_selection,
-                       mpi_cmd, n_jobs, params, simulation_status_bar,
+                       all_data, dt, tstop, ntrials, backend_selection,
+                       mpi_cmd, n_cores, n_jobs, params, simulation_status_bar,
                        simulation_status_contents, connectivity_textfields,
                        viz_manager, simulations_list_widget,
                        cell_pameters_widgets):
@@ -2072,7 +2069,8 @@ def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
         print("start simulation")
         if backend_selection.value == "MPI":
             backend = MPIBackend(
-                n_procs=multiprocessing.cpu_count() - 1, mpi_cmd=mpi_cmd.value)
+                n_procs=n_cores - 1,
+                mpi_cmd=mpi_cmd.value)
         else:
             backend = JoblibBackend(n_jobs=n_jobs.value)
             print(f"Using Joblib with {n_jobs.value} core(s).")

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -496,6 +496,13 @@ class HNNGUI:
 
     @staticmethod
     def _available_cores():
+        """Return the number of available cores to the process.
+
+        This is important for systems where the number of available cores is
+        partitioned such as on HPC systems. Linux and Windows can return cpu
+        affinity, which is the number of available cores. MacOS can only return
+        total system cores.
+        """
         # For macos
         if platform.system() == 'Darwin':
             return psutil.cpu_count()

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -490,6 +490,15 @@ class HNNGUI:
         self._init_ui_components()
         self.add_logging_window_logger()
 
+    @staticmethod
+    def _available_cores():
+        # For macos
+        if platform.system() == 'Darwin':
+            return psutil.cpu_count()
+        # For Linux and Windows
+        else:
+            return len(psutil.Process().cpu_affinity())
+
     def get_cell_parameters_dict(self):
         """Returns the number of elements in the
             cell_parameters_dict dictionary.

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -7,8 +7,9 @@ import codecs
 import io
 import logging
 import mimetypes
-import multiprocessing
 import numpy as np
+import platform
+import psutil
 import sys
 import json
 import urllib.parse
@@ -344,6 +345,9 @@ class HNNGUI:
         # load default parameters
         self.params = self.load_parameters(network_configuration)
 
+        # Number of available cores
+        self.n_cores = self._available_cores()
+
         # In-memory storage of all simulation and visualization related data
         self.simulation_data = defaultdict(lambda: dict(net=None, dpls=list()))
 
@@ -402,7 +406,7 @@ class HNNGUI:
                                    placeholder='Fill if applies',
                                    description='MPI cmd:', disabled=False)
         self.widget_n_jobs = BoundedIntText(value=1, min=1,
-                                            max=multiprocessing.cpu_count(),
+                                            max=self.n_cores,
                                             description='Cores:',
                                             disabled=False)
         self.load_data_button = FileUpload(
@@ -641,8 +645,9 @@ class HNNGUI:
                 self.fig_default_params, self.widget_default_smoothing,
                 self.widget_min_frequency, self.widget_max_frequency,
                 self.widget_ntrials, self.widget_backend_selection,
-                self.widget_mpi_cmd, self.widget_n_jobs, self.params,
-                self._simulation_status_bar, self._simulation_status_contents,
+                self.widget_mpi_cmd, self.n_cores, self.widget_n_jobs,
+                self.params, self._simulation_status_bar,
+                self._simulation_status_contents,
                 self.connectivity_widgets, self.viz_manager,
                 self.simulation_list_widget, self.cell_pameters_widgets)
 

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -772,6 +772,10 @@ class HNNGUI:
                 self.widget_max_frequency,
             ])
         ], layout=self.layout['config_box'])
+        # Displays the default backend options
+        handle_backend_change(self.widget_backend_selection.value,
+                              self._backend_config_out, self.widget_mpi_cmd,
+                              self.widget_n_jobs)
 
         connectivity_configuration = Tab()
 

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -645,7 +645,7 @@ class HNNGUI:
                 self.fig_default_params, self.widget_default_smoothing,
                 self.widget_min_frequency, self.widget_max_frequency,
                 self.widget_ntrials, self.widget_backend_selection,
-                self.widget_mpi_cmd, self.n_cores, self.widget_n_jobs,
+                self.widget_mpi_cmd, self.widget_n_jobs,
                 self.params, self._simulation_status_bar,
                 self._simulation_status_contents,
                 self.connectivity_widgets, self.viz_manager,
@@ -2060,7 +2060,7 @@ def _init_network_from_widgets(params, dt, tstop, single_simulation_data,
 
 def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
                        all_data, dt, tstop, ntrials, backend_selection,
-                       mpi_cmd, n_cores, n_jobs, params, simulation_status_bar,
+                       mpi_cmd, n_jobs, params, simulation_status_bar,
                        simulation_status_contents, connectivity_textfields,
                        viz_manager, simulations_list_widget,
                        cell_pameters_widgets):

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -36,6 +36,7 @@ from hnn_core.params_default import (get_L2Pyr_params_default,
                                      get_L5Pyr_params_default)
 from hnn_core.hnn_io import dict_to_network, write_network_configuration
 from hnn_core.cells_default import _exp_g_at_dist
+from hnn_core.parallel_backends import _has_mpi4py, _has_psutil
 
 hnn_core_root = Path(hnn_core.__file__).parent
 default_network_configuration = (hnn_core_root / 'param' /
@@ -398,10 +399,11 @@ class HNNGUI:
                                            placeholder='ID of your simulation',
                                            description='Name:',
                                            disabled=False)
-        self.widget_backend_selection = Dropdown(options=[('Joblib', 'Joblib'),
-                                                          ('MPI', 'MPI')],
-                                                 value='Joblib',
-                                                 description='Backend:')
+        self.widget_backend_selection = (
+            Dropdown(options=[('Joblib', 'Joblib'),
+                              ('MPI', 'MPI')],
+                     value=self._check_backend(),
+                     description='Backend:'))
         self.widget_mpi_cmd = Text(value='mpiexec',
                                    placeholder='Fill if applies',
                                    description='MPI cmd:', disabled=False)
@@ -509,6 +511,14 @@ class HNNGUI:
         # For Linux and Windows
         else:
             return len(psutil.Process().cpu_affinity())
+
+    @staticmethod
+    def _check_backend():
+        """Checks for MPI and returns the default backend name"""
+        default_backend = 'Joblib'
+        if _has_mpi4py() and _has_psutil():
+            default_backend = 'MPI'
+        return default_backend
 
     def get_cell_parameters_dict(self):
         """Returns the number of elements in the

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -774,15 +774,15 @@ class MPIBackend(object):
         The name of the mpi launcher executable. Will use 'mpiexec' (openmpi)
         by default.
     hwthreading : None | bool
-        Whether or not to tell MPI to use hardware-threading. Defaults to
-        'None', in which case it will use a heuristic for determing whether to
-        use it. If 'False', then hardware-threading is never used, and if
-        'True', then hardware-threading is always used.
+        Specifies if MPI should use hardware-threading. Defaults to 'None',
+        in which a heuristic will be used to decide. If 'False', then
+        hardware-threading is disabled, and if 'True', then hardware-threading
+        is always enabled.
     oversubscribe : None | bool
-        Whether or not to tell MPI to use oversubscription. Defaults to 'None',
-        in which case it will use a heuristic for determing whether to use
-        it. If 'False', then oversubscription is never used, and if 'True',
-        then oversubscription is always used.
+        Specifies if MPI should use oversubscription. Defaults to 'None',
+        in which a heuristic will be used to decide. If 'False', then
+        oversubscription is disabled, and if 'True', then oversubscription is
+        always enabled.
 
     Attributes
     ----------

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -893,6 +893,20 @@ class MPIBackend(object):
                 "cores. Enabling MPI oversubscription automatically."
             )
             self.mpi_cmd += " --oversubscribe"
+        elif (
+                (override_oversubscribe_option is False) and
+                (self.n_procs > n_available_cores)
+        ):
+            warn(
+                "Number of requested MPI processes exceeds available "
+                "cores. However, you have forced off MPI oversubscription. The"
+                "MPI simulation will almost certainly fail. If you see this"
+                "message, you should either decrease the number of 'n_procs'"
+                "used or re-enable oversubscription, unless you know what you"
+                "are doing and have made alternative changes. "
+            )
+            pass
+
 
         self.mpi_cmd += " -np " + str(self.n_procs)
 

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -796,10 +796,16 @@ class MPIBackend(object):
         this is passed to an option of the same name in
         `_determine_cores_hwthreading`; see that function for more details.
     sensible_default_cores : bool
-        Specifies whether to limit the number of CPU cores used based on a
-        "reasonable" heuristic. Defaults to 'False'. Note that this is passed
-        to an option of the same name in `_determine_cores_hwthreading`; see
-        that function for more details.
+        Whether to decrease the number of cores returned in a "reasonable
+        manner", such that it balances speed with the user
+        experience. Specifically, this means that if the number of available
+        cores is greater than some threshold (default 12), the threshold number
+        of cores will be used instead of the total. If the number of cores is
+        greater than 2 but less than the threshold (default 12), then the
+        number of cores used will be subtracted by 1, so that there is a core
+        left unused for the sake of the OS. Defaults to 'False'. Note that this
+        is passed to an option of the same name in
+        `_determine_cores_hwthreading`
     override_hwthreading_option : None | bool
         Force use of MPI's '--use-hwthread-cpus' support if changed from its
         default value of 'None'. By default, '--use-hwthread-cpus' is only
@@ -849,7 +855,7 @@ class MPIBackend(object):
         # Check of psutil and mpi4py import has been moved into this function,
         # since this function is called by GUI before MPIBackend()
         # instantiated.
-        [n_available_cores, hwthreading_available] = \
+        n_available_cores, hwthreading_available = \
             _determine_cores_hwthreading(
                 use_hwthreading_if_found=use_hwthreading_if_found,
                 sensible_default_cores=sensible_default_cores)

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -573,7 +573,7 @@ class JoblibBackend(object):
 
 def _determine_cores_hwthreading(
         use_hwthreading_if_found: bool = True,
-        sensible_default_cores: bool = False,
+        sensible_default_cores: bool = True,
 ) -> [int, bool]:
     """Return the available core number and if hardware-threading is detected.
 
@@ -616,7 +616,7 @@ def _determine_cores_hwthreading(
         of cores will be used instead of the total. If the number of cores is
         greater than 2 but less than the threshold (default 12), then the
         number of cores used will be subtracted by 1, so that there is a core
-        left unused for the sake of the OS. Defaults to 'False'.
+        left unused for the sake of the OS. Defaults to 'True'.
 
     Returns
     -------
@@ -803,7 +803,7 @@ class MPIBackend(object):
         of cores will be used instead of the total. If the number of cores is
         greater than 2 but less than the threshold (default 12), then the
         number of cores used will be subtracted by 1, so that there is a core
-        left unused for the sake of the OS. Defaults to 'False'. Note that this
+        left unused for the sake of the OS. Defaults to 'True'. Note that this
         is passed to an option of the same name in
         `_determine_cores_hwthreading`
     override_hwthreading_option : None | bool
@@ -844,7 +844,7 @@ class MPIBackend(object):
         n_procs: Union[None, int] = None,
         mpi_cmd: str = "mpiexec",
         use_hwthreading_if_found: bool = True,
-        sensible_default_cores: bool = False,
+        sensible_default_cores: bool = True,
         override_hwthreading_option: Union[None, bool] = None,
         override_oversubscribe_option: Union[None, bool] = None,
     ) -> None:

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -396,7 +396,7 @@ def test_gui_run_simulations(setup_gui):
     tstop_trials_tstep = [(10, 1, 0.25),
                           (10, 2, 0.5),
                           (12, 1, 0.5)]
-    assert gui.widget_backend_selection.value == "Joblib"
+    gui.widget_backend_selection.value = "Joblib"
     sim_count = 0
 
     for val_tstop, val_ntrials, val_tstep in tstop_trials_tstep:

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -241,24 +241,18 @@ class TestParallelBackends():
                 simulate_dipole(net, tstop=40)
 
         # Check that the simulation fails if oversubscribe is forced off
-        with pytest.warns(UserWarning) as record:
-            with MPIBackend(
-                    n_procs=oversubscribed_procs,
-                    use_hwthreading_if_found=use_hwthreading_if_found,
-                    override_oversubscribe_option=False,
-            ) as backend:
-                assert "--oversubscribe" not in ' '.join(backend.mpi_cmd)
-                if detected_hwthreading:
-                    assert "--use-hwthread-cpus" in ' '.join(backend.mpi_cmd)
-                with pytest.raises(
-                        RuntimeError,
-                        match="MPI simulation failed. Return code: 1"):
-                    simulate_dipole(net, tstop=40)
-
-            expected_string = ('Received BrokenPipeError exception. '
-                               'Child process failed unexpectedly')
-            assert len(record) == 2
-            assert expected_string in record[0].message.args[0]
+        with MPIBackend(
+                n_procs=oversubscribed_procs,
+                use_hwthreading_if_found=use_hwthreading_if_found,
+                override_oversubscribe_option=False,
+        ) as backend:
+            assert "--oversubscribe" not in ' '.join(backend.mpi_cmd)
+            if detected_hwthreading:
+                assert "--use-hwthread-cpus" in ' '.join(backend.mpi_cmd)
+            with pytest.raises(
+                    RuntimeError,
+                    match="MPI simulation failed. Return code: 1"):
+                simulate_dipole(net, tstop=40)
 
         # Check that simulation succeeds if oversubscription is activated but
         # unnecessary

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -240,11 +240,12 @@ class TestParallelBackends():
                 assert "--oversubscribe" in ' '.join(backend.mpi_cmd)
                 simulate_dipole(net, tstop=40)
 
-        # Case 2: Check that no warning, but option passed if oversubscription
-        # is forced on. No simulation since MacOS CI runners randomly (but not
-        # always) fail to run in the following case, even though the same
-        # simulation succeeds in Case 1 above. This is probably due to MPI
-        # instability with the MacOS CI runners (see #992 for an example).
+        # Case 2: Check that '--oversubscribe' option is passed if
+        # oversubscription is forced on. No simulation is run in this case
+        # since MacOS CI runners randomly (but not always) fail to run in the
+        # following case, even though the same simulation succeeds in Case 1
+        # above. This is probably due to MPI instability with the MacOS CI
+        # runners (see #992 for an example).
         override_oversubscribe_option = True
         with MPIBackend(
                 n_procs=oversubscribed_procs,

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -240,8 +240,11 @@ class TestParallelBackends():
                 assert "--oversubscribe" in ' '.join(backend.mpi_cmd)
                 simulate_dipole(net, tstop=40)
 
-        # Case 2: Check that the simulation runs, but with no warning if
-        # oversubscription is forced on
+        # Case 2: Check that no warning, but option passed if oversubscription
+        # is forced on. No simulation since MacOS CI runners randomly (but not
+        # always) fail to run in the following case, even though the same
+        # simulation succeeds in Case 1 above. This is probably due to MPI
+        # instability with the MacOS CI runners (see #992 for an example).
         override_oversubscribe_option = True
         with MPIBackend(
                 n_procs=oversubscribed_procs,
@@ -249,7 +252,6 @@ class TestParallelBackends():
                 override_oversubscribe_option=override_oversubscribe_option,
         ) as backend:
             assert "--oversubscribe" in ' '.join(backend.mpi_cmd)
-            simulate_dipole(net, tstop=40)
 
         # Case 3: Check that the simulation fails if oversubscribe is forced
         # off


### PR DESCRIPTION
The GUI MPI was not working on HPC systems where the number of cores partitioned to an instance is less than the total cores of a node. 

This fix uses the number of available cores to the process instead of the total number of cores of the system. 

**Work done**
1. Use psutil to get number of available cores instead of total system cores for Linux and Windows. Mac will still use total system cores.
2. Exposed the number of cores selection for the MPI backend. Default is set to 1 and the maximum is set to the number of available cores. 
3. Fixed the issue where the backend sub-options (n cores) was not displaying for the default (joblib) on startup  

![Screenshot 2024-08-26 at 1 49 28 PM](https://github.com/user-attachments/assets/df742d3c-5d5e-404a-8594-c6358e9e0ccd)

closes #870 