### PR TITLE
[MRG] Replace `flake8` linting with `ruff` linting

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -54,10 +54,10 @@
           shell: bash -el {0}
           run: |
             pip install --verbose '.[opt, parallel, test, gui]'
-        - name: Lint with flake8
+        - name: Lint with ruff
           shell: bash -el {0}
           run: |
-            flake8 --count hnn_core
+            ruff check hnn_core
         - name: Test non-MPI, embarrassingly parallel tests with pytest
           shell: bash -el {0}
           run: |

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,15 @@ clean :
 check-manifest:
 	check-manifest
 
-test: flake
+test: lint
 	pytest ./hnn_core/tests/ -m "not uses_mpi" -n auto
 	pytest ./hnn_core/tests/ -m "uses_mpi"
 
-flake:
-	@if command -v flake8 > /dev/null; then \
-		echo "Running flake8"; \
-		flake8 hnn_core --count; \
+lint:
+	@if command -v ruff > /dev/null; then \
+		echo "Running ruff check"; \
+		ruff check hnn_core; \
 	else \
-		echo "flake8 not found, please install it!"; \
+		echo "ruff not found, please install it!"; \
 		exit 1; \
 	fi;
-	@echo "flake8 passed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,13 @@ check-hidden = true
 # in jupyter notebooks - images and also some embedded outputs
 ignore-regex = '^\s*"image/\S+": ".*|.*%22%3A%20.*'
 ignore-words-list = 'tha,nam,sherif,dout'
+
+[tool.ruff]
+exclude = ["*.ipynb"]
+[tool.ruff.lint]
+exclude = ["__init__.py"]
+# We don't include rule "W504", which was in our old flake8 "setup.cfg" file, because the ruff
+# linter does not detect it.
+ignore = [
+   "E722",  # From original flake8 'setup.cfg' file, needed in gui.py and viz.py
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,9 @@ ignore-words-list = 'tha,nam,sherif,dout'
 exclude = ["*.ipynb"]
 [tool.ruff.lint]
 exclude = ["__init__.py"]
-# We don't include rule "W504", which was in our old flake8 "setup.cfg" file, because the ruff
-# linter does not detect it.
 ignore = [
-   "E722",  # From original flake8 'setup.cfg' file, needed in gui.py and viz.py
+   "E722",  # E722 is a pycodestyle PEP8 style violation called "bare-except".
+            # It indicates that the best practice of catching a specific
+            # Exception, as opposed to any, was not followed. For more details,
+            # see https://www.flake8rules.com/rules/E722.html
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[flake8]
-exclude = __init__.py
-ignore = E722, W504
-
 [check-manifest]
 ignore =
     .circleci/*

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     extras = {
         'opt': ['scikit-learn'],
         'parallel': ['joblib', 'psutil'],
-        'test': ['flake8', 'pytest', 'pytest-cov', 'pytest-xdist'],
+        'test': ['pytest', 'pytest-cov', 'pytest-xdist', 'ruff'],
         'docs': ['mne', 'nibabel', 'pooch', 'tdqm',
                  'sphinx', 'sphinx-gallery',
                  'sphinx_bootstrap_theme', 'sphinx-copybutton',


### PR DESCRIPTION
This is a small change for the purposes of replacing our previous linting with `flake8` to use the faster `ruff check` linting. For previous discussion on why this is a good idea, see the parts of #934 discussing `ruff` *linting* specifically (as opposed to "formatting"). This PR was forked off from that discussion. Note that this current PR is NOT about using `ruff format` to change our code-formatting-style. Instead, the "linting" in `ruff check` is limited to error detection (such as syntax errors) and some limited PEP8 formatting violation detection. Again, see the other issue for a more exhaustive discussion of these things, including the terminology around them.

Note: for anyone doing testing on an existing install, this DOES require that you will have to install the `ruff` Python package. Alternatively, you can also install `ruff` by re-installing the development packages the same way you originally installed `flake8`, via:

`pip install --editable "<your_hnn_dir>[dev]"`