### PR TITLE
doc: tiny: update NEURON URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ studying the circuit-level origin of some of the most commonly measured MEG/EEG 
 signals: event related potentials (ERPs) and low-frequency rhythms (alpha/beta/gamma).
 
 The HNN API, written in Python and built on top of
-[NEURON](https://www.neuron.yale.edu/neuron/), is designed to be flexible and serve
+[NEURON](https://nrn.readthedocs.io), is designed to be flexible and serve
 users with varying levels of coding expertise, while the [HNN
 GUI](https://jonescompneurolab.github.io/textbook/content/04_using_hnn_gui/gui_quickstart.html)
 is designed to be useful to researchers with no formal computational neural modeling or

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -162,6 +162,8 @@ def _simulate_single_trial(net, tstop, dt, trial_idx):
 def _is_loaded_mechanisms():
     # copied from:
     # https://www.neuron.yale.edu/neuron/static/py_doc/modelspec/programmatic/mechtype.html
+    # For newer version of the same documenation, see
+    # https://nrn.readthedocs.io/en/8.2.7/hoc/modelspec/programmatic/mechtype.html
     mt = h.MechanismType(0)
     mname = h.ref("")
     mnames = list()


### PR DESCRIPTION
This makes two very tiny changes: it changes (or appends to) existing links to the old URL of the NEURON website, https://www.neuron.yale.edu , and swaps/adds links to the new main NEURON site at https://nrn.readthedocs.io . The latter is the new location of the main NEURON website according to
https://github.com/neuronsimulator/nrn/issues/3602#issuecomment-3299864426