### PR TITLE
[MRG]: DOC Update whatsnew

### DIFF
--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -9,173 +9,169 @@ orphan: true
 
 ### API changes
 
-- Add ability to manually define colors in spike histogram plots,
-  by [Nick Tolley][] in {gh}`640`
+- Add ability to manually define colors in spike histogram plots, by [Nick Tolley][] in
+  {gh}`640`
 
-- Connection `'src_gids'` and `'target_gids'` are now stored as set objects
-  instead of lists, by [Ryan Thorpe][] in {gh}`642`.
+- Connection `'src_gids'` and `'target_gids'` are now stored as set objects instead of
+  lists, by [Ryan Thorpe][] in {gh}`642`
 
 - {func}`~hnn_core.CellResponse.write` and {func}`~hnn_core.Cell_response.read_spikes`
-  now support hdf5 format for read/write Cell response object, by
-  [Rajat Partani][] in {gh}`644`
+  now support hdf5 format for read/write Cell response object, by [Rajat Partani][] in
+  {gh}`644`
 
 - Add ability to customize plot colors for each cell section in
   {func}`~hnn_core.Cell.plot_morphology`, by [Nick Tolley][] in {gh}`646`
 
-- {func}`~hnn_core.Dipole.write` and {func}`~hnn_core.Dipole.read_dipoles`
-  now support hdf5 format for read/write Dipole object, by
-  [Rajat Partani][] in {gh}`648`
+- {func}`~hnn_core.Dipole.write` and {func}`~hnn_core.Dipole.read_dipoles` now support
+  hdf5 format for read/write Dipole object, by [Rajat Partani][] in {gh}`648`
 
 - Added {class}`~hnn_core.viz.NetworkPlotter` to visualize and animate network
-  simulations, by [Nick Tolley][] in {gh}`649`.
+  simulations, by [Nick Tolley][] in {gh}`649`
 
 - Add ability to optimize parameters associated with evoked drives and plot
-  convergence. User can constrain parameter ranges and specify solver,
-  by [Carolina Fernandez Pujol][] in {gh}`652`
+  convergence. User can constrain parameter ranges and specify solver, by [Carolina
+  Fernandez Pujol][] in {gh}`652`
 
-- Add ability to optimize parameters associated with rhythmic drives,
-  by [Carolina Fernandez Pujol][] in {gh}`673`.
+- Add ability to optimize parameters associated with rhythmic drives, by [Carolina
+  Fernandez Pujol][] in {gh}`673`
 
-- Add ability to specify number of cells in {class}`~hnn_core.Network`,
-  by [Nick Tolley][] in {gh}`705`
+- Add ability to specify number of cells in {class}`~hnn_core.Network`, by [Nick
+  Tolley][] in {gh}`705`
 
-- Added kwargs options to `plot_spikes_hist` for adjusting the histogram plots
-  of spiking activity, by [Abdul Samad Siddiqui][] in {gh}`732`.
+- Added kwargs options to `plot_spikes_hist` for adjusting the histogram plots of
+  spiking activity, by [Abdul Samad Siddiqui][] in {gh}`732`
 
-- Updated `plot_spikes_raster` logic to include all neurons in network model.
-  Removed GUI exclusion from build, by [Abdul Samad Siddiqui][]  in {gh}`754`.
+- Updated `plot_spikes_raster` logic to include all neurons in network model.  Removed
+  GUI exclusion from build, by [Abdul Samad Siddiqui][] in {gh}`754`
 
-- Added feature to read/write {class}`~hnn_core.Network` configurations to
-  json, by [George Dang][] and [Rajat Partani][] in {gh}`757`
+- Added feature to read/write {class}`~hnn_core.Network` configurations to json, by
+  [George Dang][] and [Rajat Partani][] in {gh}`757`
 
-- {func}`network.add_tonic_bias` cell-specific tonic bias can now be provided using the argument
-  amplitude in {func}`network.add_tonic_bias`, by [Camilo Diaz][] in {gh}`766`
+- {func}`network.add_tonic_bias` cell-specific tonic bias can now be provided using the
+  argument amplitude in {func}`network.add_tonic_bias`, by [Camilo Diaz][] in {gh}`766`
 
-- {func}`~plot_lfp`, {func}`~plot_dipole`, {func}`~plot_spikes_hist`,
-  and {func}`~plot_spikes_raster` now plotted from 0 to tstop. Inputs tmin and tmax are deprecated,
-  by [Katharina Duecker][] in {gh}`769`
+- {func}`~plot_lfp`, {func}`~plot_dipole`, {func}`~plot_spikes_hist`, and
+  {func}`~plot_spikes_raster` now plotted from 0 to tstop. Inputs tmin and tmax are
+  deprecated, by [Katharina Duecker][] in {gh}`769`
 
-- Add function {func}`~hnn_core.params.convert_to_json` to convert legacy param
-  and json files to new json format, by [George Dang][] in {gh}`772`
+- Add function {func}`~hnn_core.params.convert_to_json` to convert legacy param and json
+  files to new json format, by [George Dang][] in {gh}`772`
 
-- Add {class}`~hnn_core.BatchSimulate` for batch simulation capability,
-  by [Abdul Samad Siddiqui][] in {gh}`782`.
+- Add {class}`~hnn_core.BatchSimulate` for batch simulation capability, by [Abdul Samad
+  Siddiqui][] in {gh}`782`
 
-- Added features to {func}`~plot_csd`: to set color of sinks and sources, range of the colormap,
-  and interpolation method to smoothen CSD plot, by [Katharina Duecker][] in {gh}`815`
+- Added features to {func}`~plot_csd`: to set color of sinks and sources, range of the
+  colormap, and interpolation method to smoothen CSD plot, by [Katharina Duecker][] in
+  {gh}`815`
 
-- Add argument to change colors of `plot_spikes_raster`, shortened line lengths
-  to prevent overlap, and added an argument for custom cell types, by
-  [George Dang][] in {gh}`895`
+- Add argument to change colors of `plot_spikes_raster`, shortened line lengths to
+  prevent overlap, and added an argument for custom cell types, by [George Dang][] in
+  {gh}`895`
 
-- Add method to {class}`~hnn_core.Network` to modify synaptic gains, by
-  [Nick Tolley][]  and [George Dang][] in {gh}`897`
+- Add method to {class}`~hnn_core.Network` to modify synaptic gains, by [Nick Tolley][]
+  and [George Dang][] in {gh}`897`
 
 - Add {func}`~hnn_core.CellResponse.spike_times_by_type` to get cell spiking times
