### PR TITLE
[WIP] Fix: Potentially fix new MPI test failures

### DIFF
--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -306,6 +306,11 @@ class TestParallelBackends():
 
         # Case 1 (default): Check that hwthreading turns on if needed
         override_hwthreading_option = None
+
+        # Possibly needed to prevent MPIBackend failures to exit processes
+        del net
+        net = jones_2009_model(params, add_drives_from_params=True,
+                               mesh_shape=(3, 3))
         with MPIBackend(
                 n_procs=n_procs,
                 use_hwthreading_if_found=use_hwthreading_if_found,
@@ -332,6 +337,11 @@ class TestParallelBackends():
 
         # Case 3: Check that hwthreading turns off if forced off.
         override_hwthreading_option = False
+
+        # Possibly needed to prevent MPIBackend failures to exit processes
+        del net
+        net = jones_2009_model(params, add_drives_from_params=True,
+                               mesh_shape=(3, 3))
         with MPIBackend(
                 n_procs=n_procs,
                 use_hwthreading_if_found=use_hwthreading_if_found,


### PR DESCRIPTION

If you made any PRs to `hnn-core` recently, you may have noticed frequent, *but random/stochastic* failures in the unit tests. Failed workflows can be found here: https://github.com/jonescompneurolab/hnn-core/actions?query=is%3Afailure . The failures are stochastic, meaning they occur randomly and unpredictably, but usually, simply re-running any failed tests once or twice enables the unit tests to pass. In every single case I have inspected, these tests tend to fail in the MacOS MPI test cases specifically, in the function you can invoke via 

```
pytest ./hnn_core/tests/test_parallel_backends.py::TestParallelBackends::test_run_mpibackend_hwthreading
```
These failures always occur with an error like the following: `RuntimeError: MPI simulation failed. Return code: 143` where the return code is 143 or -11.

## The short version is:

This current PR makes tiny changes to that test function that appear to successfully "evade" the issue causing these test failures, which are occurring in the new test code pushed by the MPI handling PR https://github.com/jonescompneurolab/hnn-core/pull/871 . I'll be totally honest that I don't completely understand *why* this solves the test failures, but these trivial changes certainly do not introduce any new bugs, and **I think should be merged now**. Full root-cause investigation can happen later (e.g. after the April workshop). We could also revert #871, BUT if this PR is effective in preventing the random test failures, then that is very helpful data towards understanding what the actual cause is (which is unknown).

## Longer version:

I will eventually make an Issue once I have more time and have investigated more thoroughly, but I've already done a bit of investigation and have further to go. My current (weakly-held) hypothesis is that there is a hard-to-find bug that is occurring with how we kill existing MPI child processes in `parallel_backends.py`. Part of the evidence for this is that every test failure, in addition to showing the `RuntimeError` discussed above, is also accompanied by the following warning, which indicates that this block of code is executing: https://github.com/jonescompneurolab/hnn-core/blob/master/hnn_core/parallel_backends.py#L196-L201

```
   /Users/runner/work/hnn-core/hnn-core/hnn_core/parallel_backends.py:198: UserWarning: Timeout exceeded while waiting for child process output. Terminating...
    warn("Timeout exceeded while waiting for child process output"
```

Another small piece of evidence for this hypothesis is that separating the run Networks into different copies (what this PR does), rather than re-simulating the same Network, *seems* to make the test failures much less likely. I don't know why this would be, however, and I don't know the reliability (this PR has solved the issue in every test run I've done).

Something very helpful is that these test failures *do* appear to be reproducible on my personal MacOS laptop with an Apple Silicon chip, although they are still stochastic. I believe I can reproduce the failures by going into here https://github.com/jonescompneurolab/hnn-core/blob/master/hnn_core/tests/test_parallel_backends.py#L310-L343 and changing the used `n_procs` to actually use the number of cores detected by the machine. However, like I said before, the tests still fail randomly, but appear to fail independent of whichever pytest parametrization is used.

Currently, the most likely possible causes I can think of include, roughly in order of estimated probability:

1. The actual hardware-threading- and oversubscription-option changes I added to this recently merged PR: #871 (possibly a new, unknown bug I introduced),
2. An existing MPI child process kill bug that had not surfaced before due to the fact that #871 introduced more tests of more variations of MPIBackends / MPI commands,
3. (unlikely) Some change related to MPI exiting, due to our recent forced version-floor of MPI in test runners: #994 ,
4. (unlikely) Some unforeseen interaction between the amount of MPI processes spawned and the larger use of parametrization via `pytest`,
5. ???
