### PR TITLE
[MRG] ENH: Refactor dipole visualization to invert y-axis when min_freq > max_freq

### DIFF
--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -24,6 +24,9 @@ orphan: true
   to prevent overlap, and added an argument for custom cell types, by
   [George Dang][] in {gh}`895`
 
+- Added check for invalid Axes object in :func:`~hnn_core.viz.plot_cells`
+  function, by [Abdul Samad Siddiqui][] in {gh}`744`.
+
 ### Bug
 
 - Fix GUI over-plotting of loaded data where the app stalled and did not plot

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -300,9 +300,8 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
         if len(dpls_copied) > 0:
             min_f = plot_config['min_spectral_frequency']
             max_f = plot_config['max_spectral_frequency']
-            if max_f > min_f:
-                step_f = 1
-            elif min_f > max_f:
+            step_f = 1.0
+            if min_f > max_f:
                 step_f = -1
             freqs = np.arange(min_f, max_f, step_f)
             n_cycles = freqs / 2.

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -304,6 +304,10 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
             freqs = np.arange(min_f, max_f, step_f)
             n_cycles = freqs / 2.
 
+            if freqs[0] > freqs[-1]:
+                freqs = freqs[::-1]
+                ax.invert_yaxis()
+
             try:
                 dpls_copied[0].plot_tfr_morlet(
                     freqs,

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -300,13 +300,12 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
         if len(dpls_copied) > 0:
             min_f = plot_config['min_spectral_frequency']
             max_f = plot_config['max_spectral_frequency']
-            step_f = 1.0
+            if max_f > min_f:
+                step_f = 1
+            elif min_f > max_f:
+                step_f = -1
             freqs = np.arange(min_f, max_f, step_f)
             n_cycles = freqs / 2.
-
-            if freqs[0] > freqs[-1]:
-                freqs = freqs[::-1]
-                ax.invert_yaxis()
 
             try:
                 dpls_copied[0].plot_tfr_morlet(

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -700,6 +700,26 @@ def test_gui_visualization(setup_gui):
             assert any(['_cbar-ax-' in attr
                         for attr in dir(gui.viz_manager.figs[figid])]) is False
             assert len(gui.viz_manager.figs[figid].axes) == 1
+            assert not gui.viz_manager.figs[figid].axes[0].has_data()
+
+            # Test that frequency inversion works
+            # First, test no inversion
+            gui._simulate_viz_action("edit_figure", figname, axname, 'default',
+                                     'spectrogram', {
+                                         'min_spectral_frequency': 10,
+                                         'max_spectral_frequency': 100,
+                                     }, 'plot')
+            assert gui.viz_manager.figs[figid].axes[0].has_data()
+            gui._simulate_viz_action("edit_figure", figname, axname, 'default',
+                                     'spectrogram', {}, 'clear')
+            assert not gui.viz_manager.figs[figid].axes[0].has_data()
+            # Next, test inversion
+            gui._simulate_viz_action("edit_figure", figname, axname, 'default',
+                                     'spectrogram', {
+                                         'min_spectral_frequency': 100,
+                                         'max_spectral_frequency': 10,
+                                     }, 'plot')
+            assert gui.viz_manager.figs[figid].axes[0].has_data()
 
         else:
             # Check if the correct number of axes are present

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -194,6 +194,13 @@ def test_dipole_visualization(setup_net):
     # multiple TFRs get averaged
     fig = plot_tfr_morlet(dpls, freqs=np.arange(23, 26, 1.), n_cycles=3,
                           show=False)
+    # when min_freq > max_freq (y-axis inversion)
+    fig = plot_tfr_morlet(dpls, freqs=np.array([30, 20, 10]),
+                          n_cycles=3, show=False)
+    ax = fig.get_axes()[0]
+    y_limits = ax.get_ylim()
+    assert y_limits[0] > y_limits[1], \
+        "Y-axis should be inverted when min_freq > max_freq"
 
     with pytest.raises(RuntimeError,
                        match="All dipoles must be scaled equally!"):

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -851,6 +851,11 @@ def plot_tfr_morlet(dpl, freqs, *, n_cycles=7., tmin=None, tmax=None,
     power = np.mean(trial_power, axis=0)
     im = ax.pcolormesh(times, freqs, power[0, 0, ...], cmap=colormap,
                        shading='auto')
+
+    if freqs[0] > freqs[-1]:
+        freqs = freqs[::-1]
+        ax.invert_yaxis()
+
     ax.set_xlabel('Time (ms)')
     ax.set_ylabel('Frequency (Hz)')
 


### PR DESCRIPTION
Added support for reversed y-axis in `plot_tfr_morlet` to allow min_freq > max_freq
Fixes #898 