### PR TITLE
[MRG] hotfix: update link to current install webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,5 +120,4 @@ JOSS](https://doi.org/10.21105/joss.05848):
 [Contributing Guide]: https://jonescompneurolab.github.io/hnn-core/stable/contributing.html
 
 <!-- TODO: Once we have a "stable" version of the install webpage, need to update this link to it: -->
-<!-- TODO: Once the install page is merged into "dev", we need to update this link to it: -->
-[Installation Guide]: https://github.com/asoplata/hnn-core/blob/iss969-authoring/doc/install.md
+[Installation Guide]: https://jonescompneurolab.github.io/hnn-core/dev/install.html


### PR DESCRIPTION
After the new standalone installation page was merged into the documentation, I forgot to update the link from the README, since this step had to be done AFTER the PR was fully merged (cyclic dependency). Since I recently deleted the old branch it was sitting on, the current Install link now gives a 404.

I am going to merge this immediately, of my own accord, because it fixes a broken link on our current README.