### PR TITLE
[MRG] GUI synaptic gains implementation

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1739,10 +1739,13 @@ def add_cell_parameters_tab(cell_params_out, cell_pameters_vboxes,
 
 def add_synaptic_gain_tab(net, syn_gain_out, syn_gain_textfields, layout):
 
+    gain_values = net.get_synaptic_gains()
     gain_types = ('e_e', 'e_i', 'i_e', 'i_i')
     for gain_type in gain_types:
         gain_widget = BoundedFloatText(
-            value=1, description=f'{gain_type}', min=0, max=1e6, step=.1,
+            value=gain_values[gain_type],
+            description=f'{gain_type}',
+            min=0, max=1e6, step=.1,
             disabled=False, layout=layout)
         syn_gain_textfields[gain_type] = gain_widget
 

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -424,6 +424,8 @@ class HNNGUI:
 
         # Cell parameter list
         self.cell_pameters_widgets = dict()
+        # Cell parameter dict
+        self.cell_parameters_widgets = dict()
 
         self._init_ui_components()
         self.add_logging_window_logger()
@@ -570,6 +572,7 @@ class HNNGUI:
                 self._simulation_status_bar, self._simulation_status_contents,
                 self.connectivity_widgets, self.viz_manager,
                 self.simulation_list_widget, self.cell_pameters_widgets)
+                self.simulation_list_widget, self.cell_parameters_widgets,
 
         def _simulation_list_change(value):
             # Simulation Data
@@ -612,13 +615,13 @@ class HNNGUI:
 
         def _cell_type_radio_change(value):
             _update_cell_params_vbox(self._cell_params_out,
-                                     self.cell_pameters_widgets,
+                                     self.cell_parameters_widgets,
                                      value.new,
                                      self.cell_layer_radio_buttons.value)
 
         def _cell_layer_radio_change(value):
             _update_cell_params_vbox(self._cell_params_out,
-                                     self.cell_pameters_widgets,
+                                     self.cell_parameters_widgets,
                                      self.cell_type_radio_buttons.value,
                                      value.new)
 
@@ -688,8 +691,10 @@ class HNNGUI:
 
         connectivity_configuration.children = [connectivity_box,
                                                cell_parameters]
+                                               cell_parameters,
         connectivity_configuration.titles = ['Connectivity',
                                              'Cell parameters']
+                                             'Cell parameters',
 
         drive_selections = VBox([
             self.add_drive_button, self.widget_drive_type_selection,
@@ -902,7 +907,7 @@ class HNNGUI:
                                  self._connectivity_out,
                                  self.connectivity_widgets,
                                  self._cell_params_out,
-                                 self.cell_pameters_widgets,
+                                 self.cell_parameters_widgets,
                                  self.cell_layer_radio_buttons,
                                  self.cell_type_radio_buttons,
                                  self.layout)
@@ -1034,7 +1039,7 @@ class HNNGUI:
             if load_type == 'connectivity':
                 add_connectivity_tab(
                     params, self._connectivity_out, self.connectivity_widgets,
-                    self._cell_params_out, self.cell_pameters_widgets,
+                    self._cell_params_out, self.cell_parameters_widgets,
                     self.cell_layer_radio_buttons,
                     self.cell_type_radio_buttons, layout)
             elif load_type == 'drives':
@@ -1598,7 +1603,7 @@ def _build_drive_objects(drive_type, name, tstop_widget, layout, style,
 
 
 def add_connectivity_tab(params, connectivity_out, connectivity_textfields,
-                         cell_params_out, cell_pameters_vboxes,
+                         cell_params_out, cell_parameters_vboxes,
                          cell_layer_radio_button, cell_type_radio_button,
                          layout):
     """Add all possible connectivity boxes to connectivity tab."""
@@ -1609,7 +1614,7 @@ def add_connectivity_tab(params, connectivity_out, connectivity_textfields,
                                  connectivity_textfields)
 
     # build cell parameters tab
-    add_cell_parameters_tab(cell_params_out, cell_pameters_vboxes,
+    add_cell_parameters_tab(cell_params_out, cell_parameters_vboxes,
                             cell_layer_radio_button, cell_type_radio_button,
                             layout)
     return net
@@ -1819,7 +1824,6 @@ def _init_network_from_widgets(params, dt, tstop, single_simulation_data,
                     'nc_dict']['A_weight'] = vbox_key.children[1].value
 
     # Update cell params
-
     update_functions = {
         'L2 Geometry': _update_L2_geometry_cell_params,
         'L5 Geometry': _update_L5_geometry_cell_params,
@@ -1934,6 +1938,7 @@ def run_button_clicked(widget_simulation_name, log_out, drive_widgets,
                                    simulation_data[_sim_name], drive_widgets,
                                    connectivity_textfields,
                                    cell_pameters_widgets)
+                                   cell_parameters_widgets,
 
         print("start simulation")
         if backend_selection.value == "MPI":

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -679,7 +679,7 @@ class HNNGUI:
                 self._backend_config_out]),
         ], layout=self.layout['config_box'])
 
