### PR TITLE
[MRG]: Update and include `BatchSimulate` documentation

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -25,8 +25,7 @@ jobs:
         shell: bash -el {0}
         run: |
           python -m pip install --upgrade pip
-          pip install numpy matplotlib scipy NEURON
-          pip install '.[gui, docs]'
+          pip install '.[docs, gui, parallel]'
 
       - name: Linkcheck
         shell: bash -el {0}

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -24,6 +24,7 @@ Simulation (:py:mod:`hnn_core`):
    Cell
    CellResponse
    pick_connection
+   BatchSimulate
 
 Network Models (:py:mod:`hnn_core`):
 ------------------------------------

--- a/examples/howto/plot_batch_simulate.py
+++ b/examples/howto/plot_batch_simulate.py
@@ -20,7 +20,8 @@ for comprehensive analysis.
 
 import matplotlib.pyplot as plt
 import numpy as np
-from hnn_core.batch_simulate import BatchSimulate
+
+from hnn_core import BatchSimulate
 from hnn_core import jones_2009_model
 
 # The number of cores may need modifying depending on your current machine.

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -6,5 +6,6 @@ from .cell import Cell
 from .cell_response import CellResponse, read_spikes
 from .cells_default import pyramidal, basket
 from .parallel_backends import MPIBackend, JoblibBackend
+from .batch_simulate import BatchSimulate
 
 __version__ = '0.4rc4'

--- a/hnn_core/batch_simulate.py
+++ b/hnn_core/batch_simulate.py
@@ -16,102 +16,120 @@ from .network_models import jones_2009_model
 
 
 class BatchSimulate(object):
-    def __init__(self, set_params, net=jones_2009_model(),
-                 tstop=170, dt=0.025, n_trials=1,
-                 save_folder='./sim_results', batch_size=100,
-                 overwrite=True, save_outputs=False, save_dpl=True,
-                 save_spiking=False, save_lfp=False, save_voltages=False,
-                 save_currents=False, save_calcium=False, record_vsec=False,
-                 record_isec=False, postproc=False, clear_cache=False,
-                 summary_func=None):
-        """Initialize the BatchSimulate class.
+    """The BatchSimulate class.
 
-        Parameters
-        ----------
-        set_params : func
-            User-defined function that sets parameters in network drives.
+    Parameters
+    ----------
+    set_params : func
+        User-defined function that sets parameters in network drives.
 
-                ``set_params(net, params) -> None``
+            ``set_params(net, params) -> None``
 
