### PR TITLE
[MRG] Spikes raster plot colors

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,10 +18,15 @@ Changelog
 - Add minimum spectral frequency widget to GUI for adjusting spectrogram
   frequency axis, by `George Dang`_ in :gh:`894`
 
-- Add method to modify synaptic gains, by `Nick Tolley`_  and `George Dang`_
-  in :gh:`897`
+- Add method to :class:`~hnn_core.Network` to modify synaptic gains, by
+  `Nick Tolley`_  and `George Dang`_ in :gh:`897`
 
 - Update GUI to display "L2/3", by `Austin Soplata`_ in :gh:`904`
+
+- Add argument to change colors of `plot_spikes_raster`, shortened line lengths
+  to prevent overlap, and added an argument for custom cell types, by
+  `George Dang`_ in :gh:`895`
+
 
 Bug
 ~~~

--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -293,7 +293,8 @@ class CellResponse(object):
 
         return spike_rates
 
-    def plot_spikes_raster(self, trial_idx=None, ax=None, show=True):
+    def plot_spikes_raster(self, trial_idx=None, ax=None, show=True,
+                           colors=None):
         """Plot the aggregate spiking activity according to cell type.
 
         Parameters
@@ -304,6 +305,8 @@ class CellResponse(object):
             An axis object from matplotlib. If None, a new figure is created.
         show : bool
             If True, show the figure.
+        colors: list of str | None
+            Optional custom colors to plot. Default will use the color cycler.
 
         Returns
         -------
@@ -311,7 +314,8 @@ class CellResponse(object):
             The matplotlib figure object.
         """
         return plot_spikes_raster(
-            cell_response=self, trial_idx=trial_idx, ax=ax, show=show)
+            cell_response=self, trial_idx=trial_idx, ax=ax, show=show,
+            colors=colors)
 
     def plot_spikes_hist(self, trial_idx=None, ax=None, spike_types=None,
                          color=None, show=True, **kwargs_hist):

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -363,7 +363,6 @@ class TestCellResponsePlotters:
                                                  colors=dict_mapping)
 
 
-
 def test_network_plotter_init(setup_net):
     """Test init keywords of NetworkPlotter class."""
     net = setup_net

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -279,6 +279,7 @@ class TestCellResponsePlotters:
         return net, dpls
 
     def test_spikes_raster_trial_idx(self, base_simulation_spikes):
+        """Plotting with different index arguments"""
         net, _ = base_simulation_spikes
 
         # Bad index argument raises error
@@ -297,6 +298,7 @@ class TestCellResponsePlotters:
             ), "No data plotted in raster plot"
 
     def test_spikes_raster_colors(self, base_simulation_spikes):
+        """Plotting with different color arguments"""
         net, _ = base_simulation_spikes
 
         def _get_line_hex_colors(fig):

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -291,9 +291,10 @@ class TestCellResponsePlotters:
             fig = net.cell_response.plot_spikes_raster(trial_idx=index_arg,
                                                        show=False)
             # Check that collections contain data
-            assert (all([collection.get_positions() != [-1]
-                         for collection in fig.axes[0].collections]),
-                    "No data plotted in raster plot")
+            assert all(
+                [collection.get_positions() != [-1]
+                 for collection in fig.axes[0].collections]
+            ), "No data plotted in raster plot"
 
     def test_spikes_raster_colors(self, base_simulation_spikes):
         net, _ = base_simulation_spikes

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -19,6 +19,13 @@ from hnn_core.dipole import simulate_dipole
 matplotlib.use('agg')
 
 
+@pytest.fixture(autouse=True)
+def cleanup_matplotlib():
+    # Code runs after the test finishes
+    yield
+    plt.close('all')
+
+
 @pytest.fixture
 def setup_net():
     hnn_core_root = op.dirname(hnn_core.__file__)

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -251,6 +251,7 @@ class TestCellResponsePlotters:
     """Tests plotting methods of the CellResponse class"""
     @pytest.fixture(scope='class')
     def class_setup_net(self):
