### PR TITLE
[MRG] GUI spectrogram min freq widget

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,11 +12,20 @@ Current
 
 Changelog
 ~~~~~~~~~
+- Add button to delete a single drive on GUI drive windows, by
+  `George Dang`_ in :gh:`890`
+
+- Add minimum spectral frequency widget to GUI for adjusting spectrogram
+  frequency axis, by `George Dang`_ in :gh:`894`
+
 
 Bug
 ~~~
 - Fix GUI over-plotting of loaded data where the app stalled and did not plot
   RMSE, by `George Dang`_ in :gh:`869`
+
+- Fix scaling and smoothing of loaded data dipoles to the GUI, by `George Dang`_
+  in :gh:`892`
 
 API
 ~~~

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -10,8 +10,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 from IPython.display import display
-from ipywidgets import (Box, Button, Dropdown, FloatText, HBox, Label, Layout,
-                        Output, Tab, VBox, link)
+from ipywidgets import (Box, Button, Dropdown, BoundedFloatText, FloatText,
+                        HBox, Label, Layout, Output, Tab, VBox, link)
 
 from hnn_core.dipole import average_dipoles, _rmse
 from hnn_core.gui._logging import logger
@@ -592,15 +592,19 @@ def _get_ax_control(widgets, data, fig_idx, fig, ax):
         layout=layout,
         style=analysis_style)
 