-            where ``net`` is a Network object and ``params`` is a dictionary
-            of the parameters that will be set inside the function.
-        net : Network object, optional
-            The network model to use for simulations. Examples include:
-            - `jones_2009_model`: A network model based on Jones et al. (2009).
-            - `law_2021_model`: A network model based on Law et al. (2021).
-            - `calcium_model`: A network model incorporating calcium dynamics.
-            Default is `jones_2009_model()`
-        tstop : float, optional
-            The stop time for the simulation. Default is 170 ms.
-        dt : float, optional
-            The time step for the simulation. Default is 0.025 ms.
-        n_trials : int, optional
-            The number of trials for the simulation. Default is 1.
-        save_folder : str, optional
-            The path to save the simulation outputs.
-            Default is './sim_results'.
-        batch_size : int, optional
-            The maximum number of simulations saved in a single file.
-            Default is 100.
-        overwrite : bool, optional
-            Whether to overwrite existing files and create file paths
-            if they do not exist. Default is True.
-        save_outputs : bool, optional
-            Whether to save the simulation outputs to files. Default is False.
-        save_dpl : bool
-            If True, save dipole results. Note, `save_outputs` must be True.
-            Default: True.
-        save_spiking : bool
-            If True, save spiking results. Note, `save_outputs` must be True.
-            Default: False.
-        save_lfp : bool
-            If True, save local field potential (lfp) results.
-            Note, `save_outputs` must be True.
-            Default: False.
-        save_voltages : bool
-            If True, save voltages results. Note, `save_outputs` must be True.
-            Default: False.
-        save_currents : bool
-            If True, save currents results. Note, `save_outputs` must be True.
-            Default: False.
-        save_calcium : bool
-            If True, save calcium concentrations.
-            Note, `save_outputs` must be True.
-            Default: False.
-        record_vsec : 'all' | 'soma' | False
-            Option to record voltages from all sections ('all'), or just
-            the soma ('soma'). Default: False.
-        record_isec : 'all' | 'soma' | False
-            Option to record voltages from all sections ('all'), or just
-            the soma ('soma'). Default: False.
-        postproc : bool
-            If True, smoothing (``dipole_smooth_win``) and scaling
-            (``dipole_scalefctr``) values are read from the parameter file, and
-            applied to the dipole objects before returning.
-            Default: False.
-        clear_cache : bool, optional
-            Whether to clear the results cache after saving each batch.
-            Default is False.
-        summary_func : callable, optional
-            A function to calculate summary statistics from the simulation
-            results. Default is None.
-        Notes
-        -----
-        When `save_output=True`, the saved files will appear as
-        `sim_run_{start_idx}-{end_idx}.npz` in the specified `save_folder`
-        directory. The `start_idx` and `end_idx` indicate the range of
-        simulation indices contained in each file. Each file will contain
-        a maximum of `batch_size` simulations, split evenly among the
-        available files. If `overwrite=True`, existing files with the same name
-        will be overwritten.
-        """
+        where ``net`` is a Network object and ``params`` is a dictionary
+        of the parameters that will be set inside the function.
+    net : Network object, optional
+        The network model to use for simulations. Examples include the
+        returned value of the following functions:
+
+        - `jones_2009_model`: A network model based on Jones et al. (2009).
+        - `law_2021_model`: A network model based on Law et al. (2021).
+        - `calcium_model`: A network model incorporating calcium dynamics.
+
+        Default is ``jones_2009_model()``.
+    tstop : float, optional
+        The stop time for the simulation. Default is 170 ms.
+    dt : float, optional
+        The time step for the simulation. Default is 0.025 ms.
+    n_trials : int, optional
+        The number of trials for the simulation. Default is 1.
+    save_folder : str, optional
+        The path to save the simulation outputs.
+        Default is './sim_results'.
+    batch_size : int, optional
+        The maximum number of simulations saved in a single file.
+        Default is 100.
+    overwrite : bool, optional
+        Whether to overwrite existing files and create file paths
+        if they do not exist. Default is True.
+    save_outputs : bool, optional
+        Whether to save the simulation outputs to files. Default is False.
+    save_dpl : bool, optional
+        If True, save dipole results. Note, `save_outputs` must be True.
+        Default: True.
+    save_spiking : bool, optional
+        If True, save spiking results. Note, `save_outputs` must be True.
+        Default: False.
+    save_lfp : bool, optional
+        If True, save local field potential (lfp) results.
+        Note, `save_outputs` must be True.
+        Default: False.
+    save_voltages : bool, optional
+        If True, save voltages results. Note, `save_outputs` must be True.
+        Default: False.
+    save_currents : bool, optional
+        If True, save currents results. Note, `save_outputs` must be True.
+        Default: False.
+    save_calcium : bool, optional
+        If True, save calcium concentrations.
+        Note, `save_outputs` must be True.
+        Default: False.
+    record_vsec : {False, 'all', 'soma'}
+        Option to record voltages from all sections ('all'), or just
+        the soma ('soma'). Default: False.
+    record_isec : {False, 'all', 'soma'}
+        Option to record voltages from all sections ('all'), or just
+        the soma ('soma'). Default: False.
+    postproc : bool, optional
+        If True, smoothing (``dipole_smooth_win``) and scaling
+        (``dipole_scalefctr``) values are read from the parameter file, and
+        applied to the dipole objects before returning.
+        Default: False.
+    clear_cache : bool, optional
+        Whether to clear the results cache after saving each batch.
+        Default is False.
+    summary_func : func, optional
+        A function to calculate summary statistics from the simulation
+        results. Default is None.
+
+    Notes
+    -----
+    When ``save_output=True``, the saved files will appear as
+    ``sim_run_{start_idx}-{end_idx}.npz`` in the specified `save_folder`
+    directory. The `start_idx` and `end_idx` indicate the range of
+    simulation indices contained in each file. Each file will contain
+    a maximum of `batch_size` simulations, split evenly among the
+    available files. If ``overwrite=True``, existing files with the same name
+    will be overwritten.
+    """
+
+    def __init__(
+        self,
+        set_params,
+        net=jones_2009_model(),
+        tstop=170,
+        dt=0.025,
+        n_trials=1,
+        save_folder='./sim_results',
+        batch_size=100,
+        overwrite=True,
+        save_outputs=False,
+        save_dpl=True,
+        save_spiking=False,
+        save_lfp=False,
+        save_voltages=False,
+        save_currents=False,
+        save_calcium=False,
+        record_vsec=False,
+        record_isec=False,
+        postproc=False,
+        clear_cache=False,
+        summary_func=None,
+    ):
 
         _validate_type(net, Network, 'net', 'Network')
         _validate_type(tstop, types='numeric', item_name='tstop')
         _validate_type(dt, types='numeric', item_name='dt')
         _validate_type(n_trials, types='int', item_name='n_trials')