-        connectivity_configuration = Tab()
+        network_configuration = Tab()
 
         connectivity_box = VBox([
             HBox([self.load_connectivity_button, ]),
@@ -694,12 +694,12 @@ class HNNGUI:
 
         syn_gain = VBox([self._syn_gain_out])
 
-        connectivity_configuration.children = [connectivity_box,
-                                               cell_parameters,
-                                               syn_gain]
-        connectivity_configuration.titles = ['Connectivity',
-                                             'Cell parameters',
-                                             'Synaptic gains']
+        network_configuration.children = [connectivity_box,
+                                          cell_parameters,
+                                          syn_gain]
+        network_configuration.titles = ['Connectivity',
+                                        'Cell parameters',
+                                        'Synaptic gains']
 
         drive_selections = VBox([
             self.add_drive_button, self.widget_drive_type_selection,
@@ -719,7 +719,7 @@ class HNNGUI:
         # Tabs for left pane
         left_tab = Tab()
         left_tab.children = [
-            simulation_box, connectivity_configuration, drives_options,
+            simulation_box, network_configuration, drives_options,
             config_panel,
         ]
         titles = ('Simulation', 'Network', 'External drives',

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1880,7 +1880,7 @@ def _init_network_from_widgets(params, dt, tstop, single_simulation_data,
     # Update with synaptic gains
     syn_gain_values = {key: widget.value
                        for key, widget in syn_gain_textfields.items()}
-    single_simulation_data['net'].update_weights(**syn_gain_values)
+    single_simulation_data['net'].set_synaptic_gains(**syn_gain_values)
 
     if add_drive is False:
         return

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1525,6 +1525,52 @@ class Network:
         if copy:
             return net
 
+    def get_synaptic_gains(self):
+        """Retrieve gain values for different connection types in the network.
+
+        This function identifies excitatory and inhibitory cells in the network
+        and retrieves the gain value for each type of synaptic connection:
+        - excitatory to excitatory (e_e)
+        - excitatory to inhibitory (e_i)
+        - inhibitory to excitatory (i_e)
+        - inhibitory to inhibitory (i_i)
+
+        The gain is assumed to be uniform within each connection type, and only
+        the first connection's gain value is used for each type.
+
+        Returns
+        -------
+        dict: A dictionary with the connection types ('e_e', 'e_i', 'i_e',
+        'i_i') as keys and their corresponding gain values.
+        """
+        # Initialize gain values with default gain of 1.0 for all connection types
+        values = {k: 1.0 for k in ('e_e', 'e_i', 'i_e', 'i_i')}
+
+        e_cells, i_cells = _get_cell_index_by_synapse_type(self)
+
+        # Define the connection types and corresponding source/target cell indexes
+        conn_types = {
+            'e_e': (e_cells, e_cells),
+            'e_i': (e_cells, i_cells),
+            'i_e': (i_cells, e_cells),
+            'i_i': (i_cells, i_cells)
+        }
+
+        # Retrieve the gain value for each connection type
+        for conn_type, (src_indexes, target_indexes) in conn_types.items():
+            conn_indices = pick_connection(self,
+                                           src_gids=src_indexes,
+                                           target_gids=target_indexes)
+
+            if conn_indices:
+                # Extract the gain from the first connection
+                values[conn_type] = (
+                    self.connectivity[conn_indices[0]]['nc_dict']['gain']
+                )
+
+        return values
+
+
     def plot_cells(self, ax=None, show=True):
         """Plot the cells using Network.pos_dict.
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1461,8 +1461,8 @@ class Network:
                                      method=method,
                                      min_distance=min_distance)})
 
-    def update_weights(self, e_e=None, e_i=None,
-                       i_e=None, i_i=None, copy=False):
+    def set_synaptic_gains(self, e_e=None, e_i=None,
+                           i_e=None, i_i=None, copy=False):
         """Update synaptic weights of the network.
 
         Parameters

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -322,7 +322,7 @@ def _get_cell_index_by_synapse_type(net):
 
     def list_src_gids(indices):
         return np.concatenate([list(net.connectivity[conn_idx]['src_gids'])
-                                  for conn_idx in indices]).tolist()
+                               for conn_idx in indices]).tolist()
 
     e_conns = pick_connection(net, receptor=['ampa', 'nmda'])
     e_cells = list_src_gids(e_conns)
@@ -1543,12 +1543,12 @@ class Network:
         dict: A dictionary with the connection types ('e_e', 'e_i', 'i_e',
         'i_i') as keys and their corresponding gain values.
         """
-        # Initialize gain values with default gain of 1.0 for all connection types
+        # Initialize gain values with default gain of 1.0
         values = {k: 1.0 for k in ('e_e', 'e_i', 'i_e', 'i_i')}
 
         e_cells, i_cells = _get_cell_index_by_synapse_type(self)
 
-        # Define the connection types and corresponding source/target cell indexes
+        # Define the connection types and source/target cell indexes
         conn_types = {
             'e_e': (e_cells, e_cells),
             'e_i': (e_cells, i_cells),
@@ -1569,7 +1569,6 @@ class Network:
                 )
 
         return values
-
 
     def plot_cells(self, ax=None, show=True):
         """Plot the cells using Network.pos_dict.

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1127,3 +1127,34 @@ def test_delete_single_drive(setup_gui):
                                           'alpha_prox (proximal)',
                                           'poisson (proximal)',
                                           'tonic')
+
+
+def test_adjust_synaptic_weights(setup_gui):
+    """Test adjusting synaptic weight widgets."""
+
+    gui = setup_gui
+    _single_simulation = {}
+    _single_simulation['net'] = dict_to_network(gui.params)
+    _init_network_from_widgets(gui.params, gui.widget_dt, gui.widget_tstop,
+                               _single_simulation, gui.drive_widgets,
+                               gui.connectivity_widgets,
+                               gui.cell_parameters_widgets,
+                               gui.synaptic_gain_widgets)
+
+    gains_default = _single_simulation['net'].get_synaptic_gains()
+    assert gains_default == {'e_e': 1.0, 'e_i': 1.0, 'i_e': 1.0, 'i_i': 1.0}
+
+    # Change the synaptic weight widgets
+    gui.synaptic_gain_widgets['e_e'].value = 0.5
+    gui.synaptic_gain_widgets['e_i'].value = 0.5
+    gui.synaptic_gain_widgets['i_i'].value = 1.1
+    gui.synaptic_gain_widgets['i_e'].value = 1.1
+    _init_network_from_widgets(gui.params, gui.widget_dt, gui.widget_tstop,
+                               _single_simulation, gui.drive_widgets,
+                               gui.connectivity_widgets,
+                               gui.cell_parameters_widgets,
+                               gui.synaptic_gain_widgets)
+
+    gains_altered = _single_simulation['net'].get_synaptic_gains()
+    assert gains_altered == {'e_e': 0.5, 'e_i': 0.5, 'i_e': 1.1, 'i_i': 1.1}
+

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -1157,4 +1157,3 @@ def test_adjust_synaptic_weights(setup_gui):
 
     gains_altered = _single_simulation['net'].get_synaptic_gains()
     assert gains_altered == {'e_e': 0.5, 'e_i': 0.5, 'i_e': 1.1, 'i_i': 1.1}
-

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -309,7 +309,8 @@ def test_gui_change_connectivity():
                                            _single_simulation,
                                            gui.drive_widgets,
                                            gui.connectivity_widgets,
-                                           gui.cell_pameters_widgets,
+                                           gui.cell_parameters_widgets,
+                                           gui.synaptic_gain_widgets,
                                            add_drive=False)
 
                 # test if the new value is reflected in the network
@@ -348,7 +349,8 @@ def test_gui_init_network(setup_gui):
     _init_network_from_widgets(gui.params, gui.widget_dt, gui.widget_tstop,
                                _single_simulation, gui.drive_widgets,
                                gui.connectivity_widgets,
-                               gui.cell_pameters_widgets)
+                               gui.cell_parameters_widgets,
+                               gui.synaptic_gain_widgets)
     plt.close('all')
 
     net_from_gui = _single_simulation['net']
@@ -939,7 +941,8 @@ def test_gui_add_tonic_input():
     _init_network_from_widgets(gui.params, gui.widget_dt, gui.widget_tstop,
                                _single_simulation, gui.drive_widgets,
                                gui.connectivity_widgets,
-                               gui.cell_pameters_widgets)
+                               gui.cell_parameters_widgets,
+                               gui.synaptic_gain_widgets)
 
     net = _single_simulation['net']
     assert net.external_biases['tonic'] is not None
