### PR TITLE
[MRG] Bugfix: Update vecevent mod

### DIFF
--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Neuron on Windows separately
         shell: cmd
         run: |
-          powershell -command "gh release download 8.2.6 --repo https://github.com/neuronsimulator/nrn --pattern '*.exe' --output nrn-setup.exe"
+          powershell -command "gh release download --repo https://github.com/neuronsimulator/nrn --pattern '*.exe' --output nrn-setup.exe"
           start /b /wait .\nrn-setup.exe /S /D=C:\nrn_test
           powershell -command "'C:\nrn_test\bin' >> $env:GITHUB_PATH"
           python -c "import neuron"

--- a/hnn_core/mod/vecevent.mod
+++ b/hnn_core/mod/vecevent.mod
@@ -1,69 +1,175 @@
 :  Vector stream of events
 
+COMMENT
+A VecStim is an artificial spiking cell that generates
+events at times that are specified in a Vector.
+
+---
+AES: This newer version of vecevent.mod was taken from
+https://github.com/neuronsimulator/nrn/blob/master/share/examples/nrniv/netcon/vecevent.mod
+as of this commit
+https://github.com/neuronsimulator/nrn/commit/3ebf32d27396b2c88ea83bbfaa606a7e286451f3
+This mod file needed to be updated as a result of some unknown change in 
+`nrnivmodl` from NEURON version 8.2.6 to 8.2.7.
+
+The rest of the original comment follows.
+---
+
+
+HOC Example:
+
+// assumes spt is a Vector whose elements are all > 0
+// and are sorted in monotonically increasing order
+objref vs
+vs = new VecStim()
+vs.play(spt)
+// now launch a simulation, and vs will produce spike events
+// at the times contained in spt
+
+Python Example:
+
+from neuron import h
+spt = h.Vector(10).indgen(1, 0.2)
+vs = h.VecStim()
+vs.play(spt)
+
+def pr():
+  print (h.t)
+
+nc = h.NetCon(vs, None)
+nc.record(pr)
+
+cvode = h.CVode()
+h.finitialize()
+cvode.solve(20)
+
+ENDCOMMENT
+
 NEURON {
-    ARTIFICIAL_CELL VecStim
+	THREADSAFE
+	ARTIFICIAL_CELL VecStim
+	BBCOREPOINTER ptr
 }
 
 ASSIGNED {
-    index
-    etime (ms)
-    space
+	index
+	etime (ms)
+	ptr
 }
 
+
 INITIAL {
-    index = 0
-    element()
-    if (index > 0) {
-        net_send(etime - t, 1)
-    }
+	index = 0
+	element()
+	if (index > 0) {
+		net_send(etime - t, 1)
+	}
 }
 
 NET_RECEIVE (w) {
-    if (flag == 1) {
-        net_event(t)
-        element()
-        if (index > 0) {
-            net_send(etime - t, 1)
-        }
-    }
+	if (flag == 1) {
+		net_event(t)
+		element()
+		if (index > 0) {
+			net_send(etime - t, 1)
+		}
+	}
 }
 
