### PR TITLE
[MRG] doc: add Neymotin2020 impl to j09 docstring

### DIFF
--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -14,8 +14,7 @@ from .externals.mne import _validate_type
 def jones_2009_model(
     params=None, add_drives_from_params=False, legacy_mode=False, mesh_shape=(10, 10)
 ):
-    """Instantiate the network model described in
-    Jones et al. J. of Neurophys. 2009 [1]_
+    """Instantiate the network model described in Jones et al. 2009 [1]_
 
     Parameters
     ----------
@@ -47,12 +46,20 @@ def jones_2009_model(
     connectivity pattern is applied between cells. Inhibitory basket cells are
     present at a 1:3-ratio.
 
+    This network was first described in Jones et al. 2009 [1]_ , and this code provides
+    the implementation used in Neymotin et al. 2020 [2]_ .
+
     References
     ----------
     .. [1] Jones, Stephanie R., et al. "Quantitative Analysis and
            Biophysically Realistic Neural Modeling of the MEG Mu Rhythm:
            Rhythmogenesis and Modulation of Sensory-Evoked Responses."
            Journal of Neurophysiology 102, 3554–3572 (2009).
+           https://doi.org/10.1152/jn.00535.2009
+
+    .. [2] Neymotin, Samuel A, et al. 2020. "Human Neocortical Neurosolver (HNN), a New
+           Software Tool for Interpreting the Cellular and Network Origin of Human
+           MEG/EEG Data." eLife 9 (January):e51214. https://doi.org/10.7554/eLife.51214
 
     """
     hnn_core_root = op.dirname(hnn_core.__file__)


### PR DESCRIPTION
This is a tiny, trivial change to the doctring to the very important function `network_models.py::jones_2009_model()`. This adds a note that the "model network" is still defined by the Jones 2009 reference, but that the "implementation" is from the Neymotin 2020 reference. This is meant for rectifying the small but distinct differences between the two references.

To be clear, although the code, parameters, and math between the the Jones 2009 implementation (can be seen https://modeldb.science/136803?tab=1 and here https://github.com/ModelDBRepository/136803 ) and the Neymotin 2020 implementation (seen here https://github.com/jonescompneurolab/hnn ) are very similar, they are not *exactly* the same.

In addition to differences with various parameters, there are also differences between the MOD files. There are at least some differences between the two implementations that affect the "speed" of activation curves for some of the ion channels, which are documented in this thread:
https://github.com/jonescompneurolab/hnn-core/discussions/930#discussioncomment-11230677

Therefore, adding this documentation change makes it clear to future researchers that, even though Jones 2009 is the main paper of the model in a scientific sense, they should refer to Neymotin 2020 when it comes to the exact code and parameters used, especially for reproducibility.