@@ -966,7 +969,7 @@ def test_gui_cell_params_widgets(setup_gui):
     layers = gui.cell_layer_radio_buttons.options
     assert (len(layers) == 3)
 
-    keys = gui.cell_pameters_widgets.keys()
+    keys = gui.cell_parameters_widgets.keys()
     num_cell_params = 0
     for pyramid_cell_type in pyramid_cell_types:
         cell_type = pyramid_cell_type.split('_')[0]

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -116,6 +116,8 @@ def test_gui_compose():
     gui = HNNGUI()
     gui.compose()
     assert len(gui.connectivity_widgets) == 12
+    assert len(gui.synaptic_gain_widgets) == 4
+    assert len(gui.cell_parameters_widgets) == 6
     assert len(gui.drive_widgets) == 3
     plt.close('all')
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -906,16 +906,16 @@ def test_synaptic_gains():
     arg_names = ['e_e', 'e_i', 'i_e', 'i_i']
     for arg in arg_names:
         with pytest.raises(TypeError, match='must be an instance of int or'):
-            net.update_weights(**{arg: 'abc'})
+            net.set_synaptic_gains(**{arg: 'abc'})
 
         with pytest.raises(ValueError, match='must be non-negative'):
-            net.update_weights(**{arg: -1})
+            net.set_synaptic_gains(**{arg: -1})
 
     with pytest.raises(TypeError, match='must be an instance of bool'):
