### PR TITLE
[WIP] Add template insertion for frontpage icon

### DIFF
--- a/doc/_templates/frontpage_icon.html
+++ b/doc/_templates/frontpage_icon.html
@@ -1,0 +1,14 @@
+<a href="https://hnn.brown.edu" class="home-link">
+    <div class="home-icon-container">
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24" 
+            height="24"
+            viewBox="0 0 24 24" 
+            class="home-icon">
+            <path
+                d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"
+            />
+        </svg>
+    </div>
+</a>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -144,7 +144,7 @@ html_theme_options = {
     "header_links_before_dropdown": 7,
     "navbar_align": "left",
     "navbar_start": ["navbar-logo"],
-    "navbar_center": ["navbar-nav"],
+    "navbar_center": ["frontpage_icon.html", "navbar-nav"],
     "navbar_end": ["version-switcher"],
     "pygments_dark_style": "monokai",
     "switcher": {


### PR DESCRIPTION
@dylansdaniels This adds an initial, successfully-working way for you to add the "home icon" icon-link to the Frontpage that we discussed. **I do not plan to add much more to this branch myself**, but you should push to it as needed to get the icon looking as you prefer.

This copies over the default (i.e. not dark mode) Home icon HTML from the Textbook website into its own HTML template. Since our `doc/conf.py` already makes use of `doc/_templates`, we can easily add anything in the templates into whichever part of our `navbar` that we want, as defined in `doc/conf.py`'s `html_theme_options` dict. This current location adds it to the "left" (or first) entry in the center portion of the navbar (`navbar_center`), but it may be worth trying it out as the second item in `navbar_start`. See here for guidance on the layout, including the navbar: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html 

This was figured out mostly from https://sphinx-book-theme.readthedocs.io/en/stable/sections/header.html .

Here's a screenshot of how it looks from a `make html-noplot` run:

![Screenshot 2025-06-23 at 4 57 12 PM](https://github.com/user-attachments/assets/75ac4706-b0a5-4ea5-9618-af0d3ba05f47)

It does *not* look great currently, because it's the light mode version of the icon, but on a website that is only available in "dark mode". It seems that our current Frontpage and Textbook use JS (maybe? CSS too) to transform the home icon, instead of replacing it with raw HTML. Therefore, I'm not sure how to get the exact dark mode version of our home icon from those websites into the current Sphinx template, but I figure you would know where to start.