-  organized by cell type, by [Mainak Jas][] in {gh}`916`.
+  organized by cell type, by [Mainak Jas][] in {gh}`916`
 
-- Add option to apply a tonic bias to any compartment of the cell, and option to
-  add multiple biases per simulation and cell {func}`hnn_core.network.add_tonic_bias`,
-  by [Katharina Duecker][] in {gh}`922`.
+- Add option to apply a tonic bias to any compartment of the cell, and option to add
+  multiple biases per simulation and cell {func}`hnn_core.network.add_tonic_bias`, by
+  [Katharina Duecker][] in {gh}`922`
 
-- Add plots to show relative and absolute external drive strength,
-  by [Dikshant Jha][] in {gh}`987`.
+- Add plots to show relative and absolute external drive strength, by [Dikshant Jha][]
+  in {gh}`987`
 
 ### Bug fixes
 
-- Fix inconsistent connection mapping from drive gids to cell gids, by
-  [Ryan Thorpe][] in {gh}`642`.
+- Fix inconsistent connection mapping from drive gids to cell gids, by [Ryan Thorpe][]
+  in {gh}`642`
 
-- Objective function called by {func}`~hnn_core.optimization.optimize_evoked`
-  now returns a scalar instead of tuple, by [Ryan Thorpe][] in {gh}`670`.
+- Objective function called by {func}`~hnn_core.optimization.optimize_evoked` now
+  returns a scalar instead of tuple, by [Ryan Thorpe][] in {gh}`670`
 
-- Fix GUI plotting bug due to deprecation of matplotlib color cycling method,
-  by [George Dang][] in {gh}`695`.
+- Fix GUI plotting bug due to deprecation of matplotlib color cycling method, by [George
+  Dang][] in {gh}`695`
 
-- Fix bug in {func}`~hnn_core.network.pick_connection` where connections are
-  returned for cases when there should be no valid matches, by [George Dang][]
-  in {gh}`739`
+- Fix bug in {func}`~hnn_core.network.pick_connection` where connections are returned
+  for cases when there should be no valid matches, by [George Dang][] in {gh}`739`
 
-- Fixed GUI figure annotation overlap in multiple sub-plots,
-  by [Camilo Diaz][] in {gh}`741`
+- Fixed GUI figure annotation overlap in multiple sub-plots, by [Camilo Diaz][] in
+  {gh}`741`
 
-- Fix loading of drives in the GUI: drives are now overwritten instead of updated,
-  by [Mainak Jas][] in {gh}`795`.
+- Fix loading of drives in the GUI: drives are now overwritten instead of updated, by
+  [Mainak Jas][] in {gh}`795`
 
-- Use `np.isin()` in place of `np.in1d()` to address numpy deprecation,
-  by [Nick Tolley][] in {gh}`799`.
+- Use `np.isin()` in place of `np.in1d()` to address numpy deprecation, by [Nick
+  Tolley][] in {gh}`799`
 
-- Fix drive seeding so that event times are unique across multiple trials,
-  by [Nick Tolley][] in {gh}`810`.
+- Fix drive seeding so that event times are unique across multiple trials, by [Nick
+  Tolley][] in {gh}`810`
 
 - Fix bug in {func}`~hnn_core.network.clear_drives` where network object are not
-  accurately updated, by [Nick Tolley][] in {gh}`812`.
+  accurately updated, by [Nick Tolley][] in {gh}`812`
 
-- Fix bug in {func}`~hnn_core.Network.add_poisson_drive` where an error is
-  thrown when passing a float for rate_constant when ``cell_specific=False``,
-  by [Dylan Daniels][] in {gh}`814`
+- Fix bug in {func}`~hnn_core.Network.add_poisson_drive` where an error is thrown when
+  passing a float for rate_constant when ``cell_specific=False``, by [Dylan Daniels][]
+  in {gh}`814`
 
-- Fix bug in {func}`~hnn_core.Network.add_poisson_drive` where an error is
-  thrown when passing an int for rate_constant when ``cell_specific=True``,
-  by [Dylan Daniels][] in {gh}`818`
+- Fix bug in {func}`~hnn_core.Network.add_poisson_drive` where an error is thrown when
+  passing an int for rate_constant when ``cell_specific=True``, by [Dylan Daniels][] in
+  {gh}`818`
 
-- Fix GUI over-plotting of loaded data where the app stalled and did not plot
-  RMSE, by [George Dang][] in {gh}`869`
+- Fix GUI over-plotting of loaded data where the app stalled and did not plot RMSE, by
+  [George Dang][] in {gh}`869`
 
-- Fix scaling and smoothing of loaded data dipoles to the GUI, by [George Dang][]
-  in {gh}`892`
+- Fix scaling and smoothing of loaded data dipoles to the GUI, by [George Dang][] in
+  {gh}`892`
 
 ### GUI changes
 
-- Update GUI to use ipywidgets v8.0.0+ API, by [George Dang][] in
-  {gh}`696`.
+- Update GUI to use ipywidgets v8.0.0+ API, by [George Dang][] in {gh}`696`
 
 - Added pre defined plot sets for simulated data in GUI, by [Camilo Diaz][] in {gh}`746`
 
-- Added GUI widget to enable/disable synchronous input in simulations,
-  by [Camilo Diaz][] in {gh}`750`
+- Added GUI widget to enable/disable synchronous input in simulations, by [Camilo
+  Diaz][] in {gh}`750`
 
-- Added GUI widgets to save simulation as csv and updated the file upload to support csv data,
-  by [Camilo Diaz][] in {gh}`753`
+- Added GUI widgets to save simulation as csv and updated the file upload to support csv
+  data, by [Camilo Diaz][] in {gh}`753`
 
-- Added GUI feature to include Tonic input drives in simulations,
-  by [Camilo Diaz][] {gh}`773`
+- Added GUI feature to include Tonic input drives in simulations, by [Camilo Diaz][]
+  {gh}`773`
 
-- Added GUI feature to read and modify cell parameters,
-  by [Camilo Diaz][]  in {gh}`806`.
+- Added GUI feature to read and modify cell parameters, by [Camilo Diaz][] in {gh}`806`
 