-    min_spectral_frequency = FloatText(
+    min_spectral_frequency = BoundedFloatText(
         value=10,
+        min=0.1,
+        max=1000,
         description='Min Spectral Frequency (Hz):',
         disabled=False,
         layout=layout,
         style=analysis_style)
 
-    max_spectral_frequency = FloatText(
+    max_spectral_frequency = BoundedFloatText(
         value=100,
+        min=0.1,
+        max=1000,
         description='Max Spectral Frequency (Hz):',
         disabled=False,
         layout=layout,

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -258,7 +258,7 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
 
     elif plot_type == 'spectrogram':
         if len(dpls_copied) > 0:
-            min_f = 10.0
+            min_f = plot_config['min_spectral_frequency']
             max_f = plot_config['max_spectral_frequency']
             step_f = 1.0
             freqs = np.arange(min_f, max_f, step_f)
@@ -359,7 +359,8 @@ def _avg_dipole_check(dpls):
 
 def _plot_on_axes(b, simulations_widget, widgets_plot_type,
                   data_widget,
-                  spectrogram_colormap_selection, max_spectral_frequency,
+                  spectrogram_colormap_selection,
+                  min_spectral_frequency, max_spectral_frequency,
                   dipole_smooth, dipole_scaling, data_smooth, data_scaling,
                   widgets, data, fig_idx, fig, ax, existing_plots):
     """Plotting different types of data on the given axes.
@@ -380,6 +381,8 @@ def _plot_on_axes(b, simulations_widget, widgets_plot_type,
         A dropdown widget that contains all the colormaps for spectrogram.
     dipole_smooth : ipywidgets.FloatText
         A textfield widget that specifies the smoothing window size.
+    min_spectral_frequency : ipywidgets.FloatText
+        A textfield that specifies the minimum frequency for spectrogram plot.
     max_spectral_frequency : ipywidgets.FloatText
         A textfield that specifies the max frequency for spectrogram plot.
     dipole_scaling : ipywidgets.FloatText
@@ -411,6 +414,7 @@ def _plot_on_axes(b, simulations_widget, widgets_plot_type,
     simulation_plot_config = {
         "dipole_scaling": dipole_scaling.value,
         "dipole_smooth": dipole_smooth.value,
+        "min_spectral_frequency": min_spectral_frequency.value,
         "max_spectral_frequency": max_spectral_frequency.value,
         "spectrogram_cm": spectrogram_colormap_selection.value
     }
@@ -428,6 +432,7 @@ def _plot_on_axes(b, simulations_widget, widgets_plot_type,
         data_plot_config = {
             "dipole_scaling": data_scaling.value,
             "dipole_smooth": data_smooth.value,
+            "min_spectral_frequency": min_spectral_frequency.value,
             "max_spectral_frequency": max_spectral_frequency.value,
             "spectrogram_cm": spectrogram_colormap_selection.value
         }
@@ -587,6 +592,13 @@ def _get_ax_control(widgets, data, fig_idx, fig, ax):
         layout=layout,
         style=analysis_style)
 
+    min_spectral_frequency = FloatText(
+        value=10,
+        description='Min Spectral Frequency (Hz):',
+        disabled=False,
+        layout=layout,
+        style=analysis_style)
+
     max_spectral_frequency = FloatText(
         value=100,
         description='Max Spectral Frequency (Hz):',
@@ -635,6 +647,7 @@ def _get_ax_control(widgets, data, fig_idx, fig, ax):
             widgets_plot_type=plot_type_selection,
             data_widget=target_data_selection,
             spectrogram_colormap_selection=spectrogram_colormap_selection,
+            min_spectral_frequency=min_spectral_frequency,
             max_spectral_frequency=max_spectral_frequency,
             dipole_smooth=simulation_dipole_smooth,
             dipole_scaling=simulation_dipole_scaling,
@@ -651,7 +664,7 @@ def _get_ax_control(widgets, data, fig_idx, fig, ax):
     vbox = VBox([
         plot_type_selection, simulation_selection, simulation_dipole_smooth,
         simulation_dipole_scaling, target_data_selection, data_dipole_smooth,
-        data_dipole_scaling, max_spectral_frequency,
+        data_dipole_scaling, min_spectral_frequency, max_spectral_frequency,
         spectrogram_colormap_selection,
         HBox(
             [plot_button, clear_button],
@@ -999,7 +1012,8 @@ class _VizManager:
                 A dict of visualization preprocessing parameters. Allowed keys:
                 `dipole_smooth`, `dipole_scaling`,
                 `data_to_compare`, `data_smooth`, `data_scaling`
-                `max_spectral_frequency`, `spectrogram_colormap_selection`.
+                `min_spectral_frequency`, `max_spectral_frequency`,
+                `spectrogram_colormap_selection`.
                 config could be empty: `{}`.
             operation : str
                 `"plot"` if you want to plot and `"clear"` if you want to
@@ -1035,8 +1049,9 @@ class _VizManager:
             "data_to_compare": 4,
             "data_smooth": 5,
             "data_scaling": 6,
-            "max_spectral_frequency": 7,
-            "spectrogram_colormap_selection": 8,
+            "min_spectral_frequency": 7,
+            "max_spectral_frequency": 8,
+            "spectrogram_colormap_selection": 9,
         }
         for conf_key, conf_val in preprocessing_config.items():
             assert conf_key in config_name_idx.keys()

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -1023,26 +1023,29 @@ class _VizManager:
         assert plot_type in _plot_types
         assert operation in ("plot", "clear")
 
+        # Select the figure tab
         tab = self.axes_config_tabs
         titles = tab.titles
         assert fig_name in titles, "No such figure"
         tab_idx = titles.index(fig_name)
         self.axes_config_tabs.selected_index = tab_idx
 
+        # Select the figure panel/ax tab
         ax_control_tabs = self.axes_config_tabs.children[tab_idx].children[1]
         ax_titles = ax_control_tabs.titles
         assert ax_name in ax_titles, "No such axis"
         ax_idx = ax_titles.index(ax_name)
         ax_control_tabs.selected_index = ax_idx
 
-        # ax config
-        simulation_ctrl = ax_control_tabs.children[ax_idx].children[1]
-        # return simulation_ctrl
-        simulation_ctrl.value = simulation_name
+        # Select the simulation
+        simulation_selector = ax_control_tabs.children[ax_idx].children[1]
+        simulation_selector.value = simulation_name
 
-        plot_type_ctrl = ax_control_tabs.children[ax_idx].children[0]
-        plot_type_ctrl.value = plot_type
+        # Select the plot type
+        plot_type_selector = ax_control_tabs.children[ax_idx].children[0]
+        plot_type_selector.value = plot_type
 
+        # Set the plot configurations
         config_name_idx = {
             "dipole_smooth": 2,
             "dipole_scaling": 3,


### PR DESCRIPTION
Added widget for adjusting the minimum frequency of the spectrogram plots.

<img width="760" alt="Screenshot 2024-09-20 at 11 37 50 AM" src="https://github.com/user-attachments/assets/b2f9f207-6a61-4bfc-8414-28e508388388">