-        net.update_weights(copy='True')
+        net.set_synaptic_gains(copy='True')
 
     # Single argument check with copy
-    net_updated = net.update_weights(e_e=2.0, copy=True)
+    net_updated = net.set_synaptic_gains(e_e=2.0, copy=True)
     for conn in net_updated.connectivity:
         if (conn['src_type'] in e_cell_names and
                 conn['target_type'] in e_cell_names):
@@ -927,7 +927,7 @@ def test_synaptic_gains():
         assert conn['nc_dict']['gain'] == 1.0
 
     # Single argument with inplace change
-    net.update_weights(i_e=0.5, copy=False)
+    net.set_synaptic_gains(i_e=0.5, copy=False)
     for conn in net.connectivity:
         if (conn['src_type'] in i_cell_names and
                 conn['target_type'] in e_cell_names):
@@ -936,7 +936,7 @@ def test_synaptic_gains():
             assert conn['nc_dict']['gain'] == 1.0
 
     # Two argument check
-    net.update_weights(i_e=0.5, i_i=0.25, copy=False)
+    net.set_synaptic_gains(i_e=0.5, i_i=0.25, copy=False)
     for conn in net.connectivity:
         if (conn['src_type'] in i_cell_names and
                 conn['target_type'] in e_cell_names):

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -895,8 +895,8 @@ def test_network_mesh():
     _ = law_2021_model(mesh_shape=mesh_shape)
 
 
-def test_synaptic_gains():
-    """Test synaptic gains update"""
+def test_set_synaptic_gains():
+    """Test synaptic gains setter"""
     net = jones_2009_model()
     nb_base = NetworkBuilder(net)
     e_cell_names = ['L2_pyramidal', 'L5_pyramidal']
@@ -961,6 +961,16 @@ def test_synaptic_gains():
     # Unaltered check
     assert (_get_weight(nb_updated, 'L2Pyr_L5Basket_ampa') /
             _get_weight(nb_base, 'L2Pyr_L5Basket_ampa')) == 1
+
+
+def test_get_synaptic_gains():
+    """Test synaptic gains getter."""
+    net = jones_2009_model()
+    assert net.get_synaptic_gains() == {'e_e': 1.0, 'e_i': 1.0,
+                                        'i_e': 1.0, 'i_i': 1.0}
+    new_gains = {'e_e': 0.5, 'e_i': 1.5, 'i_e': 0.75, 'i_i': 1.0}
+    net.set_synaptic_gains(**new_gains)
+    assert net.get_synaptic_gains() == new_gains
 
 
 class TestPickConnection:


### PR DESCRIPTION
Added synaptic gains widgets to the GUI.

Changes:
1. Adjusted `Network` class methods 
    2. Renamed `update_weights` method to `set_synaptic_gains` for more clarity 
    3. Added `get_synaptic_gains` method and test
4. Added new "Synaptic gains" child tab under the Network tab with widgets for each weight 
5. Updated the `_init_network_from_widgets` function to update synaptic gains 
6. Added tests for GUI synaptic gains 

![Screenshot 2024-10-22 at 2 27 42 PM](https://github.com/user-attachments/assets/efe656cd-fc1c-4480-859f-249ed302aa29)
