### PR TITLE
[WIP] Adjusting axis labels of LFP and CSD plots

### DIFF
--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -104,8 +104,8 @@ def plot_laminar_lfp(
         Sampling times (in ms).
     data : Two-dimensional Numpy array
         The extracellular voltages as an (n_contacts, n_times) array.
-    ax : instance of matplotlib figure | None
-        The matplotlib axis
+    ax : instance of matplotlib figure, optional
+        The matplotlib axis. By default, None. 
     decim : int | list of int | None (default)
         Optional (integer) factor by which to decimate the raw dipole traces.
         The SciPy function :func:`~scipy.signal.decimate` is used, which
@@ -117,12 +117,12 @@ def plot_laminar_lfp(
         defined as an RGBA-quadruplet, or an array of RGBA-values (one for each
         electrode contact trace to plot). An instance of
         :class:`~matplotlib.colors.ListedColormap` may also be provided.
-    voltage_offset : float | None (optional)
+    voltage_offset : float, default = 50
         Amount to offset traces by on the voltage-axis. Useful for plotting
-        laminar arrays.
-    voltage_scalebar : float | None (optional)
+        laminar arrays. By default, 50 uV. 
+    voltage_scalebar : float, default = 200
         Height, in units of uV, of a scale bar to plot in the top-left corner
-        of the plot.
+        of the plot. By default, 200 uV. 
     contact_labels : list
         Labels associated with the contacts to plot. Passed as-is to
         :func:`~matplotlib.axes.Axes.set_yticklabels`.
@@ -216,7 +216,7 @@ def plot_laminar_lfp(
             ax.set_xlim(left=times[0], right=times[-1])
     if voltage_offset is not None:
         ax.set_ylim(-voltage_offset, n_offsets * voltage_offset)
-        ylabel = "Individual contact traces"
+        ylabel = "Individual contact traces \n at depth [um]"
         if len(contact_labels) != n_offsets:
             raise ValueError(
                 f"contact_labels is length {len(contact_labels)},"
@@ -227,7 +227,7 @@ def plot_laminar_lfp(
                 0, len(contact_labels) * voltage_offset, voltage_offset
             )
             ax.set_yticks(trace_ticks)
-            ax.set_yticklabels(contact_labels)
+            ax.set_yticklabels([lbl if i % 3 == 0 else "" for i, lbl in enumerate(contact_labels)])
 
         if voltage_scalebar is None:
             voltage_scalebar = voltage_offset
@@ -1857,7 +1857,7 @@ def plot_laminar_csd(
         times, new_depths, data, cmap=cmap, shading="auto", vmin=vmin, vmax=vmax
     )
     ax.set_xlabel("time (s)")
-    ax.set_ylabel("electrode depth")
+    ax.set_ylabel("electrode depth [um]")
     if colorbar:
         color_axis = ax.inset_axes([1.05, 0, 0.02, 1], transform=ax.transAxes)
         plt.colorbar(im, ax=ax, cax=color_axis).set_label(r"$CSD (uV/um^{2})$")


### PR DESCRIPTION
As described in #1167, the LFP and CSD plots should be adjusted to include units. Additionally, because the LFP plot has too many labels on the y-axis, I set the label to `Individual contact traces \n at depth [um]` and adjusted the `plot_laminar_lfp()` function to display y-axis labels on every third ticklabel. I also adjusted the documentation. 

I included a screenshot of what the new plot looks like on some pseudodata. 
<img width="1708" height="777" alt="image" src="https://github.com/user-attachments/assets/fe26f1b6-dbf8-40b0-9472-4f6db74a5d5d" />
