### PR TITLE
[MRG] DEV: Add local codespell usage to dev install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,6 @@ clean :
 check-manifest:
 	check-manifest
 
-test: lint
-	pytest ./hnn_core/tests/ -m "not uses_mpi" -n auto
-	pytest ./hnn_core/tests/ -m "uses_mpi"
-
 lint:
 	@if command -v ruff > /dev/null; then \
 		echo "Running ruff check"; \
@@ -29,3 +25,16 @@ lint:
 		echo "ruff not found, please install it!"; \
 		exit 1; \
 	fi;
+
+spell:
+	@if command -v codespell > /dev/null; then \
+		echo "Running codespell"; \
+		codespell; \
+	else \
+		echo "codespell not found, please install it!"; \
+		exit 1; \
+	fi;
+
+test: lint spell
+	pytest ./hnn_core/tests/ -m "not uses_mpi" -n auto
+	pytest ./hnn_core/tests/ -m "uses_mpi"

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -153,6 +153,16 @@ encourage contributors to follow the
 {doc}`parallel backend guide <parallel>` to install `mpi4py` so that
 they can run the entire test suite locally on their computer.
 
+As part of `make test`, your code is also "linted" (meaning checked for errors)
+and spell-checked. If you would like to perform these checks individually, you
+can do so by running the following command to lint with `ruff`:
+
+    $ make lint
+
+Or the following command to perform common spell-checking:
+
+    $ make spell
+
 ## Updating documentation
 
 When you update the documentation, it is recommended to build it locally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=40.8.0", "NEURON >=7.7; platform_system != 'Windows'"]
 build-backend = "setuptools.build_meta:__legacy__"
 [tool.codespell]
-skip = '.git,*.pdf,*.svg'
+skip = '.git,*.pdf,*.svg,./hnn_core/mod,./doc/_build,./build'
 check-hidden = true
 # in jupyter notebooks - images and also some embedded outputs
 ignore-regex = '^\s*"image/\S+": ".*|.*%22%3A%20.*'

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     extras = {
         'opt': ['scikit-learn'],
         'parallel': ['joblib', 'psutil'],
-        'test': ['pytest', 'pytest-cov', 'pytest-xdist', 'ruff'],
+        'test': ['codespell', 'pytest', 'pytest-cov', 'pytest-xdist', 'ruff'],
         'docs': ['mne', 'myst-parser', 'nibabel', 'numpydoc', 'pillow',
                  'pooch', 'pydata-sphinx-theme', 'sphinx', 'sphinx-gallery',
                  'sphinx-copybutton', 'tdqm'],


### PR DESCRIPTION
This is a pretty trivial change: this adds support for automatic *local* install and usage of [codespell](https://github.com/codespell-project/codespell). This fixes an annoyance since, currently, we have a CI runner for `codespell` usage (see https://github.com/codespell-project/codespell ), but there's no automatic local way to test for such spelling mistakes before you push your commits.

This fixes the problem, in that now, `codespell` is used the same as our linting: it's installed as part of the `[test]` or `[dev]` options (e.g. `pip install "hnn_core[test]"`), and run during a developer's local `make test`. The TOML change also enables it to ignore any locally-built artifacts (which are not a problem for the CI runner).

After this, hopefully no more follow-up "`flake8 fix`" or "`spelling mistake`" commits :)