### PR TITLE
[MRG] fix: enable backwards-compatible hier JSON

### DIFF
--- a/hnn_core/hnn_io.py
+++ b/hnn_core/hnn_io.py
@@ -120,13 +120,46 @@ def _read_cell_types(cell_types_data):
             "cell_object" in cell_types_data[cell_name]
             and "cell_metadata" in cell_types_data[cell_name]
         ):
-            # New format: extract cell properties from nested "cell_object"
+            # Format post-commit-6388f9f:
+            #   Extract cell properties from nested "cell_object"
             cell_data = cell_types_data[cell_name]["cell_object"]
             cell_metadata = cell_types_data[cell_name]["cell_metadata"]
         else:
-            # Legacy format, treat the entire cell_data as the cell information
+            # Format pre-commit-6388f9f:
+            #   Treat the entire cell_data as the cell information
             cell_data = cell_types_data[cell_name]
-            cell_metadata = {}
+            if cell_name == "L2_basket":
+                cell_metadata = {
+                    "morpho_type": "basket",
+                    "electro_type": "inhibitory",
+                    "layer": "2",
+                    "measure_dipole": False,
+                    "reference": "https://doi.org/10.7554/eLife.51214",
+                }
+            elif cell_name == "L2_pyramidal":
+                cell_metadata = {
+                    "morpho_type": "pyramidal",
+                    "electro_type": "excitatory",
+                    "layer": "2",
+                    "measure_dipole": True,
+                    "reference": "https://doi.org/10.7554/eLife.51214",
+                }
+            elif cell_name == "L5_basket":
+                cell_metadata = {
+                    "morpho_type": "basket",
+                    "electro_type": "inhibitory",
+                    "layer": "5",
+                    "measure_dipole": False,
+                    "reference": "https://doi.org/10.7554/eLife.51214",
+                }
+            elif cell_name == "L5_pyramidal":
+                cell_metadata = {
+                    "morpho_type": "pyramidal",
+                    "electro_type": "excitatory",
+                    "layer": "5",
+                    "measure_dipole": True,
+                    "reference": "https://doi.org/10.7554/eLife.51214",
+                }
 
         # Now cell_data contains the cell properties regardless of format
         sections = dict()

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -1,11 +1,14 @@
 # Authors: George Dang <george_dang@brown.edu>
 #          Rajat Partani <rajatpartani@gmail.com>
 
+import json
+import os.path as op
 from pathlib import Path
 from time import sleep
-import pytest
+from urllib.request import urlretrieve
+
 import numpy as np
-import json
+import pytest
 
 from hnn_core import (
     simulate_dipole,
@@ -372,3 +375,21 @@ def test_network_serialization_metadata(jones_2009_network, tmp_path):
     assert "cell_object" in net_loaded.cell_types["L2_pyramidal"]
     assert "cell_metadata" in net_loaded.cell_types["L2_pyramidal"]
     assert net_loaded.cell_types["L2_pyramidal"]["cell_metadata"]["layer"] == "2"
+
+
+def test_read_run_tutorial_json():
+    """Test that the first tutorial Network for ERP can be loaded and ran without error."""
+    net_url = (
+        "https://raw.githubusercontent.com/jonescompneurolab/"
+        "hnn-data/refs/heads/main/"
+        "network-configurations/ERPYes100Trials.json"
+    )
+    net_fname = op.join(hnn_core_root, "param", "ERPYes100Trials.json")
+    if not op.exists(net_fname):
+        urlretrieve(net_url, net_fname)
+
+    # Test that Network can be created without error.
+    net = read_network_configuration(net_fname)
+
+    # Test that Network can be simulated without error.
+    _ = simulate_dipole(net, tstop=2, n_trials=1, dt=0.5)


### PR DESCRIPTION
This fixes an important, existing bug where backwards compatibility was accidentally broken with our Network object metadata change in https://github.com/jonescompneurolab/hnn-core/commit/6388f9f7c74f4943a1d9b06e9ae69314500913df

Essentially, because the `dipole_cell_types` in `network_builder.py` were updated to only use celltypes with the metadata flag `measure_dipole` here:
https://github.com/jonescompneurolab/hnn-core/commit/6388f9f7c74f4943a1d9b06e9ae69314500913df#diff-d6779b4e41d308a520f1e1a25957f876b38048b169e81754dbd34798fe9798aeR112-R115

BUT, prior versions of the hierarchical JSON Network files were not having their `cell_metadata` populated here:

github.com/jonescompneurolab/hnn-core/commit/6388f9f7c74f4943a1d9b06e9ae69314500913df#diff-c5cd599377b4cc9a814e360206d53b51279f0844392c1de9c39e558c627f3b0bR129

This lead to the case where older hierarchical JSON files such as https://github.com/jonescompneurolab/hnn-data/blob/main/network-configurations/ERPYes100Trials.json could be loaded, but after simulation time, their Dipole data would not be saved or created correctly, since they were missing the appropriate metadata. This meant that, such in our ERP tutorial located here https://jonescompneurolab.github.io/textbook/content/05_erps/erps_in_gui.html when a user loaded and ran the first network "ERPYes100Trials.json", it would (falsely) load and simulate without issue, but at the end of the simulation there would be something like the following error output:

```
Traceback (most recent call last):
  File "<redacted>/rep/brn/pbrn02-hnn-sw-dev-wurk/runscripts/d_read_network_configuration.py", line 13, in <module>
    dpl = simulate_dipole(net, tstop=110., n_trials=1)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<redacted>/rep/brn/hnn-core/hnn_core/dipole.py", line 128, in simulate_dipole
    dpls = _BACKEND.simulate(net, tstop, dt, n_trials, postproc)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<redacted>/rep/brn/hnn-core/hnn_core/parallel_backends.py", line 1006, in simulate
    dpls = _gather_trial_data(sim_data, net, n_trials, postproc)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<redacted>/rep/brn/hnn-core/hnn_core/parallel_backends.py", line 70, in _gather_trial_data
    dpl._baseline_renormalize(N_pyr_x, N_pyr_y)  # XXX cf. #270
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<redacted>/rep/brn/hnn-core/hnn_core/dipole.py", line 710, in _baseline_renormalize
    self.data["L2"] -= dpl_offset["L2"]
    ~~~~~~~~~^^^^^^
KeyError: 'L2'
```

Additionally, there would be no output Dipole data plot, since the L2 and L5 dipole data time series had not been found, due to the missing metadata.

This commit/PR fixes this issue, AND it introduces a new test for this situation: the new test downloads a copy of the same hierarhical JSON Network file used in this exact tutorial from the `hnn-data` repo (unless the file already exists), then attempts to load it as a Network and then run a simulation with it. This test will need to be changed if the file location is ever updated, but since this is the first Network file that users are likely to use if they are following our first and most important GUI tutorial (the one for ERPs), this is a good Network file to test.