### PR TITLE
[MRG] tiny: ignore all "venv" for codespell

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=40.8.0", "NEURON >=7.7; platform_system != 'Windows'"]
 build-backend = "setuptools.build_meta:__legacy__"
 [tool.codespell]
-skip = '.git,*.pdf,*.svg,./hnn_core/mod,./doc/_build,./build,./venv'
+skip = '.git,*.pdf,*.svg,./hnn_core/mod,./doc/_build,./build,*venv*'
 check-hidden = true
 # in jupyter notebooks - images and also some embedded outputs
 ignore-regex = '^\s*"image/\S+": ".*|.*%22%3A%20.*'


### PR DESCRIPTION
This is a very tiny config change: this tells codespell to ignore all directories and files matching the glob `*venv*`. This way, any local virtual environment that includes the string "venv" such as at `my-venv` or `.venv` will be ignored from codespell, which usually finds errors in the files of the venvs.

This is useful in part because, *soon*, we will be able to have full-feature HNN installs possible through venvs alone, without `conda`...