+        """Creates a base network for tests within this class"""
         hnn_core_root = op.dirname(hnn_core.__file__)
         params_fname = op.join(hnn_core_root, 'param', 'default.json')
         params = read_params(params_fname)
@@ -260,6 +261,7 @@ class TestCellResponsePlotters:
 
     @pytest.fixture(scope='class')
     def base_simulation_spikes(self, class_setup_net):
+        """Adds drives with spikes for testing of spike visualizations"""
         net = class_setup_net
         weights_ampa = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.}
         syn_delays = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.}

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -248,7 +248,7 @@ def test_dipole_visualization(setup_net):
 
 
 class TestCellResponsePlotters:
-
+    """Tests plotting methods of the CellResponse class"""
     @pytest.fixture(scope='class')
     def class_setup_net(self):
         hnn_core_root = op.dirname(hnn_core.__file__)
@@ -302,31 +302,33 @@ class TestCellResponsePlotters:
         def _get_line_hex_colors(fig):
             colors = [matplotlib.colors.to_hex(line.get_color())
                       for line in fig.axes[0].legend_.get_lines()]
-            return colors
+            labels = [text.get_text()
+                      for text in fig.axes[0].legend_.get_texts()]
+            return colors, labels
 
         # Default colors should be the default color cycle
         fig = net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
-        colors = _get_line_hex_colors(fig)
+        colors, _ = _get_line_hex_colors(fig)
         default_colors = (plt.rcParams['axes.prop_cycle']
                           .by_key()['color'][0:len(colors)])
         assert colors == default_colors
 
-        # Custom hex colors
+        # Custom hex colors as list
         custom_colors = ['#daf7a6', '#ffc300', '#ff5733', '#c70039']
         fig = net.cell_response.plot_spikes_raster(trial_idx=0, show=False,
                                                    colors=custom_colors)
-        colors = _get_line_hex_colors(fig)
+        colors, _ = _get_line_hex_colors(fig)
         assert colors == custom_colors
 
-        # Custom named colors
+        # Custom named colors as list
         custom_colors = ['skyblue', 'maroon', 'gold', 'hotpink']
         color_map = matplotlib.colors.get_named_colors_mapping()
         fig = net.cell_response.plot_spikes_raster(trial_idx=0, show=False,
                                                    colors=custom_colors)
-        colors = _get_line_hex_colors(fig)
+        colors, _ = _get_line_hex_colors(fig)
         assert colors == [color_map[color].lower() for color in custom_colors]
 
-        # Incorrect number of colors
+        # Incorrect number of colors as list
         too_few = ['r', 'g', 'b']
         too_many = ['r', 'g', 'b', 'y', 'k']
         for colors in [too_few, too_many]:
@@ -335,6 +337,29 @@ class TestCellResponsePlotters:
                 net.cell_response.plot_spikes_raster(trial_idx=0,
                                                      show=False,
                                                      colors=colors)
+
+        # Colors as dict mapping
+        dict_mapping = {'L2_basket': '#daf7a6', 'L2_pyramidal': '#ffc300',
+                        'L5_basket': '#ff5733', 'L5_pyramidal': '#c70039'}
+        fig = net.cell_response.plot_spikes_raster(trial_idx=0, show=False,
+                                                   colors=dict_mapping)
+        colors, _ = _get_line_hex_colors(fig)
+        assert colors == list(dict_mapping.values())
+
+        # Change color of only one cell type
+        dict_mapping = {'L2_pyramidal': '#daf7a6'}
+        fig = net.cell_response.plot_spikes_raster(trial_idx=0, show=False,
+                                                   colors=dict_mapping)
+        colors, cell_types = _get_line_hex_colors(fig)
+        assert colors[cell_types.index('L2_pyramidal')] == '#daf7a6'
+
+        # Invalid key in dict mapping
+        dict_mapping = {'bad_cell_type': '#daf7a6'}
+        with pytest.raises(ValueError,
+                           match='Invalid cell types provided.'):
+            net.cell_response.plot_spikes_raster(trial_idx=0, show=False,
+                                                 colors=dict_mapping)
+
 
 
 def test_network_plotter_init(setup_net):

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -611,12 +611,13 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
             events.append(
                 ax.eventplot(cell_type_times, lineoffsets=cell_type_ypos,
                              color=color,
-                             label=cell_type, linelengths=5))
+                             label=cell_type, linelengths=1))
         else:
+            # Blank plot for no spiking
             events.append(
                 ax.eventplot([-1], lineoffsets=[-1],
                              color=color,
-                             label=cell_type, linelengths=5))
+                             label=cell_type, linelengths=1))
 
     ax.legend(handles=[e[0] for e in events], loc=1)
     ax.set_xlabel('Time (ms)')

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -509,8 +509,8 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
 
 
 def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
-                       cell_types = ['L2_basket', 'L2_pyramidal',
-                                     'L5_basket','L5_pyramidal'],
+                       cell_types=['L2_basket', 'L2_pyramidal',
+                                   'L5_basket', 'L5_pyramidal'],
                        colors=None,
                        ):
     """Plot the aggregate spiking activity according to cell type.
@@ -554,7 +554,6 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
                              f"cell types. {len(colors)} colors provided "
                              f"for {len(cell_types)} cell types.")
 
-
     # Extract desired trials
     spike_times = np.concatenate(
         np.array(cell_response._spike_times, dtype=object)[trial_idx])
@@ -575,7 +574,7 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
     for cell_type in cell_types:
         cell_type_gids = np.unique(spike_gids[spike_types == cell_type])
         cell_type_times, cell_type_ypos = [], []
-        color =  next(color_iter)
+        color = next(color_iter)
 
         for gid in cell_type_gids:
             gid_time = spike_times[spike_gids == gid]

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -539,10 +539,8 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
     if trial_idx is None:
         trial_idx = list(range(n_trials))
 
-    # Get spike types
-    spike_types_data = np.concatenate(np.array(cell_response.spike_types,
-                                               dtype=object))
-    spike_types = np.unique(spike_types_data).tolist()
+    # Get spike types from cell response
+    unique_spike_types = cell_response.cell_types
 
     # validate trial argument
     if isinstance(trial_idx, int):
@@ -550,39 +548,39 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
     _validate_type(trial_idx, list, 'trial_idx', 'int, list of int')
 
     # validate cell types
-    default_cell_types = ['L2_basket', 'L2_pyramidal',
-                          'L5_basket', 'L5_pyramidal']
     if cell_types:
         _validate_type(cell_types, list, 'cell_types', 'list of str')
-        if not set(cell_types).issubset(set(spike_types)):
+        if not set(cell_types).issubset(set(unique_spike_types)):
             raise ValueError("Invalid cell types provided. "
-                             f"Must be of set {spike_types}. "
+                             f"Must be of set {unique_spike_types}. "
                              f"Got {cell_types}")
-        default_cell_types = cell_types
+    else:
+        # Use default cell types
+        cell_types = ['L2_basket', 'L2_pyramidal', 'L5_basket', 'L5_pyramidal']
 
     # Set default colors
     default_colors = (plt.rcParams['axes.prop_cycle']
-                      .by_key()['color'][:len(default_cell_types)])
+                      .by_key()['color'][:len(cell_types)])
     cell_colors = {cell: color
-                   for cell, color in zip(default_cell_types, default_colors)}
+                   for cell, color in zip(cell_types, default_colors)}
 
     # validate colors argument
     _validate_type(colors, (list, dict, None), 'color', 'list of str, or dict')
     if colors:
         if isinstance(colors, list):
-            if len(colors) != len(default_cell_types):
+            if len(colors) != len(cell_types):
                 raise ValueError(
                     f"Number of colors must be equal to number of "
                     f"cell types. {len(colors)} colors provided "
-                    f"for {len(default_cell_types)} cell types.")
+                    f"for {len(cell_types)} cell types.")
             cell_colors = {cell: color
-                           for cell, color in zip(default_cell_types, colors)}
+                           for cell, color in zip(cell_types, colors)}
 
         if isinstance(colors, dict):
             # Check valid cell types
-            if not set(colors.keys()).issubset(set(spike_types)):
+            if not set(colors.keys()).issubset(set(unique_spike_types)):
                 raise ValueError("Invalid cell types provided. "
-                                 f"Must be of set {spike_types}. "
+                                 f"Must be of set {unique_spike_types}. "
                                  f"Got {colors.keys()}")
             cell_colors.update(colors)
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -546,8 +546,8 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
         np.array(cell_response._spike_gids, dtype=object)[trial_idx])
 
     cell_types = ['L2_basket', 'L2_pyramidal', 'L5_basket', 'L5_pyramidal']
-    cell_type_colors = {'L5_pyramidal': 'r', 'L5_basket': 'b',
-                        'L2_pyramidal': 'g', 'L2_basket': 'w'}
+    cell_type_colors = {'L5_pyramidal': 'C0', 'L5_basket': 'C1',
+                        'L2_pyramidal': 'C2', 'L2_basket': 'C3'}
 
     if ax is None:
         _, ax = plt.subplots(1, 1, constrained_layout=True)
@@ -573,7 +573,6 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
                              label=cell_type, linelengths=5))
 
     ax.legend(handles=[e[0] for e in events], loc=1)
-    ax.set_facecolor('k')
     ax.set_xlabel('Time (ms)')
     ax.get_yaxis().set_visible(False)
 

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -508,7 +508,11 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
     return ax.get_figure()
 
 
-def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
+def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
+                       cell_types = ['L2_basket', 'L2_pyramidal',
+                                     'L5_basket','L5_pyramidal'],
+                       colors=None,
+                       ):
     """Plot the aggregate spiking activity according to cell type.
 
     Parameters
