### PR TITLE
[MRG] fix: remove linkcheck anchor check

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -236,8 +236,9 @@ intersphinx_mapping = {
 }
 intersphinx_timeout = 5
 
+linkcheck_anchors = False
+
 linkcheck_ignore = [
-    'https://github.com/mne-tools/mne-python/blob/148de1661d5e43cc88d62e27731ce44e78892951/mne/utils/misc.py#',
     'https://neuron.yale.edu/neuron',
     'https://doi.org/10.1152/jn.00535.2009',
     'https://doi.org/10.1152/jn.00122.2010',


### PR DESCRIPTION
This fixes a current bug that is causing the CircleCI doc builds to fail. It does by removing checking of link "anchors".

Problem:

TIL: Apparently, URL "anchors" such as the text after the # character in https://github.com/jonescompneurolab/hnn-core-conda-packaging?tab=readme-ov-file#how-to-use-this-repo-to-build-and-upload-the-packages are *not* processed the same as the rest of the URL. For example, as far as I can tell from reading related issues in https://github.com/sphinx-doc/sphinx/issues/9016 Github processes some/all of its anchors using javascript. This means that programs for checking the existence of URLs (like sphinx' linkcheck), which possibly don't involve running the javascript of Github, will return failures indicating that the URL doesn't exist, even if the URL does work when a user go to it *in their browser*.

For example, when using the default settings (where `linkcheck_anchors` is true), I get the following error in linkcheck, similar to what our CircleCI builds are doing now:

> (how_to_create_releases: line  235) broken    https://github.com/jonescompneurolab/hnn-core-conda-packaging?tab=readme-ov-file#how-to-use-this-repo-to-build-and-upload-the-packages - Anchor 'how-to-use-this-repo-to-build-and-upload-the-packages' not found

However, if one goes to that URL in their browser, both the URL and the anchor itself is valid.

This breaking-anchor behavior appears to the case with most, or all, of Github's URLs involving an anchor, including the currently-ignored link to an `mne-tools` Github code file line.

Solution:

However, because this is an ongoing issue with Sphinx' linkcheck (see the issue I mentioned earlier; there are many issues still dealing with the problem), and the fact that checking the existence of the anchors is much less important than checking the non-anchor URL (which is important), I think the best solution is to tell linkcheck to ignore anchors entirely. I've tested locally, and this seems to fix the existing linkcheck errors. This also also us to remove the particular `mne-tools` URL currently in our linkcheck ignore, because the anchor was the problem with that URL in the first place.