### PR TITLE
[MRG] Fix MPIBackend platform logic

### DIFF
--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -648,11 +648,7 @@ class MPIBackend(object):
                          'mpi_child.py')
 
         # Split the command into shell arguments for passing to Popen
-        if 'win' in sys.platform:
-            use_posix = True
-        else:
-            use_posix = False
-        self.mpi_cmd = shlex.split(self.mpi_cmd, posix=use_posix)
+        self.mpi_cmd = shlex.split(self.mpi_cmd, posix=sys.platform != 'win32')
 
     def __enter__(self):
         global _BACKEND

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -85,7 +85,7 @@ def _get_mpi_env():
     """Set some MPI environment variables."""
     my_env = os.environ.copy()
     # For Linux systems
-    if sys.platform not in ['win32', 'darwin']:
+    if sys.platform != 'win32':
         my_env["OMPI_MCA_btl_base_warn_component_unused"] = '0'
 
     if 'darwin' in sys.platform:

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -649,7 +649,8 @@ class MPIBackend(object):
                          'mpi_child.py')
 
         # Split the command into shell arguments for passing to Popen
-        self.mpi_cmd = shlex.split(self.mpi_cmd, posix=sys.platform != 'win32')
+        use_posix = True if sys.platform != 'win32' else False
+        self.mpi_cmd = shlex.split(self.mpi_cmd, posix=use_posix)
 
     def __enter__(self):
         global _BACKEND

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -84,7 +84,8 @@ def _gather_trial_data(sim_data, net, n_trials, postproc):
 def _get_mpi_env():
     """Set some MPI environment variables."""
     my_env = os.environ.copy()
-    if 'win' not in sys.platform:
+    # For Linux systems
+    if sys.platform not in ['win32', 'darwin']:
         my_env["OMPI_MCA_btl_base_warn_component_unused"] = '0'
 
     if 'darwin' in sys.platform:


### PR DESCRIPTION
Updated the logic for MPIBackend and get_mpi_env function to not use the obtuse 'win' string search. 

closes #875 