### PR TITLE
[MRG] GUI: delete single drive button

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -926,96 +926,97 @@ class HNNGUI:
             return
 
         style = {'description_width': '125px'}
-        self._drives_out.clear_output()
         if not prespecified_drive_data:
             prespecified_drive_data = {}
         prespecified_drive_data.update({"seedcore": max(event_seed, 2)})
 
-        with self._drives_out:
-            if not prespecified_drive_name:
-                name = drive_type + str(len(self.drive_boxes))
-            else:
-                name = prespecified_drive_name
-            if drive_type in ('Rhythmic', 'Bursty'):
-                drive, drive_box = _get_rhythmic_widget(
-                    name,
-                    self.widget_tstop,
-                    layout,
-                    style,
-                    location,
-                    data=prespecified_drive_data,
-                    weights_ampa=prespecified_weights_ampa,
-                    weights_nmda=prespecified_weights_nmda,
-                    delays=prespecified_delays,
-                    n_drive_cells=prespecified_n_drive_cells,
-                    cell_specific=prespecified_cell_specific,
-                )
-            elif drive_type == 'Poisson':
-                drive, drive_box = _get_poisson_widget(
-                    name,
-                    self.widget_tstop,
-                    layout,
-                    style,
-                    location,
-                    data=prespecified_drive_data,
-                    weights_ampa=prespecified_weights_ampa,
-                    weights_nmda=prespecified_weights_nmda,
-                    delays=prespecified_delays,
-                    n_drive_cells=prespecified_n_drive_cells,
-                    cell_specific=prespecified_cell_specific,
-                )
-            elif drive_type in ('Evoked', 'Gaussian'):
-                drive, drive_box = _get_evoked_widget(
-                    name,
-                    layout,
-                    style,
-                    location,
-                    data=prespecified_drive_data,
-                    weights_ampa=prespecified_weights_ampa,
-                    weights_nmda=prespecified_weights_nmda,
-                    delays=prespecified_delays,
-                    n_drive_cells=prespecified_n_drive_cells,
-                    cell_specific=prespecified_cell_specific,
-                )
-            elif drive_type == 'Tonic':
-                drive, drive_box = _get_tonic_widget(
-                    name,
-                    self.widget_tstop,
-                    layout,
-                    style,
-                    data=prespecified_drive_data
-                )
-
-            # Add delete button
-            delete_button = Button(
-                description='Delete',
-                button_style='danger',
-                icon='close',
-                layout=self.layout['del_fig_btn']
+        if not prespecified_drive_name:
+            name = drive_type + str(len(self.drive_boxes))
+        else:
+            name = prespecified_drive_name
+        if drive_type in ('Rhythmic', 'Bursty'):
+            drive, drive_box = _get_rhythmic_widget(
+                name,
+                self.widget_tstop,
+                layout,
+                style,
+                location,
+                data=prespecified_drive_data,
+                weights_ampa=prespecified_weights_ampa,
+                weights_nmda=prespecified_weights_nmda,
+                delays=prespecified_delays,
+                n_drive_cells=prespecified_n_drive_cells,
+                cell_specific=prespecified_cell_specific,
             )
-            # Call-back on drive deletion
-            delete_button.on_click(self._delete_single_drive)
-            drive_box.children += (HTML(value="<p> </p>"),
-                                   delete_button)
+        elif drive_type == 'Poisson':
+            drive, drive_box = _get_poisson_widget(
+                name,
+                self.widget_tstop,
+                layout,
+                style,
+                location,
+                data=prespecified_drive_data,
+                weights_ampa=prespecified_weights_ampa,
+                weights_nmda=prespecified_weights_nmda,
+                delays=prespecified_delays,
+                n_drive_cells=prespecified_n_drive_cells,
+                cell_specific=prespecified_cell_specific,
+            )
+        elif drive_type in ('Evoked', 'Gaussian'):
+            drive, drive_box = _get_evoked_widget(
+                name,
+                layout,
+                style,
+                location,
+                data=prespecified_drive_data,
+                weights_ampa=prespecified_weights_ampa,
+                weights_nmda=prespecified_weights_nmda,
+                delays=prespecified_delays,
+                n_drive_cells=prespecified_n_drive_cells,
+                cell_specific=prespecified_cell_specific,
+            )
+        elif drive_type == 'Tonic':
+            drive, drive_box = _get_tonic_widget(
+                name,
+                self.widget_tstop,
+                layout,
+                style,
+                data=prespecified_drive_data
+            )
 
-            if drive_type in [
-                'Evoked', 'Poisson', 'Rhythmic', 'Bursty', 'Gaussian', 'Tonic'
-            ]:
-                self.drive_boxes.append(drive_box)
-                self.drive_widgets.append(drive)
+        # Add delete button
+        delete_button = Button(
+            description='Delete',
+            button_style='danger',
+            icon='close',
+            layout=self.layout['del_fig_btn']
+        )
+        # Call-back on drive deletion
+        delete_button.on_click(self._delete_single_drive)
+        drive_box.children += (HTML(value="<p> </p>"),
+                               delete_button)
 
-            if render:
-                self.drive_accordion.children = self.drive_boxes
-                self.drive_accordion.selected_index = (
-                    len(self.drive_boxes) - 1 if expand_last_drive else None
-                )
+        if drive_type in [
+            'Evoked', 'Poisson', 'Rhythmic', 'Bursty', 'Gaussian', 'Tonic'
+        ]:
+            self.drive_boxes.append(drive_box)
+            self.drive_widgets.append(drive)
 
-                for idx, drive in enumerate(self.drive_widgets):
-                    tab_name = drive['name']
-                    if drive['type'] != 'Tonic':
-                        tab_name += f" ({drive['location']})"
-                    self.drive_accordion.set_title(idx, tab_name)
+        if render:
+            # Construct accordion object
+            self.drive_accordion.children = self.drive_boxes
+            self.drive_accordion.selected_index = (
+                len(self.drive_boxes) - 1 if expand_last_drive else None
+            )
+            # Update accordion title with location
+            for idx, drive in enumerate(self.drive_widgets):
+                tab_name = drive['name']
+                if drive['type'] != 'Tonic':
+                    tab_name += f" ({drive['location']})"
+                self.drive_accordion.set_title(idx, tab_name)
 
+            self._drives_out.clear_output()
+            with self._drives_out:
                 display(self.drive_accordion)
 
     def add_drive_tab(self, params):

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1680,55 +1680,6 @@ def get_cell_param_default_value(cell_type_key, param_dict):
     return param_dict[cell_type_key]
 
 
-def add_drive_tab(params, log_out, drives_out, drive_widgets, drive_boxes,
-                  tstop, layout):
-    net = dict_to_network(params)
-    drive_specs = net.external_drives
-    tonic_specs = net.external_biases
-
-    # clear before adding drives
-    drives_out.clear_output()
-    while len(drive_widgets) > 0:
-        drive_widgets.pop()
-        drive_boxes.pop()
-
-    drive_names = list(drive_specs.keys())
-    # Add tonic biases
-    if tonic_specs:
-        drive_names.extend(list(tonic_specs.keys()))
-
-    for idx, drive_name in enumerate(drive_names):  # order matters
-        if 'tonic' in drive_name:
-            specs = dict(type='tonic', location=None)
-            kwargs = dict(prespecified_drive_data=tonic_specs[drive_name])
-        else:
-            specs = drive_specs[drive_name]
-            kwargs = dict(prespecified_drive_data=specs['dynamics'],
-                          prespecified_weights_ampa=specs['weights_ampa'],
-                          prespecified_weights_nmda=specs['weights_nmda'],
-                          prespecified_delays=specs['synaptic_delays'],
-                          prespecified_n_drive_cells=specs['n_drive_cells'],
-                          prespecified_cell_specific=specs['cell_specific'],
-                          event_seed=specs['event_seed'],
-                          )
-
-        should_render = idx == (len(drive_names) - 1)
-
-        add_drive_widget(
-            specs['type'].capitalize(),
-            drive_boxes,
-            drive_widgets,
-            drives_out,
-            tstop,
-            specs['location'],
-            layout=layout,
-            prespecified_drive_name=drive_name,
-            render=should_render,
-            expand_last_drive=False,
-            **kwargs
-        )
-
-
 def on_upload_data_change(change, data, viz_manager, log_out):
     if len(change['owner'].value) == 0:
         return

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -884,6 +884,10 @@ class HNNGUI:
         action = getattr(self.viz_manager, f"_simulate_{action_name}")
         action(*args, **kwargs)
 
+    def _simulate_delete_single_drive(self, idx=0):
+        self.drive_accordion.selected_index = idx
+        self.drive_boxes[idx].children[-1].click()
+
     def load_drive_and_connectivity(self):
         """Add drive and connectivity ipywidgets from params."""
         with self._log_out:

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -942,16 +942,11 @@ class HNNGUI:
             prespecified_n_drive_cells, prespecified_cell_specific
         )
 
