### PR TITLE
maint: bump post-release version to v0.4.4.dev0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,9 +33,9 @@ author = 'HNN Developers'
 # -- Version handling --------------------------------------------------------
 
 # The short X.Y version
-version = '0.4.3'
+version = '0.4.4.dev0'
 # The full version, including alpha/beta/rc tags
-release = '0.4.3'
+release = '0.4.4.dev0'
 
 ### HTML theme version control
 # If you are making a stable release, then you should add entries to the file

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -26,13 +26,23 @@ merged into `master`! Use `git log` instead and cross-reference instead. -->
 
 <!-- ### Changelog -->
 
-## 0.4.3 Patch Notes
+## 0.4.4 In-progress Development Notes
 
 <!-- ### New Features -->
 
 <!-- ### Deprecations -->
 
 <!-- ### Upcoming Deprecations -->
+
+<!-- ### Bug Fixes -->
+
+<!-- ### Public API Changes -->
+
+<!-- ### People who contributed to this release (in alphabetical order of family name): -->
+
+<!-- ### Changelog -->
+
+## 0.4.3 Patch Notes
 
 Please note that not all updates since 0.4.2 are documented here, since this is an
 emergency patch release. All work done since 0.4.2 will be properly documented for the

--- a/hnn_core/__init__.py
+++ b/hnn_core/__init__.py
@@ -19,4 +19,4 @@ from .hnn_io import (
     write_network_configuration,
 )
 
-__version__ = "0.4.3"
+__version__ = "0.4.4.dev0"


### PR DESCRIPTION
All testing of the new v0.4.3 source, PyPI packages, and Conda package has been successful. Bumping version to return back to development mode.