### PR TITLE
MAINT: 0.4 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,4 @@ JOSS](https://doi.org/10.21105/joss.05848):
 > Software*, 8(92), 5848, <https://doi.org/10.21105/joss.05848>
 
 [Contributing Guide]: https://jonescompneurolab.github.io/hnn-core/stable/contributing.html
-
-<!-- TODO: Once we have a "stable" version of the install webpage, need to update this link to it: -->
-[Installation Guide]: https://jonescompneurolab.github.io/hnn-core/dev/install.html
+[Installation Guide]: https://jonescompneurolab.github.io/hnn-core/stable/install.html

--- a/doc/_static/versions.json
+++ b/doc/_static/versions.json
@@ -5,14 +5,9 @@
         "url": "https://jonescompneurolab.github.io/hnn-core/dev/index.html"
     },
     {
-        "name": "Stable",
+        "name": "Stable (v0.4)",
         "version": "stable",
         "url": "https://jonescompneurolab.github.io/hnn-core/stable/index.html"
-    },
-    {
-        "name": "v0.4",
-        "version": "0.4",
-        "url": "https://jonescompneurolab.github.io/hnn-core/v0.4/index.html"
     },
     {
         "name": "v0.3",

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -8,4 +8,4 @@ from .cells_default import pyramidal, basket
 from .parallel_backends import MPIBackend, JoblibBackend
 from .batch_simulate import BatchSimulate
 
-__version__ = '0.4rc4'
+__version__ = '0.4'


### PR DESCRIPTION
Note: This does not include the usual change to `doc/conf.py` because the existing file previously (incorrectly) had the version set to `0.4` (when it should have been `0.4rc4`).

Also note that Linkcheck will fail due to a new documention website page reference in the README. This is expected and will be fixed when the `gh-pages` branch is updated momentarily.