### PR TITLE
[MRG] maint: update versions.json sphinx link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -100,12 +100,9 @@ html_theme = "pydata_sphinx_theme"
 
 # versions
 #
-# TODO GH #969 Once we're ready to merge this into `master`, we need to switch
-# this to dev's version
-#
 # The actual, local version of `versions.json` that you should edit (if
 # necessary) is in `_static/versions.json`.
-json_versions_url = "https://jonescompneurolab.github.io/hnn-core/stable/_static/versions.json"
+json_versions_url = "https://jonescompneurolab.github.io/hnn-core/dev/_static/versions.json"
 switcher_version_match = "dev" if ".rc" in version else version
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
Now that #971 is merged, we need to make a very small follow-up change to fix a circular dependency, which is in this PR. Merging #971 has created a new file available at https://jonescompneurolab.github.io/hnn-core/dev/_static/versions.json . This file, which is now publicly accessible, can be used as the proper `versions.json` for all documentation site builds going forward. This updates the dev build of the documentation so that it uses this new file (which is ALSO updated itself through the dev doc build).

After this, anytime we want to rename or add an additional version (like when we make a release), we only need to edit the file referenced in config line in this PR.