### PR TITLE
[MRG] Include top-level venv in codespell ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=40.8.0", "NEURON >=7.7; platform_system != 'Windows'"]
 build-backend = "setuptools.build_meta:__legacy__"
 [tool.codespell]
-skip = '.git,*.pdf,*.svg,./hnn_core/mod,./doc/_build,./build'
+skip = '.git,*.pdf,*.svg,./hnn_core/mod,./doc/_build,./build,./venv'
 check-hidden = true
 # in jupyter notebooks - images and also some embedded outputs
 ignore-regex = '^\s*"image/\S+": ".*|.*%22%3A%20.*'


### PR DESCRIPTION
Useful for venv users like Maira to pass local codespell tests