### PR TITLE
[MRG] Fix HNN logo hosting locn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <h1 align="center">
-<img src="https://hnn.brown.edu/wp-content/uploads/hnn-medium.png" width="300">
+<img src="https://raw.githubusercontent.com/jonescompneurolab/jones-website/master/images/frontpage/logos/logo-hnn-medium.png" width="300">
 </h1><br>
 
 # hnn-core


### PR DESCRIPTION
This changes the hosting location of the
HNN Icon displayed, since we recently
updated the homepage domain.