### PR TITLE
[WIP] Sync PSD Axes

### DIFF
--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -28,6 +28,16 @@ merged into `master`! Use `git log` instead and cross-reference instead. -->
 
 ## 0.5.1.dev0 In-progress Development Changes
 
+### People who contributed to this release:
+
+- [Karthikeya Kodlai][]
+
+### Changelog
+
+- Add support for syncing the y-axes limits of multi-layer PSD plots in the GUI, along
+  with some refactoring of the same code,
+  by [Karthikeya Kodlai][] in {gh}`1162`.
+
 ## 0.5.0 Release Notes
 
 ### New Features
@@ -1245,3 +1255,4 @@ v0.4 represents a major milestone in development of `hnn_core` and the HNN ecosy
 [Maira Usman]: https://github.com/Myrausman
 [Chetan Kandpal]: https://github.com/Chetank99
 [NEURON]: https://nrn.readthedocs.io
+[Karthikeya Kodlai]: https://github.com/sketch123456

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -319,48 +319,48 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
                 invert_spike_types=distal_drives,
                 color=drive_colors,
             )
-
-    elif plot_type == "PSD":
+            
+    elif plot_type in ["PSD", "layer2/3 PSD", "layer5 PSD"]:
         if len(dpls_copied) > 0:
             min_f = plot_config["min_spectral_frequency"]
             max_f = plot_config["max_spectral_frequency"]
             color = ax._get_lines.get_next_color()
-            label = sim_name + " (Aggregate)"
-            dpls_copied[0].plot_psd(
-                fmin=min_f, fmax=max_f, color=color, label=label, ax=ax, show=False
-            )
+            
+            layer_label = {
+                "PSD": "Aggregate",
+                "layer2/3 PSD": "Layer 2/3",
+                "layer5 PSD": "Layer 5",
+            }[plot_type]
+            label = f"{sim_name} ({layer_label})"
 
-    elif plot_type == "layer2/3 PSD":
-        if len(dpls_copied) > 0:
-            min_f = plot_config["min_spectral_frequency"]
-            max_f = plot_config["max_spectral_frequency"]
-            color = ax._get_lines.get_next_color()
-            label = sim_name + " (Layer 2/3)"
+            layer = {
+                "PSD" : "agg",
+                "layer2/3 PSD": "L2",
+                "layer5 PSD": "L5",
+            }[plot_type]
+
             dpls_copied[0].plot_psd(
-                fmin=min_f,
-                fmax=max_f,
-                layer="L2",
-                color=color,
-                label=label,
                 ax=ax,
                 show=False,
-            )
-
-    elif plot_type == "layer5 PSD":
-        if len(dpls_copied) > 0:
-            min_f = plot_config["min_spectral_frequency"]
-            max_f = plot_config["max_spectral_frequency"]
-            color = ax._get_lines.get_next_color()
-            label = sim_name + " (Layer 5)"
-            dpls_copied[0].plot_psd(
-                fmin=min_f,
-                fmax=max_f,
-                layer="L5",
                 color=color,
                 label=label,
-                ax=ax,
-                show=False,
+                fmin=min_f,
+                fmax=max_f,
+                layer=layer,
             )
+
+            if not hasattr(fig, "_psd_axes"):
+                fig._psd_axes = []
+                fig._psd_max_values = []
+
+            y_max = ax.get_ylim()[1]
+            fig._psd_axes.append(ax)
+            fig._psd_max_values.append(y_max)
+
+            if len(fig._psd_axes) > 1:
+                global_y_max = max(fig._psd_max_values)
+                for psd_ax in fig._psd_axes:
+                    psd_ax.set_ylim(top=global_y_max)
 
     elif plot_type == "spectrogram":
         if len(dpls_copied) > 0:

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -319,22 +319,22 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
                 invert_spike_types=distal_drives,
                 color=drive_colors,
             )
-            
+
     elif plot_type in ["PSD", "layer2/3 PSD", "layer5 PSD"]:
         if len(dpls_copied) > 0:
             min_f = plot_config["min_spectral_frequency"]
             max_f = plot_config["max_spectral_frequency"]
             color = ax._get_lines.get_next_color()
-            
+
             layer_label = {
-                "PSD": "Aggregate",
-                "layer2/3 PSD": "Layer 2/3",
-                "layer5 PSD": "Layer 5",
+                "PSD": "(Aggregate)",
+                "layer2/3 PSD": "(Layer 2/3)",
+                "layer5 PSD": "(Layer 5)",
             }[plot_type]
-            label = f"{sim_name} ({layer_label})"
+            label = f"{sim_name} {layer_label}"
 
             layer = {
-                "PSD" : "agg",
+                "PSD": "agg",
                 "layer2/3 PSD": "L2",
                 "layer5 PSD": "L5",
             }[plot_type]
@@ -348,19 +348,6 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
                 fmax=max_f,
                 layer=layer,
             )
-
-            if not hasattr(fig, "_psd_axes"):
-                fig._psd_axes = []
-                fig._psd_max_values = []
-
-            y_max = ax.get_ylim()[1]
-            fig._psd_axes.append(ax)
-            fig._psd_max_values.append(y_max)
-
-            if len(fig._psd_axes) > 1:
-                global_y_max = max(fig._psd_max_values)
-                for psd_ax in fig._psd_axes:
-                    psd_ax.set_ylim(top=global_y_max)
 
     elif plot_type == "spectrogram":
         if len(dpls_copied) > 0:
@@ -1027,14 +1014,13 @@ def _postprocess_template(template_name, fig, idx, use_ipympl=True, widgets=None
     this function. For example, L2 and L5 dipole plots should have the same
     y-axis range.
     """
-    if template_name not in ["Dipole Layers (3x1)"]:
+    if template_name not in ["Dipole Layers (3x1)", "PSD Layers (3x1)"]:
         return
 
-    if template_name == "Dipole Layers (3x1)":
-        # Make the L2, L5, and aggregate plots use the same y-range
-        y_lims_list = [ax.get_ylim() for ax in fig.axes]
-        y_lims = (np.min(y_lims_list), np.max(y_lims_list))
-        [ax.set_ylim(y_lims) for ax in fig.axes]
+    # Make the L2, L5, and aggregate plots use the same y-range
+    y_lims_list = [ax.get_ylim() for ax in fig.axes]
+    y_lims = (np.min(y_lims_list), np.max(y_lims_list))
+    [ax.set_ylim(y_lims) for ax in fig.axes]
 
     # Re-render
     if not use_ipympl:


### PR DESCRIPTION
This is concerning issue #1049

Currently, PSD layer plots (`PSD`, `layer2/3 PSD`, `layer5 PSD`) in the GUI display each layer on independent y-axes. This can be misleading, as L2/3 contributions may appear visually comparable to L5 or aggregate even when their magnitudes differ by orders of magnitude. This PR updates the `_update_ax` function in `hnn_core/gui/_viz_manager.py` to:

1. Collect all PSD axes in `fig._psd_axes`
2. After plotting, synchronize the y-axis limits across all PSD layer subplots.
3. Ensure that legends display correctly for each layer.