@@ -521,6 +525,10 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
         An axis object from matplotlib. If None, a new figure is created.
     show : bool
         If True, show the figure.
+    cell_types: list of str
+        List of cell types to plot
+    colors: list of str | None
+        Optional custom colors to plot. Default will use the color cycler.
 
     Returns
     -------
@@ -533,9 +541,19 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
     if trial_idx is None:
         trial_idx = list(range(n_trials))
 
+    # validate trial argument
     if isinstance(trial_idx, int):
         trial_idx = [trial_idx]
     _validate_type(trial_idx, list, 'trial_idx', 'int, list of int')
+
+    # validate colors argument
+    if colors:
+        _validate_type(colors, list, 'colors', 'list of str')
+        if len(colors) != len(cell_types):
+            raise ValueError(f"Number of colors must be equal to number of "
+                             f"cell types. {len(colors)} colors provided "
+                             f"for {len(cell_types)} cell types.")
+
 
     # Extract desired trials
     spike_times = np.concatenate(
@@ -545,17 +563,20 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
     spike_gids = np.concatenate(
         np.array(cell_response._spike_gids, dtype=object)[trial_idx])
 
-    cell_types = ['L2_basket', 'L2_pyramidal', 'L5_basket', 'L5_pyramidal']
-    cell_type_colors = {'L5_pyramidal': 'C0', 'L5_basket': 'C1',
-                        'L2_pyramidal': 'C2', 'L2_basket': 'C3'}
-
     if ax is None:
         _, ax = plt.subplots(1, 1, constrained_layout=True)
+
+    # Check if custom colors are provided, else use the default color cycle
+    if colors is None:
+        colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
+    color_iter = iter(colors)
 
     events = []
     for cell_type in cell_types:
         cell_type_gids = np.unique(spike_gids[spike_types == cell_type])
         cell_type_times, cell_type_ypos = [], []
+        color =  next(color_iter)
+
         for gid in cell_type_gids:
             gid_time = spike_times[spike_gids == gid]
             cell_type_times.append(gid_time)
@@ -564,12 +585,12 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True):
         if cell_type_times:
             events.append(
                 ax.eventplot(cell_type_times, lineoffsets=cell_type_ypos,
-                             color=cell_type_colors[cell_type],
+                             color=color,
                              label=cell_type, linelengths=5))
         else:
             events.append(
                 ax.eventplot([-1], lineoffsets=[-1],
-                             color=cell_type_colors[cell_type],
+                             color=color,
                              label=cell_type, linelengths=5))
 
     ax.legend(handles=[e[0] for e in events], loc=1)

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -561,11 +561,13 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
         default_cell_types = cell_types
 
     # Set default colors