-- Changed the configuration/parameter file format support of the GUI. Loading
-  of connectivity and drives use a new multi-level json structure that mirrors
-  the structure of the Network object. Flat parameter and json configuration
-  files are no longer supported by the GUI, by [George Dang][] in {gh}`837`
+- Changed the configuration/parameter file format support of the GUI. Loading of
+  connectivity and drives use a new multi-level json structure that mirrors the
+  structure of the Network object. Flat parameter and json configuration files are no
+  longer supported by the GUI, by [George Dang][] in {gh}`837`
 
-- Updated the GUI load drive widget to be able to load tonic biases from a
-  network configuration file. [George Dang][] in {gh}`852`
+- Updated the GUI load drive widget to be able to load tonic biases from a network
+  configuration file. [George Dang][] in {gh}`852`
 
-- Added "No. Drive Cells" input widget to the GUI and changed the "Synchronous
-  Input" checkbox to "Cell-Specific" to align with the API [George Dang][] in {gh}`861`
+- Added "No. Drive Cells" input widget to the GUI and changed the "Synchronous Input"
+  checkbox to "Cell-Specific" to align with the API [George Dang][] in {gh}`861`
 
-- Add button to delete a single drive on GUI drive windows, by
-  [George Dang][] in {gh}`890`
+- Add button to delete a single drive on GUI drive windows, by [George Dang][] in
+  {gh}`890`
 
-- Add minimum spectral frequency widget to GUI for adjusting spectrogram
-  frequency axis, by [George Dang][] in {gh}`894`
+- Add minimum spectral frequency widget to GUI for adjusting spectrogram frequency axis,
+  by [George Dang][] in {gh}`894`
 
 - Update GUI to display "L2/3", by [Austin Soplata][] in {gh}`904`
 
 ### Other changes
 
-- Cleaned up internal logic in {class}`~hnn_core.CellResponse`,
-  by [Nick Tolley][] in {gh}`647`.
+- Cleaned up internal logic in {class}`~hnn_core.CellResponse`, by [Nick Tolley][] in
+  {gh}`647`
 
-- Update minimum supported version of Python to 3.8, by [Ryan Thorpe][] in
-  {gh}`678`.
+- Update minimum supported version of Python to 3.8, by [Ryan Thorpe][] in {gh}`678`
 
-- Add dependency groups to setup.py and update CI workflows to reference
-  dependency groups, by [George Dang][] in {gh}`703`.
+- Add dependency groups to setup.py and update CI workflows to reference dependency
+  groups, by [George Dang][] in {gh}`703`
 
-- Added check for invalid Axes object in {func}`~hnn_core.viz.plot_cells`
-  function, by [Abdul Samad Siddiqui][] in {gh}`744`.
+- Added check for invalid Axes object in {func}`~hnn_core.viz.plot_cells` function, by
+  [Abdul Samad Siddiqui][] in {gh}`744`
 
 ### People who contributed to this release (in alphabetical order):
 
@@ -200,7 +196,7 @@ orphan: true
 ### Changelog
 
 - Add option to select drives using argument 'which_drives' in
-  {func}`~hnn_core.optimization.optimize_evoked`, by [Mohamed A. Sherif][] in {gh}`478`.
+  {func}`~hnn_core.optimization.optimize_evoked`, by [Mohamed A. Sherif][] in {gh}`478`
 
 - Changed ``conn_seed`` default to ``None`` (from ``3``) in {func}`~hnn_core.network.add_connection`,
   by [Mattan Pelah][] in {gh}`492`.

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -5,108 +5,51 @@ orphan: true
 (whats_new)=
 # What's new?
 
-## Current
+## Current (v0.4 release candidates)
 
-### Changelog
-
-- Add relative and absolute external drive strength plotting,
-  by [Dikshant Jha][] in {gh}`987`.
-
-- Add button to delete a single drive on GUI drive windows, by
-  [George Dang][] in {gh}`890`
-
-- Add minimum spectral frequency widget to GUI for adjusting spectrogram
-  frequency axis, by [George Dang][] in {gh}`894`
-
-- Add method to {class}`~hnn_core.Network` to modify synaptic gains, by
-  [Nick Tolley][]  and [George Dang][] in {gh}`897`
-
-- Update GUI to display "L2/3", by [Austin Soplata][] in {gh}`904`
-
-- Add argument to change colors of `plot_spikes_raster`, shortened line lengths
-  to prevent overlap, and added an argument for custom cell types, by
-  [George Dang][] in {gh}`895`
-
-- Added check for invalid Axes object in :func:`~hnn_core.viz.plot_cells`
-  function, by [Abdul Samad Siddiqui][] in {gh}`744`.
-
-### Bug
-
-- Fix GUI over-plotting of loaded data where the app stalled and did not plot
-  RMSE, by [George Dang][] in {gh}`869`
-
-- Fix scaling and smoothing of loaded data dipoles to the GUI, by [George Dang][]
-  in {gh}`892`
-
-### API
-
-- Add {func}`~hnn_core.CellResponse.spike_times_by_type` to get cell spiking times
-  organized by cell type, by [Mainak Jas][] in {gh}`916`.
-
-- Add option to apply a tonic bias to any compartment of the cell, and option to
-  add multiple biases per simulation and cell {func}`hnn_core.network.add_tonic_bias`,
-  by [Katharina Duecker][] in {gh}`922`.
-
-## 0.4
-
-### Changelog
-
-- Fix bug in {func}`~hnn_core.Network.add_poisson_drive` where an error is
-  thrown when passing an int for rate_constant when ``cell_specific=True``,
-  by [Dylan Daniels][] in {gh}`818`
-
-- Fix bug in {func}`~hnn_core.Network.add_poisson_drive` where an error is
-  thrown when passing a float for rate_constant when ``cell_specific=False``,
-  by [Dylan Daniels][] in {gh}`814`
-
-- Add ability to customize plot colors for each cell section in
-  {func}`~hnn_core.Cell.plot_morphology`, by [Nick Tolley][] in {gh}`646`
+### API changes
 
 - Add ability to manually define colors in spike histogram plots,
   by [Nick Tolley][] in {gh}`640`
 
-- Update minimum supported version of Python to 3.8, by [Ryan Thorpe][] in
-  {gh}`678`.
+- Connection `'src_gids'` and `'target_gids'` are now stored as set objects
+  instead of lists, by [Ryan Thorpe][] in {gh}`642`.
 
-- Update GUI to use ipywidgets v8.0.0+ API, by [George Dang][] in
-  {gh}`696`.
+- {func}`~hnn_core.CellResponse.write` and {func}`~hnn_core.Cell_response.read_spikes`
+  now support hdf5 format for read/write Cell response object, by
+  [Rajat Partani][] in {gh}`644`
 
