### PR TITLE
[MRG] fix: relax test for poisson drive stats

### DIFF
--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -59,7 +59,7 @@ def test_external_drive_times():
     lamtha = 50.
     event_times = _create_extpois(t0=0, T=100000, lamtha=lamtha, prng=prng)
     event_intervals = np.diff(event_times)
-    assert pytest.approx(event_intervals.mean(), abs=1.) == 1000 * 1 / lamtha
+    assert pytest.approx(event_intervals.mean(), abs=1.5) == 1000 * 1 / lamtha
 
     with pytest.raises(ValueError, match='The start time for Poisson'):
         _create_extpois(t0=-5, T=5, lamtha=lamtha, prng=prng)


### PR DESCRIPTION
This is a trivial fix for stochastic, difficult-to-reproduce test failure. Rarely, and seemingly only on Python 3.8 `Unit Test` runners, this test will fail due to the random Poisson mean interval exceeding the `approx` threshold. Here is an example case: https://github.com/asoplata/hnn-core/actions/runs/12952951618/job/36131478285#step:9:164 . I noticed the same thing happening on the first time I tried to run the tests for #971 ; however, since I told it to re-run the failed jobs, now I can't find any data on the previously-failed jobs. (It's possible that when you re-run failed jobs, maybe you can't access the old failed data using GitHub Actions?). As you can see in the above example, the test failed because the mean event interval was around 18.98, which is *just* outside of the threshold of 20 +/- 1.

This may have been a pre-existing issue that sometimes produced random failures in the tests, but only rarely and stochastically. By expanding the tolerance for this test, this should become *far* less likely to cause test failures in the future.

To be clear, scientifically, we're saying that the mean of our realized Poisson rate is within 1.5 ([Hz] I believe) of our expected value, instead of 1 [Hz], for testing purposes. We could also tighten the tolerance gap back to something like 1.1 if anyone else is uncomfortable with this change (@ntolley ?)