-    default_colors = plt.rcParams['axes.prop_cycle'].by_key()['color'][:len(default_cell_types)]
-    cell_colors = {cell: color for cell, color in zip(default_cell_types, default_colors)}
+    default_colors = (plt.rcParams['axes.prop_cycle']
+                      .by_key()['color'][:len(default_cell_types)])
+    cell_colors = {cell: color
+                   for cell, color in zip(default_cell_types, default_colors)}
 
     # validate colors argument
-    _validate_type(colors, (list, dict, None),'color', 'list of str, or dict')
+    _validate_type(colors, (list, dict, None), 'color', 'list of str, or dict')
     if colors:
         if isinstance(colors, list):
             if len(colors) != len(default_cell_types):
@@ -573,7 +575,8 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
                     f"Number of colors must be equal to number of "
                     f"cell types. {len(colors)} colors provided "
                     f"for {len(default_cell_types)} cell types.")
-            cell_colors = {cell: color for cell, color in zip(default_cell_types, colors)}
+            cell_colors = {cell: color
+                           for cell, color in zip(default_cell_types, colors)}
 
         if isinstance(colors, dict):
             # Check valid cell types

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -509,9 +509,7 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
 
 
 def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
-                       cell_types=['L2_basket', 'L2_pyramidal',
-                                   'L5_basket', 'L5_pyramidal'],
-                       colors=None,
+                       cell_types=None, colors=None,
                        ):
     """Plot the aggregate spiking activity according to cell type.
 
@@ -545,6 +543,13 @@ def plot_spikes_raster(cell_response, trial_idx=None, ax=None, show=True,
     if isinstance(trial_idx, int):
         trial_idx = [trial_idx]
     _validate_type(trial_idx, list, 'trial_idx', 'int, list of int')
+
+    # validate cell types
+    if cell_types:
+        _validate_type(cell_types, list, 'cell_types', 'list of str')
+    else:
+        cell_types = ['L2_basket', 'L2_pyramidal',
+                      'L5_basket', 'L5_pyramidal']
 
     # validate colors argument
     if colors:


### PR DESCRIPTION
**Changes**
1. Changed the spike raster colors to have a white background and use the current color cycle's first 4 colors.
2. Added argument to change the cell colors by either dictionary or list of colors.
3. Added argument to add custom cell types if the Network has different cell types than the default. 
4. Changed the line lengths to 1 to prevent overlap

With new colors
![Screenshot 2024-09-20 at 4 12 30 PM](https://github.com/user-attachments/assets/24f08bc5-4193-414d-bbac-a0149eb89968)

With new shorter lines. 
<img width="415" alt="Screenshot 2024-10-23 at 10 06 41 AM" src="https://github.com/user-attachments/assets/ff55524a-c049-46b0-beb1-b8a48e2dca0e">



**Question:**
* ~~Should the API allow users to be able to specify colors?~~ Yes
    * With this new implementation the user could technically change the plot colors outside of the hnn-core API if they changed the Matplotlib color cycle and default background with the matplotlib API. 


closes #888 