-        _check_option('record_vsec', record_vsec, ['all', 'soma', False])
-        _check_option('record_isec', record_isec, ['all', 'soma', False])
         _validate_type(save_folder, types='path-like', item_name='save_folder')
         _validate_type(batch_size, types='int', item_name='batch_size')
         _validate_type(save_outputs, types=(bool,), item_name='save_outputs')
@@ -121,6 +139,8 @@ class BatchSimulate(object):
         _validate_type(save_voltages, types=(bool,), item_name='save_voltages')
         _validate_type(save_currents, types=(bool,), item_name='save_currents')
         _validate_type(save_calcium, types=(bool,), item_name='save_calcium')
+        _check_option('record_vsec', record_vsec, ['all', 'soma', False])
+        _check_option('record_isec', record_isec, ['all', 'soma', False])
         _validate_type(clear_cache, types=(bool,), item_name='clear_cache')
 
         if set_params is not None and not callable(set_params):
@@ -129,30 +149,36 @@ class BatchSimulate(object):
         if summary_func is not None and not callable(summary_func):
             raise TypeError("summary_func must be a callable function")
 
-        self.net = net
         self.set_params = set_params
+        self.net = net
         self.tstop = tstop
         self.dt = dt
         self.n_trials = n_trials
-        self.record_vsec = record_vsec
-        self.record_isec = record_isec
-        self.postproc = postproc
-        self.save_outputs = save_outputs
         self.save_folder = save_folder
         self.batch_size = batch_size
         self.overwrite = overwrite
-        self.summary_func = summary_func
+        self.save_outputs = save_outputs
         self.save_dpl = save_dpl
         self.save_spiking = save_spiking
         self.save_lfp = save_lfp
         self.save_voltages = save_voltages
         self.save_currents = save_currents
         self.save_calcium = save_calcium
+        self.record_vsec = record_vsec
+        self.record_isec = record_isec
+        self.postproc = postproc
         self.clear_cache = clear_cache
+        self.summary_func = summary_func
 
