### PR TITLE
[MRG] Update Network eq method

### DIFF
--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -465,20 +465,16 @@ class Network:
             return False
 
         # Check all other attributes
-        all_attrs = dir(self)
-        attrs_to_ignore = [x for x in all_attrs if x.startswith('_')]
-        attrs_to_ignore.extend(['add_bursty_drive', 'add_connection',
-                                'add_electrode_array', 'add_evoked_drive',
-                                'add_poisson_drive', 'add_tonic_bias',
-                                'clear_connectivity', 'clear_drives',
-                                'connectivity', 'copy', 'gid_to_type',
-                                'plot_cells', 'set_cell_positions',
-                                'to_dict', 'write_configuration',
-                                'update_weights'])
-        attrs_to_check = [x for x in all_attrs if x not in attrs_to_ignore]
+        attrs_to_ignore = ['connectivity']
+        for attr in vars(self).keys():
+            if attr.startswith('_') or attr in attrs_to_ignore:
+                continue
 
-        for attr in attrs_to_check:
-            if getattr(self, attr) != getattr(other, attr):
+            if hasattr(self, attr) and hasattr(other, attr):
+                if getattr(self, attr) != getattr(other, attr):
+                    return False
+            else:
+                # Does not have the same set of attributes
                 return False
 
         return True

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -94,19 +94,11 @@ def check_equal_networks(net1, net2):
                         message=f'{bias_name}>{cell_type}>')
 
     # Check all other attributes
-    all_attrs = dir(net1)
-    attrs_to_ignore = [x for x in all_attrs if x.startswith('_')]
-    attrs_to_ignore.extend(['add_bursty_drive', 'add_connection',
-                            'add_electrode_array', 'add_evoked_drive',
-                            'add_poisson_drive', 'add_tonic_bias',
-                            'clear_connectivity', 'clear_drives',
-                            'connectivity', 'copy', 'gid_to_type',
-                            'plot_cells', 'set_cell_positions',
-                            'to_dict', 'write_configuration',
-                            'external_drives', 'external_biases',
-                            'update_weights'])
-    attrs_to_check = [x for x in all_attrs if x not in attrs_to_ignore]
-    for attr in attrs_to_check:
+    attrs_to_ignore = ['connectivity', 'external_drives', 'external_biases']
+    for attr in vars(net1).keys():
+        if attr.startswith('_') or attr in attrs_to_ignore:
+            continue
+
         check_equality(getattr(net1, attr), getattr(net2, attr),
                        f'{attr} not equal')
 


### PR DESCRIPTION
The eq method was refactored to be more flexible to new methods added to the object. 

The eq method loops over class attributes and compares the values to assess equality. 
* Previously we used the dir() function to list all of the classes attributes and methods and then filtered for only the attributes.
    * We used a hard-coded list of attributes and methods we wanted to pass over. This was annoying because each new method added to the Network class had to be manually added to this list. 
* This change uses the var() function to grab just the list of attributes from the class so new methods don't need to be coded manually. 
* The change was also made to the test_gui.py>check_equal_networks function, which had logic adapted from the eq method. 