### PR TITLE
[MRG] Bugfix: update new frontpage/textbook urls

### DIFF
--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -276,4 +276,4 @@ sensory and motor cortices during median nerve stimulation.
 
 [^1]: We do not claim all the neural mechanisms of these signals are completely understood, rather that there is a baseline of knowledge to build from and that HNN provides a framework for further investigation.
 
-[prior studies]: https://hnn.brown.edu/index.php/publications/
+[prior studies]: https://hnn.brown.edu/publications.html

--- a/examples/workflows/README.txt
+++ b/examples/workflows/README.txt
@@ -2,16 +2,14 @@ Tutorials
 ---------
 
 The following tutorials contain the workflow and code to simulate and visualize commonly
-studied M/EEG signals including event related potentials and low frequency rhythms in the
-alpha, beta and gamma bands. The tutorial workflows, and all parameter values used,
-are based on the detailed tutorials provided on the `HNN GUI website
-<https://hnn.brown.edu/tutorials>`_, and reproduce a subset of examples and figures in the
-more elaborated GUI tutorials using the HNN-core API.
+studied M/EEG signals including event related potentials and low frequency rhythms in
+the alpha, beta and gamma bands. These tutorial workflows are analogous to those on the
+`textbook website <https://jonescompneurolab.github.io/textbook/content/preface.html>`_.
 
-We strongly recommend that you
-first go through the background information provided on the `HNN website
-<https://hnn.brown.edu/overview-uniqueness/>`_ and each of the HNN GUI tutorials,
-after which the code and instructions in these HNN-core tutorials will be clearer.
-All tutorials build from our prior publications investigating the origin of ERPs and
-brain rhythms in the somatosensory system, and parameter and data sets are provided to
-help users get started.
+We strongly recommend that you first go through the background information provided on
+the `HNN textbook website
+<https://jonescompneurolab.github.io/textbook/content/preface.html>`_ and each of the
+HNN GUI tutorials, after which the code and instructions in these HNN-core tutorials
+will be clearer.  All tutorials build from our prior publications investigating the
+origin of ERPs and brain rhythms in the somatosensory system, and parameter and data
+sets are provided to help users get started.


### PR DESCRIPTION
Since we recently updated the HNN frontpage at <https://hnn.brown.edu>, this broke a couple of our existing `hnn-core` documentation links to sub-pages on the old website. This fixes those links.

Also, do *not* worry about wording changes to `examples/workflows/README.txt`, since all of the Examples section on our code website ( https://jonescompneurolab.github.io/hnn-core/stable/auto_examples/index.html ) have been reproduced and moved to a section of our new Textbook website here https://jonescompneurolab.github.io/textbook/content/04_using_hnn/plot_firing_pattern.html . In other words, *soon we will be removing all the `examples` content from our main `hnn-core` repo*, since all documentation on how to USE HNN will live on the Textbook website.