-    def run(self, param_grid, return_output=True,
-            combinations=True, n_jobs=1, backend='loky',
-            verbose=50):
+    def run(
+        self,
+        param_grid,
+        return_output=True,
+        combinations=True,
+        n_jobs=1,
+        backend='loky',
+        verbose=50,
+    ):
         """Run batch simulations.
 
         Parameters
@@ -169,7 +195,9 @@ class BatchSimulate(object):
             Number of parallel jobs. Default is 1.
         backend : str or joblib.parallel.ParallelBackendBase instance, optional
             The parallel backend to use. Can be one of `loky`, `threading`,
-            `multiprocessing`, or `dask`. Default is `loky`
+            `multiprocessing`, or `dask`. WARNING: currently only `loky` is
+            completely operationable; all other backends are in
+            development. Default is `loky`.
         verbose : int, optional
             The verbosity level for parallel execution. Default is 50.
 
@@ -177,15 +205,13 @@ class BatchSimulate(object):
         -------
         results : dict
             Dictionary containing 'summary_statistics' and optionally
-            'simulated_data'.
-            'simulated_data' may include keys: 'dpl', 'lfp', 'spikes',
-            'voltages', 'param_values', 'net', 'times'.
+            'simulated_data'. 'simulated_data' may include keys: 'dpl', 'lfp',
+            'spikes', 'voltages', 'param_values', 'net', 'times'.
 
         Notes
         -----
-        Return content depends on summary_func, return_output, and
-        clear_cache settings.
-
+        Return content depends on `summary_func`, `return_output`, and
+        `clear_cache` settings.
         """
         _validate_type(param_grid, types=(dict,), item_name='param_grid')
         _validate_type(n_jobs, types='int', item_name='n_jobs')
@@ -231,8 +257,13 @@ class BatchSimulate(object):
                 return {"summary_statistics": results,
                         "simulated_data": simulated_data}
 
-    def simulate_batch(self, param_combinations, n_jobs=1,
-                       backend='loky', verbose=50):
+    def simulate_batch(
+            self,
+            param_combinations,
+            n_jobs=1,
+            backend='loky',
+            verbose=50,
+    ):
         """Simulate a batch of parameter sets in parallel.
 
         Parameters
@@ -243,7 +274,9 @@ class BatchSimulate(object):
             Number of parallel jobs. Default is 1.
         backend : str or joblib.parallel.ParallelBackendBase instance, optional
             The parallel backend to use. Can be one of `loky`, `threading`,
-            `multiprocessing`, or `dask`. Default is `loky`
+            `multiprocessing`, or `dask`. WARNING: currently only `loky` is
+            completely operationable; all other backends are in
+            development. Default is `loky`.
         verbose : int, optional
             The verbosity level for parallel execution. Default is 50.
 
@@ -251,7 +284,9 @@ class BatchSimulate(object):
         -------
         res: list
             List of dictionaries containing simulation results.
-            Each dictionary contains the following keys:
+            Each dictionary contains the following keys along with their
+            associated values:
+
             - `net`: The network model used for the simulation.
             - `dpl`: The simulated dipole.
             - `param_values`: The parameter values used for the simulation.
@@ -405,8 +440,8 @@ class BatchSimulate(object):
         file_path : str
             The path to the file containing the simulation results.
         return_data : list of str, optional
-            List of data types to return. If None,
-            defaults to the types specified during initialization.
+            List of data types to return. If None, returns the types specified
+            during initialization. Defaults to None.
 
         Returns
         -------
@@ -434,7 +469,7 @@ class BatchSimulate(object):
         return results
 
     def load_all_results(self):
-        """Load all simulation results from the save folder.
+        """Load all simulation results from the files in `self.save_folder`.
 
         Returns
         -------


### PR DESCRIPTION
This PR does the following:

1. Promotes `BatchSimulate` to a top-level class befitting its status as a member of the public API. This means that its import is analogous to other public classes: just like `from hnn_core import Network`, you can now `from hnn_core import BatchSimulate` without having to import it strictly from its own module. This puts it on equal footing with the other classes described in the public API https://jonescompneurolab.github.io/hnn-core/stable/api.html . The example script for `BatchSimulate` has been updated to include this new import way.
2. Moves around the docstrings of `BatchSimulate` so they display properly on the sphinx build (i.e. the code website).
3. Adds a WARNING to the docstring of any `backend` options which indicate that only `loky` should be used right now (since the other backends do not work out of the box, see updates to #955).
4. Minor text polishing of docstrings.