### PR TITLE
doc: add warning about py3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ on Mac or Linux, simply do:
 
     $ pip install hnn_core
 
+Note that `hnn-core` currently only supports Python 3.8, 3.9, 3.10, 3.11, and 3.12, but *not* 3.13.
+
 If you want to track the latest developments of `hnn-core`, you can
 install the current version of the code (nightly) with:
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -17,6 +17,8 @@ Distribution](https://www.anaconda.com/download/success). If you
 are new to Python or data science in Python, we recommend you review the
 resources here: <https://docs.anaconda.com/getting-started/>.
 
+Note that `hnn-core` currently only supports Python 3.8, 3.9, 3.10, 3.11, and 3.12, but *not* 3.13.
+
 --------------
 
 # Step 2. Platform-specific requirements


### PR DESCRIPTION
Trivial PR: add a warning about not using Python 3.13 with `hnn-core`. Related to #947 .