-- Add dependency groups to setup.py and update CI workflows to reference
-  dependency groups, by [George Dang][] in {gh}`703`.
+- Add ability to customize plot colors for each cell section in
+  {func}`~hnn_core.Cell.plot_morphology`, by [Nick Tolley][] in {gh}`646`
+
+- {func}`~hnn_core.Dipole.write` and {func}`~hnn_core.Dipole.read_dipoles`
+  now support hdf5 format for read/write Dipole object, by
+  [Rajat Partani][] in {gh}`648`
+
+- Added {class}`~hnn_core.viz.NetworkPlotter` to visualize and animate network
+  simulations, by [Nick Tolley][] in {gh}`649`.
+
+- Add ability to optimize parameters associated with evoked drives and plot
+  convergence. User can constrain parameter ranges and specify solver,
+  by [Carolina Fernandez Pujol][] in {gh}`652`
+
+- Add ability to optimize parameters associated with rhythmic drives,
+  by [Carolina Fernandez Pujol][] in {gh}`673`.
 
 - Add ability to specify number of cells in {class}`~hnn_core.Network`,
   by [Nick Tolley][] in {gh}`705`
 
-- Fixed figure annotation overlap in multiple sub-plots,
-  by [Camilo Diaz][] in {gh}`741`
-
-- Fix bug in {func}`~hnn_core.network.pick_connection` where connections are
-  returned for cases when there should be no valid matches, by [George Dang][]
-  in {gh}`739`
-
-- Added check for invalid Axes object in {func}`~hnn_core.viz.plot_cells`
-  function, by [Abdul Samad Siddiqui][] in {gh}`744`.
-
 - Added kwargs options to `plot_spikes_hist` for adjusting the histogram plots
   of spiking activity, by [Abdul Samad Siddiqui][] in {gh}`732`.
 
-- Added pre defined plot sets for simulated data,
-  by [Camilo Diaz][] in {gh}`746`
-
-- Added gui widget to enable/disable synchronous input in simulations,
-  by [Camilo Diaz][] in {gh}`750`
-
-- Added gui widgets to save simulation as csv and updated the file upload to support csv data,
-  by [Camilo Diaz][] in {gh}`753`
+- Updated `plot_spikes_raster` logic to include all neurons in network model.
+  Removed GUI exclusion from build, by [Abdul Samad Siddiqui][]  in {gh}`754`.
 
 - Added feature to read/write {class}`~hnn_core.Network` configurations to
   json, by [George Dang][] and [Rajat Partani][] in {gh}`757`
 
-- Added {class}`~hnn_core.viz.NetworkPlotter` to visualize and animate network simulations,
-  by [Nick Tolley][] in {gh}`649`.
-
-- Added GUI feature to include Tonic input drives in simulations,
-  by [Camilo Diaz][] {gh}`773`
+- {func}`network.add_tonic_bias` cell-specific tonic bias can now be provided using the argument
+  amplitude in {func}`network.add_tonic_bias`, by [Camilo Diaz][] in {gh}`766`
 
 - {func}`~plot_lfp`, {func}`~plot_dipole`, {func}`~plot_spikes_hist`,
   and {func}`~plot_spikes_raster` now plotted from 0 to tstop. Inputs tmin and tmax are deprecated,
@@ -118,21 +61,88 @@ orphan: true
 - Add {class}`~hnn_core.BatchSimulate` for batch simulation capability,
   by [Abdul Samad Siddiqui][] in {gh}`782`.
 
-- Updated `plot_spikes_raster` logic to include all neurons in network model.
-  Removed GUI exclusion from build, by [Abdul Samad Siddiqui][]  in {gh}`754`.
+- Added features to {func}`~plot_csd`: to set color of sinks and sources, range of the colormap,
+  and interpolation method to smoothen CSD plot, by [Katharina Duecker][] in {gh}`815`
+
+- Add argument to change colors of `plot_spikes_raster`, shortened line lengths
+  to prevent overlap, and added an argument for custom cell types, by
+  [George Dang][] in {gh}`895`
+
+- Add method to {class}`~hnn_core.Network` to modify synaptic gains, by
+  [Nick Tolley][]  and [George Dang][] in {gh}`897`
+
+- Add {func}`~hnn_core.CellResponse.spike_times_by_type` to get cell spiking times
+  organized by cell type, by [Mainak Jas][] in {gh}`916`.
+
+- Add option to apply a tonic bias to any compartment of the cell, and option to
+  add multiple biases per simulation and cell {func}`hnn_core.network.add_tonic_bias`,
+  by [Katharina Duecker][] in {gh}`922`.
+
+- Add plots to show relative and absolute external drive strength,
+  by [Dikshant Jha][] in {gh}`987`.
+
+### Bug fixes
+
+- Fix inconsistent connection mapping from drive gids to cell gids, by
+  [Ryan Thorpe][] in {gh}`642`.
+
+- Objective function called by {func}`~hnn_core.optimization.optimize_evoked`
+  now returns a scalar instead of tuple, by [Ryan Thorpe][] in {gh}`670`.
+
+- Fix GUI plotting bug due to deprecation of matplotlib color cycling method,
+  by [George Dang][] in {gh}`695`.
+
+- Fix bug in {func}`~hnn_core.network.pick_connection` where connections are
+  returned for cases when there should be no valid matches, by [George Dang][]
+  in {gh}`739`
+
+- Fixed GUI figure annotation overlap in multiple sub-plots,
+  by [Camilo Diaz][] in {gh}`741`
+
+- Fix loading of drives in the GUI: drives are now overwritten instead of updated,
+  by [Mainak Jas][] in {gh}`795`.
+
+- Use `np.isin()` in place of `np.in1d()` to address numpy deprecation,
+  by [Nick Tolley][] in {gh}`799`.
+
+- Fix drive seeding so that event times are unique across multiple trials,
+  by [Nick Tolley][] in {gh}`810`.
+
+- Fix bug in {func}`~hnn_core.network.clear_drives` where network object are not
+  accurately updated, by [Nick Tolley][] in {gh}`812`.
+
+- Fix bug in {func}`~hnn_core.Network.add_poisson_drive` where an error is
+  thrown when passing a float for rate_constant when ``cell_specific=False``,
+  by [Dylan Daniels][] in {gh}`814`
+
+- Fix bug in {func}`~hnn_core.Network.add_poisson_drive` where an error is
+  thrown when passing an int for rate_constant when ``cell_specific=True``,
+  by [Dylan Daniels][] in {gh}`818`
+
+- Fix GUI over-plotting of loaded data where the app stalled and did not plot
+  RMSE, by [George Dang][] in {gh}`869`
+
+- Fix scaling and smoothing of loaded data dipoles to the GUI, by [George Dang][]
+  in {gh}`892`
+
+### GUI changes
+
+- Update GUI to use ipywidgets v8.0.0+ API, by [George Dang][] in
+  {gh}`696`.
+
+- Added pre defined plot sets for simulated data in GUI, by [Camilo Diaz][] in {gh}`746`
+
+- Added GUI widget to enable/disable synchronous input in simulations,
+  by [Camilo Diaz][] in {gh}`750`
+
+- Added GUI widgets to save simulation as csv and updated the file upload to support csv data,
+  by [Camilo Diaz][] in {gh}`753`
+
+- Added GUI feature to include Tonic input drives in simulations,
+  by [Camilo Diaz][] {gh}`773`
 
 - Added GUI feature to read and modify cell parameters,
   by [Camilo Diaz][]  in {gh}`806`.
