### PR TITLE
[MRG] GUI fix minor glitches

### DIFF
--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -763,9 +763,8 @@ def _add_figure(b, widgets, data, template_type, scale=0.95, dpi=96):
         with plt.ioff():
             fig = plt.figure(figsize=figsize, dpi=dpi, layout='constrained')
             axd = fig.subplot_mosaic(mosaic, **kwargs)
-
-        fig.canvas.header_visible = False
-        fig.canvas.footer_visible = False
+            fig.canvas.header_visible = False
+            fig.canvas.footer_visible = False
 
         if data['use_ipympl'] is False:
             plt.show()

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -781,6 +781,7 @@ def _add_figure(b, widgets, data, template_type, scale=0.95, dpi=96):
 
     data['figs'][fig_idx] = fig
     widgets['figs_tabs'].selected_index = n_tabs
+    widgets['axes_config_tabs'].selected_index = n_tabs
     data['fig_idx']['idx'] += 1
 
 

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -333,14 +333,12 @@ def _static_rerender(widgets, fig, fig_idx):
     fig_output = widgets['figs_tabs'].children[fig_tab_idx]
     fig_output.clear_output()
     with fig_output:
-        fig.tight_layout()
         display(fig)
 
 
 def _dynamic_rerender(fig):
     fig.canvas.draw()
     fig.canvas.flush_events()
-    fig.tight_layout()
 
 
 def _avg_dipole_check(dpls):
@@ -762,13 +760,10 @@ def _add_figure(b, widgets, data, template_type, scale=0.95, dpi=96):
                    scale * ((int(viz_output_layout.height[:-2]) - 10) / dpi))
         mosaic = template_type['mosaic']
         kwargs = template_type['kwargs']
-        plt.ioff()
-        fig, axd = plt.subplot_mosaic(mosaic,
-                                      figsize=figsize,
-                                      dpi=dpi,
-                                      **kwargs)
-        plt.ion()
-        fig.tight_layout()
+        with plt.ioff():
+            fig = plt.figure(figsize=figsize, dpi=dpi, layout='constrained')
+            axd = fig.subplot_mosaic(mosaic, **kwargs)
+
         fig.canvas.header_visible = False
         fig.canvas.footer_visible = False
 


### PR DESCRIPTION
1. Removed tight_layout method in favor of the constrained layout argument
    * The tight layout was displaying a warning for spectrogram plots. This change removes that message.

2. fixed set selected index for figure controls after new figure is generated
    * When creating a blank figure, the GUI was not automatically opening/selecting the new figure tab. This was because the selected index was only being set for the figure tabs but not the figure control tabs. This made them not synchronous, and when the two tab groups are later linked, it reverted to the un-updated index.