+DESTRUCTOR {
 VERBATIM
-extern double* vector_vec();
-extern int vector_capacity();
-extern void* vector_arg();
+#if !NRNBBCORE
+	void* vv = (void*)(_p_ptr);  
+        if (vv) {
+		hoc_obj_unref(*vector_pobj(vv));
+	}
+#endif
 ENDVERBATIM
+}
 
 PROCEDURE element() {
-VERBATIM
+VERBATIM	
   { void* vv; int i, size; double* px;
-    i = (int)index;
-    if (i >= 0) {
-        vv = *((void**)(&space));
-        if (vv) {
-            size = vector_capacity(vv);
-            px = vector_vec(vv);
-            if (i < size) {
-                etime = px[i];
-                index += 1.;
-            } else {
-                index = -1.;
-            }
-        } else {
-            index = -1.;
-        }
-    }
+	i = (int)index;
+	if (i >= 0) {
+		vv = (void*)(_p_ptr);
+		if (vv) {
+			size = vector_capacity(vv);
+			px = vector_vec(vv);
+			if (i < size) {
+				etime = px[i];
+				index += 1.;
+			}else{
+				index = -1.;
+			}
+		}else{
+			index = -1.;
+		}
+	}
   }
 ENDVERBATIM
 }
 
 PROCEDURE play() {
 VERBATIM
-    void** vv;
-    vv = (void**)(&space);
-    *vv = (void*)0;
-    if (ifarg(1)) {
-        *vv = vector_arg(1);
-    }
+#if !NRNBBCORE
+  {
+	void** pv;
+	void* ptmp = NULL;
+	if (ifarg(1)) {
+		ptmp = vector_arg(1);
+		hoc_obj_ref(*vector_pobj(ptmp));
+	}
+	pv = (void**)(&_p_ptr);
+	if (*pv) {
+		hoc_obj_unref(*vector_pobj(*pv));
+	}
+	*pv = ptmp;
+  }
+#endif
 ENDVERBATIM
 }
