### PR TITLE
[MERGE][WIP] fixed cell positioning

### DIFF
--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -629,7 +629,13 @@ class Cell:
             h.pt3dconst(0, sec=sec)  # be explicit, see documentation
             for pt in sections[sec_name].end_pts:
                 # Add positional offset to each coordinate
-                h.pt3dadd(pt[0] + self.pos[0], pt[1] + self.pos[1], pt[2] + self.pos[2], 1, sec=sec)
+                h.pt3dadd(
+                    pt[0] + self.pos[0],
+                    pt[1] + self.pos[1],
+                    pt[2] + self.pos[2],
+                    1,
+                    sec=sec,
+                )
             # with pt3dconst==0, these will alter the 3d points defined above!
             sec.L = sections[sec_name].L
             sec.diam = sections[sec_name].diam

--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -628,7 +628,8 @@ class Cell:
             h.pt3dclear(sec=sec)
             h.pt3dconst(0, sec=sec)  # be explicit, see documentation
             for pt in sections[sec_name].end_pts:
-                h.pt3dadd(pt[0], pt[1], pt[2], 1, sec=sec)
+                # Add positional offset to each coordinate
+                h.pt3dadd(pt[0] + self.pos[0], pt[1] + self.pos[1], pt[2] + self.pos[2], 1, sec=sec)
             # with pt3dconst==0, these will alter the 3d points defined above!
             sec.L = sections[sec_name].L
             sec.diam = sections[sec_name].diam


### PR DESCRIPTION
This PR addresses: https://github.com/jonescompneurolab/hnn-core/issues/1061

It looked like all cells were placed at the origin when building them in NEURON. I noticed that when looking at the LFP and CSD. Digging through the code it turned out that pos_dict and pos were not used when building the cell. I have updated this by adding the x, y, z coordinates of the cells position to the cell's end points.

LFP and CSD look as expected now.

Here an example of **unconnected** Jones 2009 with strong proximal. 
Top row: drive to L2 basket
Middle: drive to L2 pyramidal
Bottom: drive to L5 pyramidal

Before: spiking just picked up in bottom layer, even when L2/3 is driven
![test_cell_positioning_before](https://github.com/user-attachments/assets/bebebd6e-3238-4821-a36f-daad14b35586)


After: spiking in L2/3 leads to sink/source in L2/3.
![test_cell_positioning_after](https://github.com/user-attachments/assets/b41ccada-09ce-420f-884c-f28fcd1092e0)

net.plot_cells() showing cells where expected 
![Screenshot 2025-06-06 at 17 02 55](https://github.com/user-attachments/assets/e8fd016a-f320-41d2-bc0c-b40d61180887)

