### PR TITLE
[WIP]: Fix GUI error visibility by displaying new messages at bottom

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -196,7 +196,7 @@ class _OutputWidgetHandler(logging.Handler):
             "output_type": "stream",
             "text": formatted_record + "\n",
         }
-        self.out.outputs = (new_output,) + self.out.outputs
+        self.out.outputs = self.out.outputs + (new_output,)
 
 
 class _GUI_PrintToLogger:


### PR DESCRIPTION
- Changed _OutputWidgetHandler.emit() to append new messages to the end
- This ensures errors and new log messages appear at the bottom where they're more visible
- Fixes issue where errors could be hidden when appearing at the top of log window

Fixes: GUI error visibility issue