### PR TITLE
[MRG] MAINT: Remove Python 3.8 support, add Python 3.13 support

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -5,7 +5,7 @@
       branches: ['**']
     pull_request:
       branches: ['**']
-  
+
   concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
@@ -17,7 +17,7 @@
       strategy:
         matrix:
           os: [ubuntu-latest,macos-latest]
-          python-version: [3.8, 3.11, 3.12]
+          python-version: [3.9, 3.11, 3.13]
 
       steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Neuron on Windows separately
         shell: cmd
         run: |
-          powershell -command "gh release download 8.2.6 --repo https://github.com/neuronsimulator/nrn --pattern '*.exe' --output nrn-setup.exe"
+          powershell -command "gh release download --repo https://github.com/neuronsimulator/nrn --pattern '*.exe' --output nrn-setup.exe"
           start /b /wait .\nrn-setup.exe /S /D=C:\nrn_test
           powershell -command "'C:\nrn_test\bin' >> $env:GITHUB_PATH"
           python -c "import neuron"

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -9,7 +9,7 @@ on:
 env:
     PYTHONPATH: C:\nrn_test\lib\python
     NEURONHOME: C:\nrn_test
-    
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: [3.8, 3.11, 3.12]
+        python-version: [3.9, 3.11, 3.13]
 
     steps:
       - uses: actions/checkout@v4

--- a/hnn_core/mod/vecevent.mod
+++ b/hnn_core/mod/vecevent.mod
@@ -1,69 +1,175 @@
 :  Vector stream of events
 
+COMMENT
+A VecStim is an artificial spiking cell that generates
+events at times that are specified in a Vector.
+
+---
+AES: This newer version of vecevent.mod was taken from
+https://github.com/neuronsimulator/nrn/blob/master/share/examples/nrniv/netcon/vecevent.mod
+as of this commit
+https://github.com/neuronsimulator/nrn/commit/3ebf32d27396b2c88ea83bbfaa606a7e286451f3
+This mod file needed to be updated as a result of some unknown change in 
+`nrnivmodl` from NEURON version 8.2.6 to 8.2.7.
+
+The rest of the original comment follows.
+---
+
+
+HOC Example:
+
+// assumes spt is a Vector whose elements are all > 0
+// and are sorted in monotonically increasing order
+objref vs
+vs = new VecStim()
+vs.play(spt)
+// now launch a simulation, and vs will produce spike events
+// at the times contained in spt
+
+Python Example:
+
+from neuron import h
+spt = h.Vector(10).indgen(1, 0.2)
+vs = h.VecStim()
+vs.play(spt)
+
+def pr():
+  print (h.t)
+
+nc = h.NetCon(vs, None)
+nc.record(pr)
+
+cvode = h.CVode()
+h.finitialize()
+cvode.solve(20)
+
+ENDCOMMENT
+
 NEURON {
-    ARTIFICIAL_CELL VecStim
+	THREADSAFE
+	ARTIFICIAL_CELL VecStim
+	BBCOREPOINTER ptr
 }
 
 ASSIGNED {
-    index
-    etime (ms)
-    space
+	index
+	etime (ms)
+	ptr
 }
 
+
 INITIAL {
-    index = 0
-    element()
-    if (index > 0) {
-        net_send(etime - t, 1)
-    }
+	index = 0
+	element()
+	if (index > 0) {
+		net_send(etime - t, 1)
+	}
 }
 
 NET_RECEIVE (w) {
-    if (flag == 1) {
-        net_event(t)
-        element()
-        if (index > 0) {
-            net_send(etime - t, 1)
-        }
-    }
+	if (flag == 1) {
+		net_event(t)
+		element()
+		if (index > 0) {
+			net_send(etime - t, 1)
+		}
+	}
 }
 
