### PR TITLE
maint: bump versions to 0.5.0.dev0 after v0.4.1 stable

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,14 +27,39 @@ sys.path.append(os.path.abspath(os.path.join(curdir, 'sphinxext')))
 # -- Project information -----------------------------------------------------
 
 project = 'hnn-core'
-copyright = '2024, HNN Developers'
+copyright = '2025, HNN Developers'
 author = 'HNN Developers'
 
-# The short X.Y version
-version = '0.4.1'
-# The full version, including alpha/beta/rc tags
-release = '0.4.1'
+# -- Version handling --------------------------------------------------------
 
+# The short X.Y version
+version = '0.5.0.dev0'
+# The full version, including alpha/beta/rc tags
+release = '0.5.0.dev0'
+
+### HTML theme version control
+# If you are making a stable release, then you should add entries to the file
+# located in `doc/_static/versions.json`. Once your PR with that change is
+# merged, that file will be pushed to the following URL. Unfortunately our
+# theme system wants a public URL, NOT a local file for this version control.
+json_versions_url = "https://jonescompneurolab.github.io/hnn-core/dev/_static/versions.json"
+if (("rc" in version) or ("dev" in version)):
+    switcher_version_match = "dev"
+else:
+    switcher_version_match = version
+
+### Binder version control
+# Resolve binder variable `filepath_prefix` to go in `sphinx_gallery_conf`
+# below. From the docs:
+#   "A prefix to append to the filepath in the Binder links. You should use this
+#    if you will store your built documentation in a sub-folder of a repository,
+#    instead of in the root."
+# We will store dev docs in a `dev` subdirectory and all other docs in a
+# directory "v" + version_str. E.g., "v0.3"
+if (("rc" in version) or ("dev" in version)):
+    filepath_prefix = 'dev'
+else:
+    filepath_prefix = 'v{}'.format(version)
 
 # -- General configuration ---------------------------------------------------
 
@@ -78,7 +103,6 @@ source_suffix = {
     '.md': 'markdown',
 }
 
-
 # The master toctree document.
 master_doc = 'index'
 
@@ -97,13 +121,6 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'gui/index.rst']
 # -- Options for HTML output -------------------------------------------------
 
 html_theme = "pydata_sphinx_theme"
-
-# versions
-#
-# The actual, local version of `versions.json` that you should edit (if
-# necessary) is in `_static/versions.json`.
-json_versions_url = "https://jonescompneurolab.github.io/hnn-core/dev/_static/versions.json"
-switcher_version_match = "dev" if ".rc" in version else version
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -227,17 +244,6 @@ linkcheck_ignore = [
     'https://doi.org/10.1101/2021.04.16.440210',
     'https://groups.google.com/g/hnnsolver'
 ]
-
-# Resolve binder filepath_prefix. From the docs:
-# "A prefix to append to the filepath in the Binder links. You should use this
-# if you will store your built documentation in a sub-folder of a repository,
-# instead of in the root."
-# we will store dev docs in a `dev` subdirectory and all other docs in a
-# directory "v" + version_str. E.g., "v0.3"
-if 'dev' in version:
-    filepath_prefix = 'dev'
-else:
-    filepath_prefix = 'v{}'.format(version)
 
 sphinx_gallery_conf = {
     'first_notebook_cell': ("import pyvista as pv\n"

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -5,6 +5,10 @@ orphan: true
 (whats_new)=
 # What's new?
 
+## Current development version
+
+### Changelog
+
 ## 0.4.1 Patch notes
 
 - Version 0.4.1 is a bug-fixing patch release for version 0.4. This includes changes to importing of `BatchSimulate` due to previously-undetected install/import issues ({gh}`1034`), configuration of packaging metadata format (same PR), and elimination of a discrepancy in our method of cleaning local compiled files that led to architecture-specific files being included in the Pypi 0.4 release, which caused simulations on some platforms to fail ({gh}`1035`). The public Pypi version has already been updated to 0.4.1.

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -7,4 +7,4 @@ from .cell_response import CellResponse, read_spikes
 from .cells_default import pyramidal, basket
 from .parallel_backends import MPIBackend, JoblibBackend
 
-__version__ = '0.4.1'
+__version__ = '0.5.0.dev0'


### PR DESCRIPTION
This increases the master version from `v0.4.1` (the most recent stable) to `v0.5.0.dev0`. The addition of the "micro" version specificer (see https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers and
https://packaging.python.org/en/latest/discussions/versioning/ ) does not appear to cause any problems with the documentation generation as far as I've been able to test, and enables us to describe/version/publish bugfix patches in the more common manner.

This also re-locates all the version-programming code in `doc/conf.py` to the same section. Previously this code was distributed across the file, but there were also inconsistencies between the string-detection of development versions for the HTML version switcher versus Binder. These inconsistencies have been resolved.

Equivalently, in the same code blocks, the development version is indicated for both the HTML dropdown/version control and binder based on string-detection of EITHER `rc` or `dev` in the version name. This allows us to return to using `dev` for non-release-candidate development versions, but also lets us use `rc` in the future if we so desire.

This also updates the documentation copyright to the current year.