### PR TITLE
[MRG] fix: add a DOI to linkcheck ignore

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -56,7 +56,7 @@ linkcheck:
 	@$(SPHINXBUILD) -b linkcheck -D nitpicky=0 -D plot_gallery=0 -d _build/doctrees . _build/linkcheck
 
 linkcheck-all:
-	@$(SPHINXBUILD) -b linkcheck -D nitpicky=0 -D plot_gallery=0 -D linkcheck_ignore='https://doi.org/10.1152/jn.00535.2009','https://doi.org/10.1152/jn.00122.2010','https://doi.org/10.1101/2021.04.16.440210','(http|https):\/\/localhost:\d+' -d _build/doctrees . _build/linkcheck
+	@$(SPHINXBUILD) -b linkcheck -D nitpicky=0 -D plot_gallery=0 -D linkcheck_ignore='https://doi.org/10.1152/jn.00535.2009','https://doi.org/10.1152/jn.00122.2010','https://doi.org/10.1101/2021.04.16.440210','https://doi.org/10.7554/eLife.51214','(http|https):\/\/localhost:\d+' -d _build/doctrees . _build/linkcheck
 
 view:
 	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/_build/html/index.html')"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -243,6 +243,7 @@ linkcheck_ignore = [
     'https://doi.org/10.1152/jn.00535.2009',
     'https://doi.org/10.1152/jn.00122.2010',
     'https://doi.org/10.1101/2021.04.16.440210',
+    'https://doi.org/10.7554/eLife.51214',
     'https://groups.google.com/g/hnnsolver',
     r'(http|https):\/\/localhost:\d+',
     r'(http|https):\/\/github\.com\/jonescompneurolab\/hnn-core\/(issues|pull)\/\d+',


### PR DESCRIPTION
For some reason, recent linkchecks with this DOI have been failing, even though (I'm not 100% sure) it was working fine before. This change simply adds this particular publication DOI link to both linkcheck ignore lists.

Example failing can be found here: https://github.com/jonescompneurolab/hnn-core/actions/runs/17408169238/job/49423224430#step:5:486 