+
+VERBATIM
+static void bbcore_write(double* xarray, int* iarray, int* xoffset, int* ioffset, _threadargsproto_) {
+  int i, dsize, *ia;
+  double *xa, *dv;
+  dsize = 0;
+  if (_p_ptr) {
+    dsize = vector_capacity(_p_ptr);
+  }
+  if (iarray) {
+    void* vec = _p_ptr;
+    ia = iarray + *ioffset;
+    xa = xarray + *xoffset;
+    ia[0] = dsize;
+    if (dsize) {
+      dv = vector_vec(vec);
+      for (i = 0; i < dsize; ++i) {
+         xa[i] = dv[i];
+      }
+    }
+  }
+  *ioffset += 1;
+  *xoffset += dsize;
+}
+
+static void bbcore_read(double* xarray, int* iarray, int* xoffset, int* ioffset, _threadargsproto_) {
+  int dsize, i, *ia;
+  double *xa, *dv;
+  xa = xarray + *xoffset;
+  ia = iarray + *ioffset;
+  dsize = ia[0];
+  if (!_p_ptr) {
+    _p_ptr = vector_new1(dsize);
+  }
+  assert(dsize == vector_capacity(_p_ptr));
+  dv = vector_vec(_p_ptr);
+  for (i = 0; i < dsize; ++i) {
+    dv[i] = xa[i];
+  }
+  *xoffset += dsize;
+  *ioffset += 1;
+}
+
+ENDVERBATIM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "NEURON >=7.7, <8.2.7; platform_system != 'Windows'"]
+requires = ["setuptools>=40.8.0", "NEURON >=7.7; platform_system != 'Windows'"]
 build-backend = "setuptools.build_meta:__legacy__"
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,./hnn_core/mod,./doc/_build,./build'

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
           platforms='any',
           install_requires=[
               'numpy >=1.14',
-              'NEURON >=7.7, <8.2.7; platform_system != "Windows"',
+              'NEURON >=7.7; platform_system != "Windows"',
               'matplotlib>=3.5.3',
               'scipy',
               'h5io'


### PR DESCRIPTION
This may resolve #1052, but needs to be comprehensively tested.

In testing for #1052, the issue seemed to be that, with NEURON 8.2.7 on Windows, `nrnivmodl` is no longer able to compile our `vecevent.mod` file, and complains about inconsistent types. Here is example output:

```
(test-nrn-827) C:\Users\austi\mod-test>nrnivmodl
x86_64-w64-mingw32-gcc.exe -DDLL_EXPORT -DPIC -I/cygdrive/c/nrn/bin//../include -I/cygdrive/c/nrn/bin//../src/scopmath -I/cygdrive/c/nrn/bin//../src/nrnoc -I/cygdrive/c/nrn/bin//../src/oc  -c mod_func.c
nocmodl vecevent
Translating vecevent.mod into vecevent.c
Notice: VERBATIM blocks are not thread safe
x86_64-w64-mingw32-gcc.exe -DDLL_EXPORT -DPIC -I/cygdrive/c/nrn/bin//../include -I/cygdrive/c/nrn/bin//../src/scopmath -I/cygdrive/c/nrn/bin//../src/nrnoc -I/cygdrive/c/nrn/bin//../src/oc  -c vecevent.c
vecevent.c:241:16: error: conflicting types for 'vector_vec'; have 'double *(void)'
  241 | extern double* vector_vec();
      |                ^~~~~~~~~~
In file included from C:/nrn/include/hocdec.h:280,
                 from C:/nrn/include/section.h:37,
                 from vecevent.c:11:
C:/nrn/include/oc_ansi.h:57:16: note: previous declaration of 'vector_vec' with type 'double *(void *)'
   57 | extern double* vector_vec(IvocVect*);
      |                ^~~~~~~~~~
vecevent.c:242:12: error: conflicting types for 'vector_capacity'; have 'int(void)'
  242 | extern int vector_capacity();
      |            ^~~~~~~~~~~~~~~
C:/nrn/include/oc_ansi.h:58:12: note: previous declaration of 'vector_capacity' with type 'int(void *)'
   58 | extern int vector_capacity(IvocVect*);
      |            ^~~~~~~~~~~~~~~
vecevent.c:243:14: error: conflicting types for 'vector_arg'; have 'void *(void)'
  243 | extern void* vector_arg();
      |              ^~~~~~~~~~
C:/nrn/include/oc_ansi.h:55:18: note: previous declaration of 'vector_arg' with type 'void *(int)'
   55 | extern IvocVect* vector_arg(int);
      |                  ^~~~~~~~~~
vecevent.c: In function 'element__VecStim':
vecevent.c:253:20: error: too many arguments to function 'vector_capacity'; expected 0, have 1
  253 |             size = vector_capacity(vv);
      |                    ^~~~~~~~~~~~~~~ ~~
vecevent.c:242:12: note: declared here
  242 | extern int vector_capacity();
      |            ^~~~~~~~~~~~~~~
vecevent.c:254:18: error: too many arguments to function 'vector_vec'; expected 0, have 1
  254 |             px = vector_vec(vv);
      |                  ^~~~~~~~~~ ~~
vecevent.c:241:16: note: declared here
  241 | extern double* vector_vec();
      |                ^~~~~~~~~~
vecevent.c: In function 'play__VecStim':
vecevent.c:283:15: error: too many arguments to function 'vector_arg'; expected 0, have 1
  283 |         *vv = vector_arg(1);
      |               ^~~~~~~~~~ ~
vecevent.c:243:14: note: declared here
  243 | extern void* vector_arg();
      |              ^~~~~~~~~~
make: *** [/cygdrive/c/nrn/bin//../lib/mknrndll.mak:26: vecevent.o] Error 1

There was an error in the process of creating nrnmech.dll
```

Specifically, you can see here https://github.com/jonescompneurolab/hnn-core/blob/master/hnn_core/mod/vecevent.mod#L32-L34 that our `vecevent.mod` forces some variables to use specific types.

However, the NEURON source code has a more recent version of a file of the same name that appears to have similar (or identical) functionality, which can be seen here: https://github.com/neuronsimulator/nrn/blob/master/share/examples/nrniv/netcon/vecevent.mod . I haven't fully dug into the NEURON source code enough to completely understand the differences, but my hypothesis is that our older version is forcing the three variables (and/or their pointers) to use certain types, but the newer version is not, and perhaps these variables' types have changed on the back-end.

Swapping to this new `vecevent.mod` allows the install on my Windows to work, and allows for simulations to run successfully. Whether this mod file works as a complete replacement across all operating systems and code needs to be extensively tested, and the first place to do that is in the automated CI tests in this PR.