### PR TITLE
fix: log messages to the bottom of the output window instead of the top

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -156,7 +156,7 @@ class _OutputWidgetHandler(logging.Handler):
             'output_type': 'stream',
             'text': formatted_record + '\n'
         }
-        self.out.outputs = (new_output, ) + self.out.outputs
+        self.out.outputs = self.out.outputs + (new_output, )
 
 
 class HNNGUI:


### PR DESCRIPTION
Prints log messages to the bottom of the output instead of the top.
