### PR TITLE
[MRG] Flip specified drives in input histogram

### DIFF
--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -294,7 +294,8 @@ class CellResponse(object):
             cell_response=self, trial_idx=trial_idx, ax=ax, show=show)
 
     def plot_spikes_hist(self, trial_idx=None, ax=None, spike_types=None,
-                         color=None, show=True, **kwargs_hist):
+                         invert_spike_types=None, color=None, show=True,
+                         **kwargs_hist):
         """Plot the histogram of spiking activity across trials.
 
         Parameters
@@ -346,8 +347,9 @@ class CellResponse(object):
             The matplotlib figure handle.
         """
         return plot_spikes_hist(self, trial_idx=trial_idx, ax=ax,
-                                spike_types=spike_types, color=color,
-                                show=show, **kwargs_hist)
+                                spike_types=spike_types,
+                                invert_spike_types=invert_spike_types,
+                                color=color, show=show, **kwargs_hist)
 
     def to_dict(self):
         """Return cell response as a dict object.

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -365,6 +365,21 @@ def test_invert_spike_types(setup_net):
 
     _ = simulate_dipole(net, dt=0.5, tstop=80., n_trials=1)
 
+    # test string input
+    net.cell_response.plot_spikes_hist(
+        spike_types=['evprox', 'evdist'],
+        invert_spike_types='evdist',
+        show=False,
+    )
+
+    # test case where all inputs are flipped
+    net.cell_response.plot_spikes_hist(
+        spike_types=['evprox', 'evdist'],
+        invert_spike_types=['evprox', 'evdist'],
+        show=False,
+    )
+
+    # test case where some inputs are flipped
     fig = net.cell_response.plot_spikes_hist(
         spike_types=['evprox', 'evdist'],
         invert_spike_types=['evdist'],
@@ -382,5 +397,8 @@ def test_invert_spike_types(setup_net):
     y2_max = max(y2.get_ylim())
 
     assert y1_max == y2_max
+
+    # check that data are plotted
+    assert y1_max > 1
 
     plt.close('all')

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -342,3 +342,45 @@ def test_network_plotter_export(tmp_path, setup_net):
     assert path_out.is_file()
 
     plt.close('all')
+
+
+def test_invert_spike_types(setup_net):
+    """Test plotting a histogram with an inverted external drive"""
+    net = setup_net
+
+    weights_ampa = {'L2_pyramidal': 0.15, 'L5_pyramidal': 0.15}
+    syn_delays = {'L2_pyramidal': 0.1, 'L5_pyramidal': 1.}
+
+    net.add_evoked_drive(
+        'evdist1', mu=63.53, sigma=3.85, numspikes=1,
+        weights_ampa=weights_ampa, location='distal',
+        synaptic_delays=syn_delays, event_seed=274
+    )
+
+    net.add_evoked_drive(
+        'evprox1', mu=26.61, sigma=2.47, numspikes=1,
+        weights_ampa=weights_ampa, location='proximal',
+        synaptic_delays=syn_delays, event_seed=274
+    )
+
+    _ = simulate_dipole(net, dt=0.5, tstop=80., n_trials=1)
+
+    fig = net.cell_response.plot_spikes_hist(
+        spike_types=['evprox', 'evdist'],
+        invert_spike_types=['evdist'],
+        show=False,
+    )
+
+    # check that there are 2 y axes
+    assert len(fig.axes) == 2
+
+    # check for equivalency of both y axes
+    y1 = fig.axes[0]
+    y2 = fig.axes[1]
+
+    y1_max = max(y1.get_ylim())
+    y2_max = max(y2.get_ylim())
+
+    assert y1_max == y2_max
+
+    plt.close('all')

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -379,7 +379,7 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
 
         | Ex: ``['evdist', 'evprox']``
 
-        If None, all input spike types are plotted on the same y axis 
+        If None, all input spike types are plotted on the same y axis
     color : str | list of str | dict | None
         Input defining colors of plotted histograms. If str, all
         histograms plotted with same color. If list of str provided,
@@ -506,19 +506,21 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
     else:
         if not isinstance(invert_spike_types, (str, list)):
             raise TypeError(
-                f"'invert_spike_types' must be a string or a list of strings")
+                "'invert_spike_types' must be a string or a list of strings")
         if isinstance(invert_spike_types, str):
             invert_spike_types = [invert_spike_types]
-        
+
         invert_spike_types = {spike_type for spike_type in invert_spike_types}
 
         # Check that spike types to invert are correctly specified
         unique_inputs = set(spike_labels.values())
-        if not invert_spike_types.intersection(unique_inputs) == invert_spike_types:
+        check_intersection = invert_spike_types.intersection(unique_inputs)
+        if not check_intersection == invert_spike_types:
             raise ValueError(
-                f"Elements of 'invert_spike_types' must map to valid input types"
+                "Elements of 'invert_spike_types' must"
+                "map to valid input types"
             )
-    
+
     # Initialize secondary axis
     ax1 = None
 
@@ -541,7 +543,7 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
     if ax1 is not None:
         ax_ylim = ax.get_ylim()[1]
         ax1_ylim = ax1.get_ylim()[1]
-        
+
         y_max = max(ax_ylim, ax1_ylim)
         ax.set_ylim(0, y_max)
         ax1.set_ylim(0, y_max)

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -504,7 +504,7 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
     if invert_spike_types is None:
         invert_spike_types = list()
     else:
-        if isinstance(invert_spike_types, dict):
+        if not isinstance(invert_spike_types, (str, list)):
             raise TypeError(
                 f"'invert_spike_types' must be a string or a list of strings")
         if isinstance(invert_spike_types, str):

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -510,12 +510,11 @@ def plot_spikes_hist(cell_response, trial_idx=None, ax=None, spike_types=None,
         if isinstance(invert_spike_types, str):
             invert_spike_types = [invert_spike_types]
 
-        invert_spike_types = {spike_type for spike_type in invert_spike_types}
-
         # Check that spike types to invert are correctly specified
         unique_inputs = set(spike_labels.values())
-        check_intersection = invert_spike_types.intersection(unique_inputs)
-        if not check_intersection == invert_spike_types:
+        unique_invert_inputs = set(invert_spike_types)
+        check_intersection = unique_invert_inputs.intersection(unique_inputs)
+        if not check_intersection == unique_invert_inputs:
             raise ValueError(
                 "Elements of 'invert_spike_types' must"
                 "map to valid input types"


### PR DESCRIPTION
Adding functionality to specify spike types to invert when creating the input histogram. 

So far:

![image](https://github.com/user-attachments/assets/cbad59b9-3491-4fa8-9b24-0e456e0f722d)

Still need to test, etc. More coming soon :)
