### PR TITLE
[MRG] Bugfix: raise minimum opt iters for upstream deps

### DIFF
--- a/hnn_core/optimization/optimize_evoked.py
+++ b/hnn_core/optimization/optimize_evoked.py
@@ -510,7 +510,7 @@ def optimize_evoked(
         The initial dipole to start the optimization.
     maxiter : int
         The maximum number of simulations to run for optimizing
-        one "chunk".
+        one "chunk". Must be at least 12 or greater.
     timing_range_multiplier : float
         The scale of timing values to sweep over.
     sigma_range_multiplier : float
@@ -623,6 +623,11 @@ def optimize_evoked(
         if maxiter == 0:
             print("Skipping optimization step %d (0 simulations)" % (step + 1))
             continue
+        elif maxiter < 12:
+            print(
+                "'maxiter' must be at least 12 for optimization to run. Increasing 'maxiter' to 12."
+            )
+            maxiter = 12
 
         if opt_params["cur_step"] > 0 and opt_params["cur_step"] == total_steps - 1:
             # For the last step (all inputs), recalculate ranges and update

--- a/hnn_core/tests/test_optimize_evoked.py
+++ b/hnn_core/tests/test_optimize_evoked.py
@@ -160,7 +160,7 @@ def test_optimize_evoked():
         )
 
     which_drives = ["evprox1"]  # drive selected to optimize
-    maxiter = 10
+    maxiter = 12
     # try without returning iteration RMSE first
     net_opt = optimize_evoked(
         net_offset,


### PR DESCRIPTION
This is at least a temporary (possibly permanent) fix for a new bug causing our MacOS unit tests to fail. This bug is probably due to a change in upstream dependency changes in `scipy.optimize`, where the COBYLA solver now seems to require that the number of maximum iterations (MAXFUN) be `at least num_vars + 2`, where num_vars is the dimension size of the variables being "optimized over", which for `optimized_evoked` is at least 10. I will write a longer description of the issue elsewhere. For now, this can probably be merged, and it should allow current tests to pass.