+DESTRUCTOR {
 VERBATIM
-extern double* vector_vec();
-extern int vector_capacity();
-extern void* vector_arg();
+#if !NRNBBCORE
+	void* vv = (void*)(_p_ptr);  
+        if (vv) {
+		hoc_obj_unref(*vector_pobj(vv));
+	}
+#endif
 ENDVERBATIM
+}
 
 PROCEDURE element() {
-VERBATIM
+VERBATIM	
   { void* vv; int i, size; double* px;
-    i = (int)index;
-    if (i >= 0) {
-        vv = *((void**)(&space));
-        if (vv) {
-            size = vector_capacity(vv);
-            px = vector_vec(vv);
-            if (i < size) {
-                etime = px[i];
-                index += 1.;
-            } else {
-                index = -1.;
-            }
-        } else {
-            index = -1.;
-        }
-    }
+	i = (int)index;
+	if (i >= 0) {
+		vv = (void*)(_p_ptr);
+		if (vv) {
+			size = vector_capacity(vv);
+			px = vector_vec(vv);
+			if (i < size) {
+				etime = px[i];
+				index += 1.;
+			}else{
+				index = -1.;
+			}
+		}else{
+			index = -1.;
+		}
+	}
   }
 ENDVERBATIM
 }
 
 PROCEDURE play() {
 VERBATIM
-    void** vv;
-    vv = (void**)(&space);
-    *vv = (void*)0;
-    if (ifarg(1)) {
-        *vv = vector_arg(1);
-    }
+#if !NRNBBCORE
+  {
+	void** pv;
+	void* ptmp = NULL;
+	if (ifarg(1)) {
+		ptmp = vector_arg(1);
+		hoc_obj_ref(*vector_pobj(ptmp));
+	}
+	pv = (void**)(&_p_ptr);
+	if (*pv) {
+		hoc_obj_unref(*vector_pobj(*pv));
+	}
+	*pv = ptmp;
+  }
+#endif
 ENDVERBATIM
 }
+
+VERBATIM
+static void bbcore_write(double* xarray, int* iarray, int* xoffset, int* ioffset, _threadargsproto_) {
+  int i, dsize, *ia;
+  double *xa, *dv;
+  dsize = 0;
+  if (_p_ptr) {
+    dsize = vector_capacity(_p_ptr);
+  }
+  if (iarray) {
+    void* vec = _p_ptr;
+    ia = iarray + *ioffset;
+    xa = xarray + *xoffset;
+    ia[0] = dsize;
+    if (dsize) {
+      dv = vector_vec(vec);
+      for (i = 0; i < dsize; ++i) {
+         xa[i] = dv[i];
+      }
+    }
+  }
+  *ioffset += 1;
+  *xoffset += dsize;
+}
+
+static void bbcore_read(double* xarray, int* iarray, int* xoffset, int* ioffset, _threadargsproto_) {
+  int dsize, i, *ia;
+  double *xa, *dv;
+  xa = xarray + *xoffset;
+  ia = iarray + *ioffset;
+  dsize = ia[0];
+  if (!_p_ptr) {
+    _p_ptr = vector_new1(dsize);
+  }
+  assert(dsize == vector_capacity(_p_ptr));
+  dv = vector_vec(_p_ptr);
+  for (i = 0; i < dsize; ++i) {
+    dv[i] = xa[i];
+  }
+  *xoffset += dsize;
+  *ioffset += 1;
+}
+
+ENDVERBATIM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "NEURON >=7.7, <8.2.7; platform_system != 'Windows'"]
+requires = ["setuptools>=40.8.0", "NEURON >=7.7; platform_system != 'Windows'"]
 build-backend = "setuptools.build_meta:__legacy__"
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,./hnn_core/mod,./doc/_build,./build'

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
           platforms='any',
           install_requires=[
               'numpy >=1.14',
-              'NEURON >=7.7, <8.2.7; platform_system != "Windows"',
+              'NEURON >=7.7; platform_system != "Windows"',
               'matplotlib>=3.5.3',
               'scipy',
               'h5io'

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,11 @@ if __name__ == "__main__":
               'Operating System :: POSIX',
               'Operating System :: Unix',
               'Operating System :: MacOS',
+              'Programming Language :: Python :: 3.9',
+              'Programming Language :: Python :: 3.10',
+              'Programming Language :: Python :: 3.11',
+              'Programming Language :: Python :: 3.12',
+              'Programming Language :: Python :: 3.13',
           ],
           platforms='any',
           install_requires=[
@@ -116,10 +121,10 @@ if __name__ == "__main__":
               'NEURON >=7.7; platform_system != "Windows"',
               'matplotlib>=3.5.3',
               'scipy',
-              'h5io'
+              'h5io',
           ],
           extras_require=extras,
-          python_requires='>=3.8',
+          python_requires='>=3.9, <3.14',
           packages=find_packages(),
           package_data={'hnn_core': [
               'param/*.json',


### PR DESCRIPTION
This removes explicit support for Python 3.8, and explicitly adds support for 3.13. This also increments the versions used in *some* of our unit tests: unit tests now run for every other supported Python version (3.9, 3.11, and 3.13). This also brings our Python version support to exactly match that of the latest release of NEURON, our most important dependency, see https://github.com/neuronsimulator/nrn/releases/tag/8.2.7

Note that this was built off of #1058, due to its reversion of the NEURON 8.2.6 version cap. This should only be merged after #1058 is merged.