### PR TITLE
[MRG] hotfix version install of MPI on macos CI

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -45,7 +45,7 @@
           run: |
             if [ ${{ matrix.os }} == 'macos-latest' ]; then
               python -m pip install --upgrade pip
-              conda install --yes -c conda-forge mpi4py openmpi
+              conda install --yes -c conda-forge mpi4py "openmpi >5"
             elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
               python -m pip install --upgrade pip
               python -m pip install mpi4py


### PR DESCRIPTION
Resolves #992. This is a tiny fix needed for our MacOS CI runners to start working again.

Short version: For some reason, some time during last week, `miniconda` started installing older, incompatible versions of `conda-forge`'s OpenMPI in our CI runners by default. This PR "raises the floor" of the version so that they should begin working again.

Long version: I don't know what caused this change, but I strongly suspect it is something on Anaconda's end. I did a lot of testing, and for some reason, `miniconda` defaults to installing an older (<5) version of `conda-forge`'s OpenMPI by default on `osx-arm64`. To make it more perplexing, it installed `4.1.1`, which is lower than even the `noarch` label of `4.1.3` as can be seen here https://anaconda.org/conda-forge/openmpi . I *also* noticed that `miniconda` vs `Anaconda` installs preferred to install different versions. Not only that, but my local `Anaconda` version completely refused to install the `osx-arm64` when explicitly requested using `conda install -c conda-forge "conda-forge/osx-arm64::openmpi"`, but weirdly, `miniconda` had no problem installing with that exact same command. 