-        # Add delete button
-        delete_button = Button(
-            description='Delete',
-            button_style='danger',
-            icon='close',
-            layout=self.layout['del_fig_btn']
-        )
-        # Call-back on drive deletion
+        # Add delete button and assign its call-back function
+        delete_button = Button(description='Delete', button_style='danger',
+                               icon='close', layout=self.layout['del_fig_btn'])
         delete_button.on_click(self._delete_single_drive)
-        drive_box.children += (HTML(value="<p> </p>"),
+        drive_box.children += (HTML(value="<p> </p>"),  # Adds blank space
                                delete_button)
 
         if drive_type in [

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -892,9 +892,13 @@ class HNNGUI:
         """Add drive and connectivity ipywidgets from params."""
         with self._log_out:
             # Add connectivity
-            add_connectivity_tab(self.params, self._connectivity_out, self.connectivity_widgets,
-                                 self._cell_params_out, self.cell_pameters_widgets,
-                                 self.cell_layer_radio_buttons, self.cell_type_radio_buttons,
+            add_connectivity_tab(self.params,
+                                 self._connectivity_out,
+                                 self.connectivity_widgets,
+                                 self._cell_params_out,
+                                 self.cell_pameters_widgets,
+                                 self.cell_layer_radio_buttons,
+                                 self.cell_type_radio_buttons,
                                  self.layout)
 
             # Add drives
@@ -1036,14 +1040,15 @@ class HNNGUI:
                 kwargs = dict(prespecified_drive_data=tonic_specs[drive_name])
             else:
                 specs = drive_specs[drive_name]
-                kwargs = dict(prespecified_drive_data=specs['dynamics'],
-                              prespecified_weights_ampa=specs['weights_ampa'],
-                              prespecified_weights_nmda=specs['weights_nmda'],
-                              prespecified_delays=specs['synaptic_delays'],
-                              prespecified_n_drive_cells=specs['n_drive_cells'],
-                              prespecified_cell_specific=specs['cell_specific'],
-                              event_seed=specs['event_seed'],
-                              )
+                kwargs = dict(
+                    prespecified_drive_data=specs['dynamics'],
+                    prespecified_weights_ampa=specs['weights_ampa'],
+                    prespecified_weights_nmda=specs['weights_nmda'],
+                    prespecified_delays=specs['synaptic_delays'],
+                    prespecified_n_drive_cells=specs['n_drive_cells'],
+                    prespecified_cell_specific=specs['cell_specific'],
+                    event_seed=specs['event_seed'],
+                )
 
             should_render = idx == (len(drive_names) - 1)
             self.add_drive_widget(drive_type=specs['type'].capitalize(),

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -640,15 +640,22 @@ class HNNGUI:
                                               'value')
 
     def _delete_single_drive(self, b):
+        index = self.drive_accordion.selected_index
+
         # Remove selected drive from drive lists
-        self.drive_boxes.pop(self.drive_accordion.selected_index)
-        self.drive_widgets.pop(self.drive_accordion.selected_index)
+        self.drive_boxes.pop(index)
+        self.drive_widgets.pop(index)
 
         # Rebuild the accordion collection
+        self.drive_accordion.titles = tuple(
+            t for i, t in enumerate(self.drive_accordion.titles) if i != index
+        )
+        self.drive_accordion.selected_index = None
+        self.drive_accordion.children = self.drive_boxes
+
+        # Render
         self._drives_out.clear_output()
         with self._drives_out:
-            self.drive_accordion.selected_index = None
-            self.drive_accordion.children = self.drive_boxes
             display(self.drive_accordion)
 
     def compose(self, return_layout=True):

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -925,64 +925,22 @@ class HNNGUI:
                 not _is_valid_add_tonic_input(self.drive_widgets)):
             return
 
+        # Build drive widget objects
+        name = (drive_type + str(len(self.drive_boxes))
+                if not prespecified_drive_name
+                else prespecified_drive_name)
         style = {'description_width': '125px'}
-        if not prespecified_drive_data:
-            prespecified_drive_data = {}
+        prespecified_drive_data = ({} if not prespecified_drive_data
+                                   else prespecified_drive_data)
         prespecified_drive_data.update({"seedcore": max(event_seed, 2)})
 
-        if not prespecified_drive_name:
-            name = drive_type + str(len(self.drive_boxes))
-        else:
-            name = prespecified_drive_name
-        if drive_type in ('Rhythmic', 'Bursty'):
-            drive, drive_box = _get_rhythmic_widget(
-                name,
-                self.widget_tstop,
-                layout,
-                style,
-                location,
-                data=prespecified_drive_data,
-                weights_ampa=prespecified_weights_ampa,
-                weights_nmda=prespecified_weights_nmda,
-                delays=prespecified_delays,
-                n_drive_cells=prespecified_n_drive_cells,
-                cell_specific=prespecified_cell_specific,
-            )
-        elif drive_type == 'Poisson':
-            drive, drive_box = _get_poisson_widget(
-                name,
-                self.widget_tstop,
-                layout,
-                style,
-                location,
-                data=prespecified_drive_data,
-                weights_ampa=prespecified_weights_ampa,
-                weights_nmda=prespecified_weights_nmda,
-                delays=prespecified_delays,
-                n_drive_cells=prespecified_n_drive_cells,
-                cell_specific=prespecified_cell_specific,
-            )
-        elif drive_type in ('Evoked', 'Gaussian'):
-            drive, drive_box = _get_evoked_widget(
-                name,
-                layout,
-                style,
-                location,
-                data=prespecified_drive_data,
-                weights_ampa=prespecified_weights_ampa,
-                weights_nmda=prespecified_weights_nmda,
-                delays=prespecified_delays,
-                n_drive_cells=prespecified_n_drive_cells,
-                cell_specific=prespecified_cell_specific,
-            )
-        elif drive_type == 'Tonic':
-            drive, drive_box = _get_tonic_widget(
-                name,
-                self.widget_tstop,
-                layout,
-                style,
-                data=prespecified_drive_data
-            )
+        drive, drive_box = _build_drive_objects(
+            drive_type, name, self.widget_tstop,
+            layout, style, location,
+            prespecified_drive_data, prespecified_weights_ampa,
+            prespecified_weights_nmda, prespecified_delays,
+            prespecified_n_drive_cells, prespecified_cell_specific
+        )
 
         # Add delete button
         delete_button = Button(
@@ -1580,6 +1538,66 @@ def _get_tonic_widget(name, tstop_widget, layout, style, data=None):
                  tstop=stop_times,)
 
     drive.update(widgets_dict)
+    return drive, drive_box
+
+
+def _build_drive_objects(drive_type, name, tstop_widget, layout, style,
+                         location, drive_data, weights_ampa,
+                         weights_nmda, delays, n_drive_cells,
+                         cell_specific):
+
+    if drive_type in ('Rhythmic', 'Bursty'):
+        drive, drive_box = _get_rhythmic_widget(
+            name,
+            tstop_widget,
+            layout,
+            style,
+            location,
+            data=drive_data,
+            weights_ampa=weights_ampa,
+            weights_nmda=weights_nmda,
+            delays=delays,
+            n_drive_cells=n_drive_cells,
+            cell_specific=cell_specific,
+        )
+    elif drive_type == 'Poisson':
+        drive, drive_box = _get_poisson_widget(
+            name,
+            tstop_widget,
+            layout,
+            style,
+            location,
+            data=drive_data,
+            weights_ampa=weights_ampa,
+            weights_nmda=weights_nmda,
+            delays=delays,
+            n_drive_cells=n_drive_cells,
+            cell_specific=cell_specific,
+        )
+    elif drive_type in ('Evoked', 'Gaussian'):
+        drive, drive_box = _get_evoked_widget(
+            name,
+            layout,
+            style,
+            location,
+            data=drive_data,
+            weights_ampa=weights_ampa,
+            weights_nmda=weights_nmda,
+            delays=delays,
+            n_drive_cells=n_drive_cells,
+            cell_specific=cell_specific,
+        )
+    elif drive_type == 'Tonic':
+        drive, drive_box = _get_tonic_widget(
+            name,
+            tstop_widget,
+            layout,
+            style,
+            data=drive_data
+        )
+    else:
+        raise ValueError(f'Unknown drive type {drive_type}')
+
     return drive, drive_box
 
 

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -983,12 +983,16 @@ class HNNGUI:
                 )
 
             # Add delete button
-            delete_button = create_expanded_button(
-                'Delete', 'success', layout=layout, button_color='red'
+            delete_button = Button(
+                description='Delete',
+                button_style='danger',
+                icon='close',
+                layout=self.layout['del_fig_btn']
             )
             # Call-back on drive deletion
             delete_button.on_click(self._delete_single_drive)
-            drive_box.children += (delete_button,)
+            drive_box.children += (HTML(value="<p> </p>"),
+                                   delete_button)
 
             if drive_type in [
                 'Evoked', 'Poisson', 'Rhythmic', 'Bursty', 'Gaussian', 'Tonic'

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -536,7 +536,6 @@ class HNNGUI:
             return self.add_drive_widget(
                 self.widget_drive_type_selection.value,
                 self.widget_location_selection.value,
-                layout=self.layout['drive_textbox']
             )
 
         def _delete_drives_clicked(b):
@@ -914,7 +913,6 @@ class HNNGUI:
     def add_drive_widget(self,
                          drive_type,
                          location,
-                         layout,
                          prespecified_drive_name=None,
                          prespecified_drive_data=None,
                          prespecified_weights_ampa=None,
@@ -943,7 +941,7 @@ class HNNGUI:
 
         drive, drive_box = _build_drive_objects(
             drive_type, name, self.widget_tstop,
-            layout, style, location,
+            self.layout['drive_textbox'], style, location,
             prespecified_drive_data, prespecified_weights_ampa,
             prespecified_weights_nmda, prespecified_delays,
             prespecified_n_drive_cells, prespecified_cell_specific
@@ -1011,7 +1009,6 @@ class HNNGUI:
             should_render = idx == (len(drive_names) - 1)
             self.add_drive_widget(drive_type=specs['type'].capitalize(),
                                   location=specs['location'],
-                                  layout=self.layout['drive_textbox'],
                                   prespecified_drive_name=drive_name,
                                   render=should_render,
                                   expand_last_drive=False,

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -731,15 +731,7 @@ class HNNGUI:
         self._link_callbacks()
 
         # initialize drive and connectivity ipywidgets
-        load_drive_and_connectivity(self.params, self._log_out,
-                                    self._drives_out, self.drive_widgets,
-                                    self.drive_boxes, self._connectivity_out,
-                                    self.connectivity_widgets,
-                                    self._cell_params_out,
-                                    self.cell_pameters_widgets,
-                                    self.cell_layer_radio_buttons,
-                                    self.cell_type_radio_buttons,
-                                    self.widget_tstop, self.layout)
+        self.load_drive_and_connectivity()
 
         if not return_layout:
             return
@@ -889,6 +881,18 @@ class HNNGUI:
         action = getattr(self.viz_manager, f"_simulate_{action_name}")
         action(*args, **kwargs)
 
+    def load_drive_and_connectivity(self):
+        """Add drive and connectivity ipywidgets from params."""
+        with self._log_out:
+            # Add connectivity
+            add_connectivity_tab(self.params, self._connectivity_out, self.connectivity_widgets,
+                                 self._cell_params_out, self.cell_pameters_widgets,
+                                 self.cell_layer_radio_buttons, self.cell_type_radio_buttons,
+                                 self.layout)
+
+            # Add drives
+            add_drive_tab(self.params, self._log_out, self._drives_out, self.drive_widgets, self.drive_boxes,
+                          self.widget_tstop, self.layout)
 
 def _prepare_upload_file_from_local(path):
     path = Path(path)
@@ -1653,24 +1657,6 @@ def add_drive_tab(params, log_out, drives_out, drive_widgets, drive_boxes,
             expand_last_drive=False,
             **kwargs
         )
-
-
-def load_drive_and_connectivity(params, log_out, drives_out,
-                                drive_widgets, drive_boxes, connectivity_out,
-                                connectivity_textfields, cell_params_out,
-                                cell_pameters_vboxes, cell_layer_radio_button,
-                                cell_type_radio_button, tstop, layout):
-    """Add drive and connectivity ipywidgets from params."""
-    with log_out:
-        # Add connectivity
-        add_connectivity_tab(params, connectivity_out, connectivity_textfields,
-                             cell_params_out, cell_pameters_vboxes,
-                             cell_layer_radio_button, cell_type_radio_button,
-                             layout)
-
-        # Add drives
-        add_drive_tab(params, log_out, drives_out, drive_widgets, drive_boxes,
-                      tstop, layout)
 
 
 def on_upload_data_change(change, data, viz_manager, log_out):

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -417,6 +417,7 @@ class HNNGUI:
         # Add drive section
         self.drive_widgets = list()
         self.drive_boxes = list()
+        self.drive_accordion = Accordion()
 
         # Connectivity list
         self.connectivity_widgets = list()
@@ -637,6 +638,18 @@ class HNNGUI:
                                              'value')
         self.cell_layer_radio_buttons.observe(_cell_layer_radio_change,
                                               'value')
+
+    def _delete_single_drive(self, b):
+        # Remove selected drive from drive lists
+        self.drive_boxes.pop(self.drive_accordion.selected_index)
+        self.drive_widgets.pop(self.drive_accordion.selected_index)
+
+        # Rebuild the accordion collection
+        self._drives_out.clear_output()
+        with self._drives_out:
+            self.drive_accordion.selected_index = None
+            self.drive_accordion.children = self.drive_boxes
+            display(self.drive_accordion)
 
     def compose(self, return_layout=True):
         """Compose widgets.
@@ -964,6 +977,14 @@ class HNNGUI:
                     style,
                     data=prespecified_drive_data
                 )
+
+            # Add delete button
+            delete_button = create_expanded_button(
+                'Delete', 'success', layout=layout, button_color='red'
+            )
+            # Call-back on drive deletion
+            delete_button.on_click(self._delete_single_drive)
+            drive_box.children += (delete_button,)
 
             if drive_type in [
                 'Evoked', 'Poisson', 'Rhythmic', 'Bursty', 'Gaussian', 'Tonic'

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -949,11 +949,8 @@ class HNNGUI:
         drive_box.children += (HTML(value="<p> </p>"),  # Adds blank space
                                delete_button)
 
-        if drive_type in [
-            'Evoked', 'Poisson', 'Rhythmic', 'Bursty', 'Gaussian', 'Tonic'
-        ]:
-            self.drive_boxes.append(drive_box)
-            self.drive_widgets.append(drive)
+        self.drive_boxes.append(drive_box)
+        self.drive_widgets.append(drive)
 
         if render:
             # Construct accordion object

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -891,8 +891,55 @@ class HNNGUI:
                                  self.layout)
 
             # Add drives
-            add_drive_tab(self.params, self._log_out, self._drives_out, self.drive_widgets, self.drive_boxes,
-                          self.widget_tstop, self.layout)
+            self.add_drive_tab(self.params)
+
+    def add_drive_tab(self, params):
+        net = dict_to_network(params)
+        drive_specs = net.external_drives
+        tonic_specs = net.external_biases
+
+        # clear before adding drives
+        self._drives_out.clear_output()
+        while len(self.drive_widgets) > 0:
+            self.drive_widgets.pop()
+            self.drive_boxes.pop()
+
+        drive_names = list(drive_specs.keys())
+        # Add tonic biases
+        if tonic_specs:
+            drive_names.extend(list(tonic_specs.keys()))
+
+        for idx, drive_name in enumerate(drive_names):  # order matters
+            if 'tonic' in drive_name:
+                specs = dict(type='tonic', location=None)
+                kwargs = dict(prespecified_drive_data=tonic_specs[drive_name])
+            else:
+                specs = drive_specs[drive_name]
+                kwargs = dict(prespecified_drive_data=specs['dynamics'],
+                              prespecified_weights_ampa=specs['weights_ampa'],
+                              prespecified_weights_nmda=specs['weights_nmda'],
+                              prespecified_delays=specs['synaptic_delays'],
+                              prespecified_n_drive_cells=specs['n_drive_cells'],
+                              prespecified_cell_specific=specs['cell_specific'],
+                              event_seed=specs['event_seed'],
+                              )
+
+            should_render = idx == (len(drive_names) - 1)
+
+            add_drive_widget(
+                specs['type'].capitalize(),
+                self.drive_boxes,
+                self.drive_widgets,
+                self._drives_out,
+                self.widget_tstop,
+                specs['location'],
+                layout=self.layout['drive_textbox'],
+                prespecified_drive_name=drive_name,
+                render=should_render,
+                expand_last_drive=False,
+                **kwargs
+            )
+
 
 def _prepare_upload_file_from_local(path):
     path = Path(path)

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1115,6 +1115,17 @@ def test_delete_single_drive(setup_gui):
     """Deleting a single drive."""
     gui = setup_gui
     assert len(gui.drive_accordion.children) == 6
+    assert gui.drive_accordion.titles == ('evdist1 (distal)',
+                                          'evprox1 (proximal)',
+                                          'evprox2 (proximal)',
+                                          'alpha_prox (proximal)',
+                                          'poisson (proximal)',
+                                          'tonic')
 
-    gui._simulate_delete_single_drive(0)
+    gui._simulate_delete_single_drive(2)
     assert len(gui.drive_accordion.children) == 5
+    assert gui.drive_accordion.titles == ('evdist1 (distal)',
+                                          'evprox1 (proximal)',
+                                          'alpha_prox (proximal)',
+                                          'poisson (proximal)',
+                                          'tonic')

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1109,3 +1109,12 @@ def test_update_nested_dict():
     updated = _update_nested_dict(original, has_nulls)
     expected = has_nulls
     assert updated == expected
+
+
+def test_delete_single_drive(setup_gui):
+    """Deleting a single drive."""
+    gui = setup_gui
+    assert len(gui.drive_accordion.children) == 6
+
+    gui._simulate_delete_single_drive(0)
+    assert len(gui.drive_accordion.children) == 5


### PR DESCRIPTION
Added a button to delete a single drive.

![optimized](https://github.com/user-attachments/assets/b59d26ba-85f1-4d5c-be2f-92534dcf7321)

I decided to refactor previous functions that changed the GUI's state as class methods. The key challenge I faced was how to close a parent object based a nested child delete button. Keeping the external functions would have required creating additional logic and data structures to keep track of drive indices upon creation and editing.  As an added benefit I found that the refactor made the method calls more straight-forward and easier to understand. 

closes #887 