-
-- Add ability to optimize parameters associated with rhythmic drives,
-  by [Carolina Fernandez Pujol][] in {gh}`673`.
-
-- Added features to {func}`~plot_csd`: to set color of sinks and sources, range of the colormap,
-  and interpolation method to smoothen CSD plot,
-  by [Katharina Duecker][] in {gh}`815`
-
-- Cleaned up internal logic in {class}`~hnn_core.CellResponse`,
-  by [Nick Tolley][] in {gh}`647`.
 
 - Changed the configuration/parameter file format support of the GUI. Loading
   of connectivity and drives use a new multi-level json structure that mirrors
@@ -145,48 +155,27 @@ orphan: true
 - Added "No. Drive Cells" input widget to the GUI and changed the "Synchronous
   Input" checkbox to "Cell-Specific" to align with the API [George Dang][] in {gh}`861`
 
-### Bug
+- Add button to delete a single drive on GUI drive windows, by
+  [George Dang][] in {gh}`890`
 
-- Fix inconsistent connection mapping from drive gids to cell gids, by
-  [Ryan Thorpe][] in {gh}`642`.
+- Add minimum spectral frequency widget to GUI for adjusting spectrogram
+  frequency axis, by [George Dang][] in {gh}`894`
 
-- Objective function called by {func}`~hnn_core.optimization.optimize_evoked`
-  now returns a scalar instead of tuple, by [Ryan Thorpe][] in {gh}`670`.
+- Update GUI to display "L2/3", by [Austin Soplata][] in {gh}`904`
 
-- Fix GUI plotting bug due to deprecation of matplotlib color cycling method,
-  by [George Dang][] in {gh}`695`.
+### Other changes
 
-- Fix loading of drives in the GUI: drives are now overwritten instead of updated,
-  by [Mainak Jas][] in {gh}`795`.
+- Cleaned up internal logic in {class}`~hnn_core.CellResponse`,
+  by [Nick Tolley][] in {gh}`647`.
 
