### PR TITLE
[MRG] fix: copy template for monthly metrics workflow

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -1,12 +1,11 @@
 name: Monthly issue metrics
-
 on:
   workflow_dispatch:
   schedule:
-    - cron: '3 2 1 * *'
+    - cron: "3 2 1 * *"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -17,29 +16,28 @@ jobs:
       pull-requests: read
 
     steps:
+      - name: Get dates for last month
+        shell: bash
+        run: |
+          # Calculate the first day of the previous month
+          first_day=$(date -d "last month" +%Y-%m-01)
 
-    - name: Get dates for last month
-      shell: bash
-      run: |
-        # Calculate the first day of the previous month
-        first_day=$(date -d "last month" +%Y-%m-01)
+          # Calculate the last day of the previous month
+          last_day=$(date -d "$first_day +1 month -1 day" +%Y-%m-%d)
 
-        # Calculate the last day of the previous month
-        last_day=$(date -d "$first_day +1 month -1 day" +%Y-%m-%d)
+          #Set an environment variable with the date range
+          echo "$first_day..$last_day"
+          echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
 
-        #Set an environment variable with the date range
-        echo "$first_day..$last_day"
-        echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
+      - name: Run issue-metrics tool
+        uses: github/issue-metrics@v3
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEARCH_QUERY: 'repo:jonescompneurolab/hnn-core is:issue created:${{ env.last_month }}'
 
-    - name: Run issue-metrics tool
-      uses: github/issue-metrics@v3
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SEARCH_QUERY: 'repo:jonescompneurolab/hnn-core is:issue created:${{ env.last_month }}'
-
-    - name: Create issue
-      uses: peter-evans/create-issue-from-file@v4
-      with:
-        title: Monthly issue metrics report
-        token: ${{ secrets.GITHUB_TOKEN }}
-        content-filepath: ./issue_metrics.md
+      - name: Create issue
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Monthly issue metrics report
+          token: ${{ secrets.GITHUB_TOKEN }}
+          content-filepath: ./issue_metrics.md


### PR DESCRIPTION
This copies over the exact content of the template for the `issue_metrics` workflow from
https://github.com/github/issue-metrics/blob/main/docs/example-workflows.md EXCEPT for the `SEARCH_QUERY` and removal of `assignees`. This may help with #935 , possibly due to the change in `permissions: contents`.