### PR TITLE
[WIP] Introducing layer_dict for cell coordinates

### DIFF
--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -5,14 +5,18 @@
 import os.path as op
 import hnn_core
 from hnn_core import read_params
-from .network import Network
+from .network import Network, _create_cell_coords
 from .params import _short_name
-from .cells_default import pyramidal_ca
+from .cells_default import pyramidal_ca, pyramidal, basket
 from .externals.mne import _validate_type
 
 
 def jones_2009_model(
-    params=None, add_drives_from_params=False, legacy_mode=False, mesh_shape=(10, 10)
+    params=None,
+    add_drives_from_params=False,
+    legacy_mode=False,
+    mesh_shape=(10, 10),
+    custom_positions=None,
 ):
     """Instantiate the network model described in Jones et al. 2009 [1]_
 
@@ -68,11 +72,39 @@ def jones_2009_model(
     if isinstance(params, str):
         params = read_params(params)
 
+    # Define cell types for Jones 2009 model
+    cell_types = {
+        "L2_basket": basket(cell_name=_short_name("L2_basket")),
+        "L2_pyramidal": pyramidal(cell_name=_short_name("L2_pyramidal")),
+        "L5_basket": basket(cell_name=_short_name("L5_basket")),
+        "L5_pyramidal": pyramidal(cell_name=_short_name("L5_pyramidal")),
+    }
+
+    # Create layer positions
+    layer_dict = _create_cell_coords(
+        n_pyr_x=mesh_shape[0],
+        n_pyr_y=mesh_shape[1],
+        zdiff=1307.4,  # Default layer separation
+        inplane_distance=1.0,  # Default in-plane distance
+    )
+
+    # Map cell types to layer positions
+    pos_dict = {
+        "L5_pyramidal": layer_dict["L5_bottom"],
+        "L2_pyramidal": layer_dict["L2_bottom"],
+        "L5_basket": layer_dict["L5_mid"],
+        "L2_basket": layer_dict["L2_mid"],
+        "origin": layer_dict["origin"],
+    }
+
+    # Create network with cell types and positions
     net = Network(
         params,
         add_drives_from_params=add_drives_from_params,
         legacy_mode=legacy_mode,
         mesh_shape=mesh_shape,
+        pos_dict=pos_dict,
+        cell_types=cell_types,
     )
 
     delay = net.delay


### PR DESCRIPTION
Hi!!

so this pull request is the first step towards refactoring the way cell positions and network structures are created and managed.

In this PR, the main change was the introduction of a `layer_dict` to provide a more structured and anatomically-based way of defining cell coordinates, moving away from the previous `pos_dict` implementation

-  In the function `_create_cell_coords` in `hnn_core/network.py`, main changes can be seen:
	- **In the current method**....It creates a `pos_dict` with keys like 'L2_pyramidal' and 'L5_pyramidal' and contained functions like `_calc_pyramidal_coord` and `_calc_basket_coord`
    
	- **What the PR proposes** .....It now returns a `layer_dict` with more descriptive keys representing anatomical layers, such as 'L5_bottom', 'L2_bottom', 'L5_mid', and 'L2_mid'.
		- this step is essential as it forms the basis of our future PRs which will build upon this to create metaData and custom position logic on top of these changes
    


The `Network` class constructor in `hnn_core/network.py` was also changed 

- It accepts`pos_dict` and `cell_types` as arguments during initialization. This allows for the future PR's for the creation of networks with custom cell arrangements and types, rather than being hard-coded.
    
- If no custom positions are provided, it falls back to a default mechanism that uses the new `layer_dict` to map cell types to their respective anatomical positionss.


some methods are being shown as green but there are exactly the same, just re-arranged in position they are placed at (`add_cell_type`,`_add_cell_type`,`add_spike_train_drive`)

The `jones_2009_model` in `hnn_core/network_models.py` was updated to use the new stuff

 - Defines the necessary `cell_types` and their templates.
    
- it uses `create_cell_coords` to get the anatomical `layer_dict`
	- maps these  to the appropriate cell types to create the `pos_dict`
    
- finally passes both `cell_types` and `pos_dict` to the `Network` constructor to build the model

for some context....
the work done till now was this:
Chunk 1: Centralizes all cell creation into a single factory that packages cell objects with their metadata.

Chunk 2: Enforces the consistent use of short cell names (like L5Pyr) across the entire codebase...it is contested for now

Chunk 3: Standardizes cell positioning to be generated from a layer_dict, allowing for optional custom overrides.

Chunk 4 (Metadata): Refactors all logic for connections, drives, and plotting to be driven by cell metadata instead of hardcoded type checks.

The PRs will be submitted in the order 3 → 1 → 2 → 4.
(depending on decision to keep chunk 2 or not)

This order is based on dependencies: we start with the most independent chunk (Chunk 3) and finish with the most dependent chunk (Chunk 4), which relies on all the others being complete.