### PR TITLE
[MRG] fix synapses properties rendering

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1971,7 +1971,7 @@ def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
 def _update_cell_params_vbox(cell_type_out, cell_parameters_list,
                              cell_type, cell_layer):
     cell_parameters_key = f"{cell_type}_{cell_layer}"
-    if "Biophysics" or 'Geometry' in cell_layer:
+    if cell_layer in ['Biophysics', 'Geometry']:
         cell_parameters_key += f" {cell_type.split(' ')[0]}"
 
     if cell_parameters_key in cell_parameters_list:


### PR DESCRIPTION
Changed logic in `_update_cell_params_vbox` to properly build the `cell_parameters_key`.

The problem was here: 
https://github.com/jonescompneurolab/hnn-core/blob/7a42650dbe41e0a740612fe374e5b19e3e8e8d7c/hnn_core/gui/gui.py#L1974-L1975

`if "Biophysics"` will always evaluate to `True`.

closes #911 