### PR TITLE
[ENH]: Update Linkcheck Schedule to Reduce Frequency

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -2,9 +2,10 @@ name: Linkcheck
 
 on:
   push:
-    branches: ['**']
-  pull_request:
-    branches: ['**']
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 1,15 * *"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -118,7 +118,4 @@ JOSS](https://doi.org/10.21105/joss.05848):
 > Software*, 8(92), 5848, <https://doi.org/10.21105/joss.05848>
 
 [Contributing Guide]: https://jonescompneurolab.github.io/hnn-core/stable/contributing.html
-
-<!-- TODO: Once we have a "stable" version of the install webpage, need to update this link to it: -->
-<!-- TODO: Once the install page is merged into "dev", we need to update this link to it: -->
-[Installation Guide]: https://github.com/asoplata/hnn-core/blob/iss969-authoring/doc/install.md
+[Installation Guide]: https://jonescompneurolab.github.io/hnn-core/stable/install.html


### PR DESCRIPTION
### Summary
This pull request updates the Linkcheck workflow to modify its frequency and reduce unnecessary runs.
### Changes Made
1. The workflow now:
   - Runs only on every push/merge to the `master` branch.
   - Executes on a scheduled basis on the 1st and 15th of each month at midnight UTC.
   - No longer runs on every pull request (including subsequent updates).

Closes #1031 