### PR TITLE
[MRG] chore: change fixed L2 names in gui to L2/3

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,8 @@ Changelog
 - Add method to modify synaptic gains, by `Nick Tolley`_  and `George Dang`_
   in :gh:`897`
 
+- Update GUI to display "L2/3", by `Austin Soplata`_ in :gh:`904`
+
 Bug
 ~~~
 - Fix GUI over-plotting of loaded data where the app stalled and did not plot

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -400,7 +400,7 @@ class HNNGUI:
             button_color=self.layout['theme_color'])
 
         self.cell_type_radio_buttons = RadioButtons(
-            options=['L2 Pyramidal', 'L5 Pyramidal'],
+            options=['L2/3 Pyramidal', 'L5 Pyramidal'],
             description='Cell type:')
 
         self.cell_layer_radio_buttons = RadioButtons(
@@ -1973,6 +1973,9 @@ def _update_cell_params_vbox(cell_type_out, cell_parameters_list,
     cell_parameters_key = f"{cell_type}_{cell_layer}"
     if cell_layer in ['Biophysics', 'Geometry']:
         cell_parameters_key += f" {cell_type.split(' ')[0]}"
+
+    # Needed for the button to display L2/3, but the underlying data to use L2
+    cell_parameters_key = cell_parameters_key.replace("L2/3", "L2")
 
     if cell_parameters_key in cell_parameters_list:
         cell_type_out.clear_output()

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -327,7 +327,9 @@ def plot_dipole(dpl, tmin=None, tmax=None, ax=None, layer='agg', decim=None,
                 r'$\times$ {:.0f})'.format(scale_applied)
         ax.set_ylabel(ylabel, multialignment='center')
         if layer == 'agg':
-            title_str = 'Aggregate (L2 + L5)'
+            title_str = 'Aggregate (L2/3 + L5)'
+        elif layer == 'L2':
+            title_str = 'L2/3'
         else:
             title_str = layer
         ax.set_title(title_str)


### PR DESCRIPTION
Note that this does not change the L2 names inherent in the `cell_types` which are loaded dynamically in the gui, such as shown here: https://github.com/jonescompneurolab/hnn-core/issues/904#issue-2589984642