### PR TITLE
[WIP] DMU Change calcium conductance in L5 Pyr soma

### DIFF
--- a/hnn_core/cells_default.py
+++ b/hnn_core/cells_default.py
@@ -429,6 +429,7 @@ def pyramidal_ca(cell_name, pos, override_params=None, gid=None):
     override_params['L5Pyr_dend_gbar_ca'] = gbar_ca
     override_params['L5Pyr_dend_gnabar_hh2'] = gbar_na
     override_params['L5Pyr_dend_gkbar_hh2'] = gbar_k
+    override_params['L5Pyr_soma_gkbar_ca'] = 10.
 
     cell = pyramidal(cell_name, pos, override_params=override_params,
                      gid=gid)


### PR DESCRIPTION
I noticed a tiny mistake in the calcium model: calcium conductance in the soma should be 10., but it's still at the default value for the Jones model (60.). Quick and dirty fix. We're still tuning the model so it's not too critical yet.