-- Use `np.isin()` in place of `np.in1d()` to address numpy deprecation,
-  by [Nick Tolley][] in {gh}`799.
+- Update minimum supported version of Python to 3.8, by [Ryan Thorpe][] in
+  {gh}`678`.
 
-- Fix drive seeding so that event times are unique across multiple trials,
-  by [Nick Tolley][] in {gh}`810`.
+- Add dependency groups to setup.py and update CI workflows to reference
+  dependency groups, by [George Dang][] in {gh}`703`.
 
-- Fix bug in {func}`~hnn_core.network.clear_drives` where network object are not
-  accurately updated, by [Nick Tolley][] in {gh}`812`.
-
-### API
-
-- {func}`~hnn_core.CellResponse.write` and {func}`~hnn_core.Cell_response.read_spikes`
-  now support hdf5 format for read/write Cell response object, by
-  [Rajat Partani][] in {gh}`644`
-
-- Connection `'src_gids'` and `'target_gids'` are now stored as set objects
-  instead of lists, by [Ryan Thorpe][] in {gh}`642`.
-
-- {func}`~hnn_core.Dipole.write` and {func}`~hnn_core.Dipole.read_dipoles`
-  now support hdf5 format for read/write Dipole object, by
-  [Rajat Partani][] in {gh}`648`
-
-- Add ability to optimize parameters associated with evoked drives and plot
-  convergence. User can constrain parameter ranges and specify solver,
-  by [Carolina Fernandez Pujol][] in {gh}`652`
-
-- {func}`network.add_tonic_bias` cell-specific tonic bias can now be provided using the argument
-  amplitude in {func}`network.add_tonic_bias`, by [Camilo Diaz][] in {gh}`766`
+- Added check for invalid Axes object in {func}`~hnn_core.viz.plot_cells`
+  function, by [Abdul Samad Siddiqui][] in {gh}`744`.
 
 ### People who contributed to this release (in alphabetical order):
 

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -198,7 +198,7 @@ orphan: true
 - Fix statistical Poisson drive tests that were failing stochastically by [Austin
   E. Soplata][] in {gh}`978`
 
-- Fix typo of "leading" in docstring, by [Dan "pynmash"][] in {gh}`979`
+- Fix typo of "leading" in docstring, by [Dan Toms][] in {gh}`979`
 
 - Copy template for monthly metrics workflow, in the hope it will fix the unsuccessful
   runs by [Austin E. Soplata][] in {gh}`983`
@@ -380,7 +380,7 @@ orphan: true
 - [Shehroz Kashif][]
 - [Rajat Partani][]
 - [Carolina Fernandez Pujol][]
-- [Dan "pynmash"][]
+- [Dan Toms][]
 - [Abdul Samad Siddiqui][]
 - [Austin E. Soplata][]
 - [Ryan Thorpe][]
@@ -805,5 +805,5 @@ orphan: true
 [Carolina Fernandez Pujol]: https://github.com/carolinafernandezp
 [Austin E. Soplata]: https://github.com/asoplata
 [Dikshant Jha]: https://github.com/dikshant182004
-[Dan "pynmash"]: https://github.com/pynmash
+[Dan Toms]: https://github.com/pynmash
 [Shehroz Kashif]: https://github.com/Shehrozkashif

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -5,7 +5,7 @@ orphan: true
 (whats_new)=
 # What's new?
 
-## Current (v0.4 release candidates)
+## Current (v0.4 release candidate) Changelog
 
 ### API changes
 
@@ -17,7 +17,7 @@ orphan: true
 
 - {func}`~hnn_core.CellResponse.write` and {func}`~hnn_core.Cell_response.read_spikes`
   now support hdf5 format for read/write Cell response object, by [Rajat Partani][] in
-  {gh}`644`
+  {gh}`644` (Note: this work was later reverted in {gh}`654`)
 
 - Add ability to customize plot colors for each cell section in
   {func}`~hnn_core.Cell.plot_morphology`, by [Nick Tolley][] in {gh}`646`
@@ -32,8 +32,14 @@ orphan: true
   convergence. User can constrain parameter ranges and specify solver, by [Carolina
   Fernandez Pujol][] in {gh}`652`
 
+- {func}`~hnn_core.CellResponse` no longer supports reading and writing to hdf5, by
+  [Rajat Partani][] and [Nick Tolley][], in {gh}`654`
+
 - Add ability to optimize parameters associated with rhythmic drives, by [Carolina
   Fernandez Pujol][] in {gh}`673`
+
+- Add initial support for {class}`~hnn_core.Network` read and write of hdf5 files by
+  [George Dang][] in {gh}`704` (Note: this work was later obviated by {gh}`756`)
 
 - Add ability to specify number of cells in {class}`~hnn_core.Network`, by [Nick
   Tolley][] in {gh}`705`
@@ -44,8 +50,8 @@ orphan: true
 - Updated `plot_spikes_raster` logic to include all neurons in network model.  Removed
   GUI exclusion from build, by [Abdul Samad Siddiqui][] in {gh}`754`
 
-- Added feature to read/write {class}`~hnn_core.Network` configurations to json, by
-  [George Dang][] and [Rajat Partani][] in {gh}`757`
+- Add initial work on hierarchical json format in place of hdf5, by [George Dang][] in
+  {gh}`763`
 
 - {func}`network.add_tonic_bias` cell-specific tonic bias can now be provided using the
   argument amplitude in {func}`network.add_tonic_bias`, by [Camilo Diaz][] in {gh}`766`
@@ -60,9 +66,17 @@ orphan: true
 - Add {class}`~hnn_core.BatchSimulate` for batch simulation capability, by [Abdul Samad
   Siddiqui][] in {gh}`782`
 
+- Recorded calcium conncetration from the soma, as well as all sections, are enabled by
+  setting `record_ca` to `soma` or `all` in {func}`~hnn_core.simulate_dipole`.
+  Recordings are accessed through {class}`~hnn_core.CellResponse.ca`, by [Katharina
+  Duecker][] in {gh}`804`
+
 - Added features to {func}`~plot_csd`: to set color of sinks and sources, range of the
   colormap, and interpolation method to smoothen CSD plot, by [Katharina Duecker][] in
   {gh}`815`
+
+- Refactor and improve documentation for {class}`~hnn_core.BatchSimulate`, by [Abdul
+  Samad Siddiqui][] in {gh}`830` and {gh}`857`
 
 - Add argument to change colors of `plot_spikes_raster`, shortened line lengths to
   prevent overlap, and added an argument for custom cell types, by [George Dang][] in
@@ -81,28 +95,53 @@ orphan: true
 - Add plots to show relative and absolute external drive strength, by [Dikshant Jha][]
   in {gh}`987`
 
-### Bug fixes
-
-- Fix inconsistent connection mapping from drive gids to cell gids, by [Ryan Thorpe][]
-  in {gh}`642`
+### Bug fixes and corrections
 
 - Objective function called by {func}`~hnn_core.optimization.optimize_evoked` now
   returns a scalar instead of tuple, by [Ryan Thorpe][] in {gh}`670`
 
+- Fix error message for drive addition, by [Tianqi Cheng][] in {gh}`681`
+
 - Fix GUI plotting bug due to deprecation of matplotlib color cycling method, by [George
   Dang][] in {gh}`695`
+
+- Typo fix, by [George Dang][] in {gh}`707`
+
+- Fix GUI dipole plot scale and smooth factors, by [Camilo Diaz][] in {gh}`730`
+
+- Fix file upload widget, by [Camilo Diaz][] in {gh}`736`
 
 - Fix bug in {func}`~hnn_core.network.pick_connection` where connections are returned
   for cases when there should be no valid matches, by [George Dang][] in {gh}`739`
 
-- Fixed GUI figure annotation overlap in multiple sub-plots, by [Camilo Diaz][] in
+- Fix GUI figure annotation overlap in multiple sub-plots, by [Camilo Diaz][] in
   {gh}`741`
+
+- Various CI updates and fixes, by [George Dang][] in {gh}`758`
+
+- Fix GUI load data button size, by [Camilo Diaz][] in {gh}`775`
+
+- Fix typos, by [George Dang][] in {gh}`777`
+
+- Fix CI Linux conda bug, by [Camilo Diaz][] in {gh}`794`
 
 - Fix loading of drives in the GUI: drives are now overwritten instead of updated, by
   [Mainak Jas][] in {gh}`795`
 
 - Use `np.isin()` in place of `np.in1d()` to address numpy deprecation, by [Nick
   Tolley][] in {gh}`799`
+
+- Fix unit tests for Python 3.11 and 3.12, by [Camilo Diaz][] in {gh}`800`
+
+- Fix README badge URL, by [Camilo Diaz][] in {gh}`802`
+
+- Fix NEURON download link, by [Camilo Diaz][] in {gh}`803`
+
+- Fix clearance of drive connections by network config read, by [George Dang][] in
+  {gh}`807`
+
+- Fixes for Binder notebook usage, by [Mainak Jas][] in {gh}`809`, {gh}`820`, and
+  {gh}`822`
 
 - Fix drive seeding so that event times are unique across multiple trials, by [Nick
   Tolley][] in {gh}`810`
@@ -118,78 +157,234 @@ orphan: true
   passing an int for rate_constant when ``cell_specific=True``, by [Dylan Daniels][] in
   {gh}`818`
 
+- Fix homepage links, by [Dylan Daniels][] in {gh}`819`
+
+- Fix GUI simulations dropdown, by [Camilo Diaz][] in {gh}`825` and {gh}`827`
+
+- Fix argument pass during conversion of network config file to
+  {class}`~hnn_core.Network`, by [George Dang][] in {gh}`834`
+
+- Fix GUI visualization, by [Camilo Diaz][] in {gh}`836`
+
+- Fix GUI probability assignment, by [George Dang][] in {gh}`844`
+
+- Fix GUI unnecessary display call, by [George Dang][] in {gh}`845`
+
+- Fix GUI drive sorting, by [George Dang][] in {gh}`851`
+
+- Fix persistent linkcheck failure, by [George Dang][] in {gh}`854`
+
+- Fix GUI MPI test, by [George Dang][] in {gh}`868`
+
 - Fix GUI over-plotting of loaded data where the app stalled and did not plot RMSE, by
   [George Dang][] in {gh}`869`
+
+- Fix GUI MPI cores, by [George Dang][] in {gh}`871`
+
+- Fix GUI output log, by [George Dang][] in {gh}`873`
+
+- Fix MPIBackend platform logic, by [George Dang][] in {gh}`876`
 
 - Fix scaling and smoothing of loaded data dipoles to the GUI, by [George Dang][] in
   {gh}`892`
 
+- Fix minor GUI glitches, by [George Dang][] in {gh}`899`
+
+- Fix GUI synapses properties rendering, by [George Dang][] in {gh}`913`
+
+- Fix accidental removal of second axis object in GUI by [Austin E. Soplata][] in
+  {gh}`929`
+
+- Fix statistical Poisson drive tests that were failing stochastically by [Austin
+  E. Soplata][] in {gh}`978`
+
+- Fix typo of "leading" in docstring, by [Dan "pynmash"][] in {gh}`979`
+
+- Copy template for monthly metrics workflow, in the hope it will fix the unsuccessful
+  runs by [Austin E. Soplata][] in {gh}`983`
+
+- Hotfix of MPI install on MacOS CI runners by [Austin E. Soplata][] in {gh}`994`
+
 ### GUI changes
+
+- Add RMSE calculation and plotting to GUI, by [Huzi Cheng][] in {gh}`636`
 
 - Update GUI to use ipywidgets v8.0.0+ API, by [George Dang][] in {gh}`696`
 
-- Added pre defined plot sets for simulated data in GUI, by [Camilo Diaz][] in {gh}`746`
+- Add GUI visualization testing, by [Abdul Samad Siddiqui][] in {gh}`726`
 
-- Added GUI widget to enable/disable synchronous input in simulations, by [Camilo
-  Diaz][] in {gh}`750`
+- Add pre defined plot sets for simulated data in GUI, by [Camilo Diaz][] in {gh}`746`
 
-- Added GUI widgets to save simulation as csv and updated the file upload to support csv
+- Add GUI widget to enable/disable synchronous input in simulations, by [Camilo Diaz][]
+  in {gh}`750`
+
+- Add GUI widgets to save simulation as csv and updated the file upload to support csv
   data, by [Camilo Diaz][] in {gh}`753`
 
-- Added GUI feature to include Tonic input drives in simulations, by [Camilo Diaz][]
+- Refactor GUI tests, by [George Dang][] in {gh}`765`
+
+- Refactor GUI import of `_read_dipole_text` function, by [George Dang][] in {gh}`771`
+
+- Add GUI feature to include Tonic input drives in simulations, by [Camilo Diaz][]
   {gh}`773`
 
-- Added GUI feature to read and modify cell parameters, by [Camilo Diaz][] in {gh}`806`
+- Add GUI feature to read and modify cell parameters, by [Camilo Diaz][] in {gh}`806`
 
-- Changed the configuration/parameter file format support of the GUI. Loading of
+- Refactor GUI `read_network_configuration`, by [George Dang][] in {gh}`833`
+
+- Change the configuration/parameter file format support of the GUI. Loading of
   connectivity and drives use a new multi-level json structure that mirrors the
   structure of the Network object. Flat parameter and json configuration files are no
   longer supported by the GUI, by [George Dang][] in {gh}`837`
 
+- GUI load confirmation message, by [George Dang][] in {gh}`846`
+
+- Differentiate L5/L2 Pyr geomtetry options in GUI, by [Nick Tolley][] in {gh}`848`
+
 - Updated the GUI load drive widget to be able to load tonic biases from a network
   configuration file. [George Dang][] in {gh}`852`
+
+- Update GUI initialization of network, by [George Dang][] in {gh}`853`
+
+- Update GUI color, by [Nick Tolley][] in {gh}`855`
 
 - Added "No. Drive Cells" input widget to the GUI and changed the "Synchronous Input"
   checkbox to "Cell-Specific" to align with the API [George Dang][] in {gh}`861`
 
+- Add GUI export of configurations, [George Dang][] in {gh}`862`
+
+- Add screenshot of GUI to README, [George Dang][] in {gh}`865` and {gh}`866`
+
 - Add button to delete a single drive on GUI drive windows, by [George Dang][] in
   {gh}`890`
+
+- Add post-processing for GUI figures, by [George Dang][] in {gh}`893`
 
 - Add minimum spectral frequency widget to GUI for adjusting spectrogram frequency axis,
   by [George Dang][] in {gh}`894`
 
-- Update GUI to display "L2/3", by [Austin Soplata][] in {gh}`904`
+- Update GUI to display "L2/3", by [Austin E. Soplata][] in {gh}`904`
+
+- Update PSD plot in GUI to use plot config provided frequencies instead of hard-coded
+  values, by [Dylan Daniels][] in {gh}`914`
+
+- Flip drives in input histogram based on position in GUI by [Dylan Daniels][] in
+  {gh}`923`
+
+- Add GUI widget to adjust default smoothing value, by [Dylan Daniels][] in {gh}`924`
+
+- Change Morlet cycles divisor for better alpha spectral plotting by [Austin
+  E. Soplata][] in {gh}`928`
+
+- Add GUI log error message if spectral arguments are invalid by [Austin E. Soplata][]
+  in {gh}`944`
+
+- Move GUI log messages to bottom of output by [George Dang][] in {gh}`946`
+
+- Add GUI frequency default visualization parameters and many other smaller visual
+  changes by [Dylan Daniels][] in {gh}`952`
+
+- Capture printed messages to logger in GUI by [Dylan Daniels][] in {gh}`956`
 
 ### Other changes
+
+- Add Github Discussions installation template, by [Mainak Jas][] in {gh}`630`
+
+- Replace NEURON functions like `define_shape()` and `distance()` with Python
+  equivalent, by [Rajat Partani][] in {gh}`661`
 
 - Cleaned up internal logic in {class}`~hnn_core.CellResponse`, by [Nick Tolley][] in
   {gh}`647`
 
+- Add section for JOSS to Readme, by [Ryan Thorpe][] in {gh}`677`
+
 - Update minimum supported version of Python to 3.8, by [Ryan Thorpe][] in {gh}`678`
+
+- Add support for `codespell` checking, by [Yaroslav Halchenko][] in {gh}`692`
+
+- Add citation info to repository, by [Ryan Thorpe][] in {gh}`700`
 
 - Add dependency groups to setup.py and update CI workflows to reference dependency
   groups, by [George Dang][] in {gh}`703`
 
-- Added check for invalid Axes object in {func}`~hnn_core.viz.plot_cells` function, by
+- Rename io to hnn_io, by [George Dang][] in {gh}`727`
+
+- Expand gitignore to virtual environment directories, by [Abdul Samad Siddiqui][] in
+  {gh}`740`
+
+- Add check for invalid Axes object in {func}`~hnn_core.viz.plot_cells` function, by
   [Abdul Samad Siddiqui][] in {gh}`744`
 
-### People who contributed to this release (in alphabetical order):
+- Refactor pick connection tests, by [George Dang][] in {gh}`745`
+
+- Add governance structure and similar changes, by [Dylan Daniels][] in {gh}`785`
+
+- Add issue metrics Github Action {gh}`790` and associated cron job {gh}`793`, by [Nick
+  Tolley][]
+
+- Remove nbsphinx and pandoc usage, by [Nick Tolley][] in {gh}`813`
+
+- Remove nulled drives during convert to hierarchical json function, by [George Dang][]
+  in {gh}`821`
+
+- Speedup optimization tests, by [Nick Tolley][] in {gh}`839`
+
+- Add GSoC 2024 acknowledgement, by [Abdul Samad Siddiqui][] in {gh}`874`
+
+- Remove deprecated `distutils` import, by [George Dang][] in {gh}`880`
+
+- Refactor {class}`~hnn_core.Network`'s `__eq__` equivalency function, by [George
+  Dang][] in {gh}`902`
+
+- Add automatic spectrogram frequency range reversal, by [Abdul Samad Siddiqui][] in
+  {gh}`903`
+
+- Flip drives in input histogram based on position, by [Dylan Daniels][] in {gh}`905`
+
+- Change default smoothing for dipoles to be 0 (only in GUI), by [George Dang][] in
+  {gh}`920`
+
+- Add support for parallelizing tests by [Austin E. Soplata][] in {gh}`932`
+
+- Replace `flake8` linting with `ruff check` linting by [Austin E. Soplata][] in
+  {gh}`961`
+
+- Add `Makefile` cleanup of arm64-generated files by [Austin E. Soplata][] in {gh}`964`
+
+- Change Sphinx theme, fixing javascript bugs with code-website, and fix some small
+  typos by [Austin E. Soplata][] in {gh}`971`
+
+- Replace most ReStructured Text of code-website with Markdown by [Austin E. Soplata][]
+  in {gh}`973`
+
+- Add install and run of `codespell` to local testing by [Austin E. Soplata][] in
+  {gh}`977`
+
+- Update Sphinx `versions.json` link to point to `dev` version, by [Austin E. Soplata][]
+  in {gh}`991`
+
+- Add docstring to `_add_cell_type_bias` by [Shehroz Kashif][] in {gh}`1001`
+
+### People who contributed to this release (in alphabetical order of family name):
 
 - [Huzi Cheng][]
 - [Tianqi Cheng][]
-- [Dylan Daniels][]
 - [George Dang][]
+- [Dylan Daniels][]
 - [Camilo Diaz][]
 - [Katharina Duecker][]
-- [Carolina Fernandez Pujol][]
 - [Yaroslav Halchenko][]
 - [Mainak Jas][]
-- [Nick Tolley][]
-- [Orsolya Beatrix Kolozsvari][]
-- [Rajat Partani][]
-- [Abdul Samad Siddiqui][]
-- [Ryan Thorpe][]
+- [Dikshant Jha][]
 - [Stephanie R. Jones][]
+- [Shehroz Kashif][]
+- [Rajat Partani][]
+- [Carolina Fernandez Pujol][]
+- [Dan "pynmash"][]
+- [Abdul Samad Siddiqui][]
+- [Austin E. Soplata][]
+- [Ryan Thorpe][]
+- [Nick Tolley][]
 
 ## 0.3
 
@@ -289,10 +484,6 @@ orphan: true
 
 - legacy_mode is now set to False by default in all for all {class}`~hnn_core.Network` objects, by
   [Nick Tolley][] and [Ryan Thorpe][] in {gh}`619`.
-
-- Recorded calcium conncetration from the soma, as well as all sections, are enabled by setting
-  `record_ca` to `soma` or `all` in {func}`~hnn_core.simulate_dipole`.  Recordings are accessed
-  through {class}`~hnn_core.CellResponse.ca`, by [Katharina Duecker][] in {gh}`804`
 
 ### People who contributed to this release (in alphabetical order):
 
@@ -612,5 +803,7 @@ orphan: true
 [Yaroslav Halchenko]:  https://github.com/yarikoptic
 [Tianqi Cheng]: https://github.com/tianqi-cheng
 [Carolina Fernandez Pujol]: https://github.com/carolinafernandezp
-[Austin Soplata]: https://github.com/asoplata
+[Austin E. Soplata]: https://github.com/asoplata
 [Dikshant Jha]: https://github.com/dikshant182004
+[Dan "pynmash"]: https://github.com/pynmash
+[Shehroz Kashif]: https://github.com/Shehrozkashif


### PR DESCRIPTION
This significantly adds to the `doc/whats_new.md` page with mention of both PRs and contributors that were not added at the time their work was merged. There were many missing contributions that should now be present in our changelog. I believe I've added all outstanding PRs that were merged into `master` (as opposed to the HDF5 changes in `upstream`'s `network-rw` branch, etc.).

I also re-organized them into a couple of categories (API, GUI, Bug, other).

Since this is only additions to contribution-documentation, this should be an easy merge.

Note that this is NOT the final version of the release notes for v0.4. I will write up some actual summary content similar to https://numpy.org/doc/stable/release/2.2.0-notes.html when we get closer to the v0.4 release very soon.