### PR TITLE
[MRG] Fix package publishing to only use tags

### DIFF
--- a/.github/workflows/publish-packages-on-tag.yml
+++ b/.github/workflows/publish-packages-on-tag.yml
@@ -6,9 +6,6 @@ name: Publish Python 🐍 distribution package to PyPI and TestPyPI
 
 on:
   push:
-    branches:
-      # - '**'  # Useful for debugging
-      - master
     tags:
       - v*
 


### PR DESCRIPTION
This fixes what I believe is a new issue introduced through #1073. In the original PR, in the `on: push:` block, I included mention of the `master` branch and the glob for the `tags` we wanted, believing that they functioned in a Boolean AND sense. I.e., I assumed that I thought that both values had to be satisfied before the workflow would run. This appears to be incorrect: between `tags` and `branches` appears to function like a Boolean OR, meaning the publishing workflow is currently running on every push to `master`, OR every pushed tag matching the glob.

Instead, we only want the latter, i.e. the tag-specific case. This fixes the issue by removing any branch-based rules for the publishing workflow, instead making it entirely rely on version tags being pushed. Since we tend to push version tags only very rarely, this should work.

See here for an example of the OR vs AND:

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags