### PR TITLE
[MRG] feat: post-processing function to adjust figures 

### DIFF
--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -981,9 +981,10 @@ class _VizManager:
                 self._simulate_edit_figure(fig_name, ax_name, sim_name,
                                            plot_type, {}, "plot")
             # template post-processing
+            fig_key = self.data['fig_idx']['idx'] - 1
             _postprocess_template(template_name,
-                                  fig=self.figs[len(self.figs)],
-                                  idx=self.data['fig_idx']['idx'] - 1,
+                                  fig=self.figs[fig_key],
+                                  idx=fig_key,
                                   use_ipympl=self.use_ipympl,
                                   widgets=self.widgets,
                                   )

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -776,6 +776,9 @@ def _postprocess_template(template_name, fig, idx,
     this function. For example, L2 and L5 dipole plots should have the same
     y-axis range.
     """
+    if template_name not in ['Dipole Layers (3x1)']:
+        return
+
     if template_name == 'Dipole Layers (3x1)':
         # Make the L2 and L5 plots the same y-range
         y_lims_list = [ax.get_ylim() for ax in fig.axes[0:2]]


### PR DESCRIPTION
Added a post-processing function to adjust figures after they have been constructed

This was created for a special case where L2 and L5 dipole plots should have the same axis limits. There wasn't a simple way to set axis limits upon plot creation so the post-process implementation seemed like the most simple solution while keeping the current APIs intact.

Admittedly this solution is a bit hacky as it renders the first set a plots and quickly re-renders the adjustment (looks like a flicker). Perhaps adding keywords to not render certain plot calls would be a solution. 

![Screenshot 2024-09-18 at 5 08 55 PM](https://github.com/user-attachments/assets/0cf94241-d7e6-4661-b3c0-1a11d14bab0e)

