### PR TITLE
[MRG] GUI Dipole load data figure scaling

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1676,23 +1676,29 @@ def load_drive_and_connectivity(params, log_out, drives_out,
 def on_upload_data_change(change, data, viz_manager, log_out):
     if len(change['owner'].value) == 0:
         return
-
+    # Parsing file information from the 'change' object passed in from
+    # the upload file widget.
     data_dict = change['new'][0]
-
     dict_name = data_dict['name'].rsplit('.', 1)
     data_fname = dict_name[0]
     file_extension = f".{dict_name[1]}"
 
+    # If data was already loaded return
     if data_fname in data['simulation_data'].keys():
-        logger.error(f"Found existing data: {data_fname}.")
+        with log_out:
+            logger.error(f"Found existing data: {data_fname}.")
         return
 
+    # Read the file
     ext_content = data_dict['content']
     ext_content = codecs.decode(ext_content, encoding="utf-8")
-    with log_out:
-        data['simulation_data'][data_fname] = {'net': None, 'dpls': [
-            _read_dipole_txt(io.StringIO(ext_content), file_extension)
-        ]}
+    with (log_out):
+        # Write loaded data to data object
+        data['simulation_data'][data_fname] = {
+            'net': None, 'dpls': [_read_dipole_txt(io.StringIO(ext_content),
+                                                   file_extension
+                                                   )
+                                  ]}
         logger.info(f'External data {data_fname} loaded.')
 
         # Create a dipole plot

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1694,16 +1694,21 @@ def on_upload_data_change(change, data, viz_manager, log_out):
             _read_dipole_txt(io.StringIO(ext_content), file_extension)
         ]}
         logger.info(f'External data {data_fname} loaded.')
+
+        # Create a dipole plot
         _template_name = "[Blank] single figure"
         viz_manager.reset_fig_config_tabs(template_name=_template_name)
         viz_manager.add_figure()
         fig_name = _idx2figname(viz_manager.data['fig_idx']['idx'] - 1)
-        ax_plots = [("ax0", "current dipole")]
-
-        # these lines plot the data per axis
-        for ax_name, plot_type in ax_plots:
-            viz_manager._simulate_edit_figure(
-                fig_name, ax_name, data_fname, plot_type, {}, "plot")
+        process_configs = {'dipole_smooth': 0, 'dipole_scaling': 1}
+        viz_manager._simulate_edit_figure(fig_name,
+                                          ax_name='ax0',
+                                          simulation_name=data_fname,
+                                          plot_type="current dipole",
+                                          preprocessing_config=process_configs,
+                                          operation='plot'
+                                          )
+        # Reset the load file widget
         change['owner'].value = []
 
 


### PR DESCRIPTION
The plot generated when loading data had the same default scaling and smoothing that is applied to simulation data. This PR removes smoothing and scaling so the plot respects the raw loaded data. The user can then choose how to adjust the scaling and smoothing as they see fit. 


![Screenshot 2024-09-18 at 3 16 36 PM](https://github.com/user-attachments/assets/7251ec8c-f30f-436e-9239-b74a9587cd76)

