### PR TITLE
[MRG] GUI add and test "smart" loading of global gains

### DIFF
--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -4384,7 +4384,7 @@ def add_network_connectivity_tab(
     ### Global synaptic gains
     # ---------------------------------------------------------------
     global_gain_out.clear_output()
-    gain_types = ("e_e", "e_i", "i_e", "i_i")
+    gui_global_gain_types = ("e_e", "e_i", "i_e", "i_i")
 
     # Do "smart" loading of the synaptic gains, where custom global gains are
     # "extracted" from the network and displayed in the "global gains" parts of the GUI,
@@ -4395,11 +4395,11 @@ def add_network_connectivity_tab(
     if _check_global_synaptic_gains_uniformity(net):
         # If the check passes, then we can faithfully rely on the getter function to get
         # the global gain of each class, including the non-default ones.
-        gain_values = net.get_global_synaptic_gains()
-        if not np.allclose(1.0, list(gain_values.values())):
+        gui_global_gain_values = net.get_global_synaptic_gains()
+        if not np.allclose(1.0, list(gui_global_gain_values.values())):
             # If any of the global gain classes use a non-default value, then reset it
             # in the Network to the default, since we're ONLY going to keep the "state"
-            # of that global gain value in the GUI via `gain_values` (until the GUI
+            # of that global gain value in the GUI via `gui_global_gain_values` (until the GUI
             # later creates a new Network).
             #
             # Apparently can't just pass a dictionary...
@@ -4416,14 +4416,14 @@ def add_network_connectivity_tab(
         # default rather than show non-default values which are not correct (since they
         # don't hold to the uniformity assumption). The individual, single gains that
         # are displayed later in the accordion should be accurate and up-to-date.
-        gain_values = {type: 1.0 for type in gain_types}
+        gui_global_gain_values = {type: 1.0 for type in gui_global_gain_types}
 
     # Same as _get_connectivity_widgets
     style = {"description_width": "100px"}
 
-    for gain_type in gain_types:
+    for gain_type in gui_global_gain_types:
         gain_widget = BoundedFloatText(
-            value=gain_values[gain_type],
+            value=gui_global_gain_values[gain_type],
             description=f"{global_gain_type_display_dict[gain_type]}",
             min=0,
             max=1e6,

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -54,7 +54,7 @@ from hnn_core.dipole import _read_dipole_txt, average_dipoles
 from hnn_core.gui._logging import logger
 from hnn_core.gui._viz_manager import _idx2figname, _VizManager
 from hnn_core.hnn_io import dict_to_network, write_network_configuration
-from hnn_core.network import pick_connection
+from hnn_core.network import pick_connection, _check_global_synaptic_gains_uniformity
 from hnn_core.optimization import Optimizer, generate_opt_history_table
 from hnn_core.parallel_backends import (
     _determine_cores_hwthreading,
@@ -4384,8 +4384,39 @@ def add_network_connectivity_tab(
     ### Global synaptic gains
     # ---------------------------------------------------------------
     global_gain_out.clear_output()
-    gain_values = net.get_global_synaptic_gains()
     gain_types = ("e_e", "e_i", "i_e", "i_i")
+
+    # Do "smart" loading of the synaptic gains, where custom global gains are
+    # "extracted" from the network and displayed in the "global gains" parts of the GUI,
+    # not the individual. This requires overwriting the "global gains" of the Network
+    # itself, since the only "state" that contains the global gain information will be
+    # the GUI itself! (This is because the Network can only store one gain value per
+    # connection, but the GUI offers multiple ways to change gains...).
+    if _check_global_synaptic_gains_uniformity(net):
+        # If the check passes, then we can faithfully rely on the getter function to get
+        # the global gain of each class, including the non-default ones.
+        gain_values = net.get_global_synaptic_gains()
+        if not np.allclose(1.0, list(gain_values.values())):
+            # If any of the global gain classes use a non-default value, then reset it
+            # in the Network to the default, since we're ONLY going to keep the "state"
+            # of that global gain value in the GUI via `gain_values` (until the GUI
+            # later creates a new Network).
+            #
+            # Apparently can't just pass a dictionary...
+            net.set_global_synaptic_gains(
+                e_e=1.0,
+                e_i=1.0,
+                i_e=1.0,
+                i_i=1.0,
+            )
+    else:
+        # If the check does NOT pass, then "all bets are off": the user will have
+        # received a warning in the log window that the gains are NOT uniform within
+        # their class. To be safe, it is better to set all the global values to their
+        # default rather than show non-default values which are not correct (since they
+        # don't hold to the uniformity assumption). The individual, single gains that
+        # are displayed later in the accordion should be accurate and up-to-date.
+        gain_values = {type: 1.0 for type in gain_types}
 
     # Same as _get_connectivity_widgets
     style = {"description_width": "100px"}

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -223,14 +223,20 @@ def test_gui_upload_connectivity():
     assert gui.connectivity_widgets[0][0].children[1].children[0].value == 0.01
 
 
-def test_gui_smart_gains_upload_connectivity():
+def test_gui_smart_gains_upload_connectivity(setup_gui):
     """Test if gui 'smartly' handles upload of Network with non-default global gains."""
-    gui = HNNGUI()
-    _ = gui.compose()
+    logger = logging.getLogger("hnn_gui")
+
+    # gui = HNNGUI()
+    # _ = gui.compose()
+    gui = setup_gui
+
+    global_gain_test_value_1 = 1.2
+    global_gain_test_value_2 = 0.9
 
     # Let's set some custom global gains
-    gui.global_gain_widgets["i_e"].value = 1.2
-    gui.global_gain_widgets["i_i"].value = 0.9
+    gui.global_gain_widgets["i_e"].value = global_gain_test_value_1
+    gui.global_gain_widgets["i_i"].value = global_gain_test_value_2
 
     # We need to run a simulation in order to download a Network
     sim_name = "sim1"
@@ -240,12 +246,16 @@ def test_gui_smart_gains_upload_connectivity():
     gui.widget_backend_selection.value = "Joblib"
     gui.widget_ntrials.value = 1
     gui.run_button.click()
+    net1 = gui.data["simulation_data"][sim_name]["net"]
 
+    # First, in the case of "uniform gains", let's check that smart gains correctly
+    # updates only the GUI global gain values AND resets the network's SINGLE gain
+    # values back to default:
+    # ----------------------------------------------------------------------------------
     with tempfile.TemporaryDirectory() as tmp_dir:
         # Get network from data dictionary and save it to temporary file
-        net = gui.data["simulation_data"][sim_name]["net"]
         file1_path = Path(tmp_dir) / "custom_global_gains.json"
-        write_network_configuration(net, file1_path)
+        write_network_configuration(net1, file1_path)
 
         # Set the GUI global gains back to defaults
         gui.global_gain_widgets["i_e"].value = 1.0
@@ -254,18 +264,83 @@ def test_gui_smart_gains_upload_connectivity():
         gui._simulate_upload_connectivity(file1_path)
 
     # Check that our GUI global gains are "smartly" loaded properly
-    assert gui.global_gain_widgets["i_e"].value == 1.2
-    assert gui.global_gain_widgets["i_i"].value == 0.9
+    assert gui.global_gain_widgets["i_e"].value == global_gain_test_value_1
+    assert gui.global_gain_widgets["i_i"].value == global_gain_test_value_2
 
     # Finally, check that the GUI single gain for one of the synapses affected is NOT
     # the changed value, but instead the default:
     conn_widget = _conn_widget_lookup(gui, "L2_basket", "L2_pyramidal")
-    single_gain_widget = conn_widget.children[2].children[0]
-    assert single_gain_widget.value == 1.0
+    assert conn_widget.children[2].children[0].value == 1.0
 
     conn_widget = _conn_widget_lookup(gui, "L2_basket", "L2_basket")
-    single_gain_widget = conn_widget.children[2].children[0]
-    assert single_gain_widget.value == 1.0
+    assert conn_widget.children[2].children[0].value == 1.0
+
+    # Second, in the case of NOT "uniform gains", let's check that smart gains correctly
+    # keeps the network's single gains, but does NOT change the GUI widgets from
+    # default, and provides a warning:
+    # ----------------------------------------------------------------------------------
+    single_gain_test_value_1 = 1.35
+    single_gain_test_value_2 = 0.75
+
+    conn_widget = _conn_widget_lookup(gui, "L2_basket", "L2_pyramidal")
+    conn_widget.children[2].children[0].value = single_gain_test_value_1
+
+    conn_widget = _conn_widget_lookup(gui, "L2_basket", "L2_basket")
+    conn_widget.children[2].children[0].value = single_gain_test_value_2
+
+    # We need to run a simulation in order to download a Network
+    sim_name = "sim2"
+    gui.widget_simulation_name.value = sim_name
+    gui.widget_tstop.value = 70
+    gui.widget_dt.value = 0.5
+    gui.widget_backend_selection.value = "Joblib"
+    gui.widget_ntrials.value = 1
+    gui.run_button.click()
+    net2 = gui.data["simulation_data"][sim_name]["net"]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Get network from data dictionary and save it to temporary file
+        file1_path = Path(tmp_dir) / "custom_global_gains_nonuniform.json"
+        write_network_configuration(net2, file1_path)
+
+        # Set the GUI global gains back to defaults
+        gui.global_gain_widgets["i_e"].value = 1.0
+        gui.global_gain_widgets["i_i"].value = 1.0
+
+        gui._simulate_upload_connectivity(file1_path)
+
+    # Check that our GUI global gains are NOT loaded by the file, but instead default
+    assert gui.global_gain_widgets["i_e"].value == 1.0
+    assert gui.global_gain_widgets["i_i"].value == 1.0
+
+    def _final_gain_compute(global_gain, single_gain):
+        """Our algorithm for using the single and global gains is like this:
+
+        ```
+        final = 1 + (<global_gain_value> - 1) + (<single_gain_widget>.value - 1)
+        ```
+        Source here:
+        https://github.com/jonescompneurolab/hnn-core/blob/0fdd2638d786e1f69dd3bf7f8fdae586b7022e84/hnn_core/gui/gui.py#L4766-L4768
+        """
+        return 1 + (global_gain - 1) + (single_gain - 1)
+
+    # Finally, check that the GUI single gain for one of the synapses affected is NOT
+    # the changed value, but instead the default:
+    conn_widget = _conn_widget_lookup(gui, "L2_basket", "L2_pyramidal")
+    assert np.isclose(
+        conn_widget.children[2].children[0].value,
+        _final_gain_compute(global_gain_test_value_1, single_gain_test_value_1),
+    )
+
+    conn_widget = _conn_widget_lookup(gui, "L2_basket", "L2_basket")
+    assert np.isclose(
+        conn_widget.children[2].children[0].value,
+        _final_gain_compute(global_gain_test_value_2, single_gain_test_value_2),
+    )
+
+    logs = [msg["text"] for msg in gui._log_out.outputs]
+    compiled_log_text = "\n".join(logs)
+    assert "uses custom synaptic gain values" in compiled_log_text
 
     plt.close("all")
 

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -5,15 +5,19 @@ import codecs
 import io
 import json
 import logging
+import os
+import tempfile
+import time
+from pathlib import Path
+from urllib.request import urlretrieve
+
+from IPython.display import IFrame
+from ipywidgets import Tab, Text, link
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-import os
 import pytest
-import time
 import traitlets
-from pathlib import Path
-from urllib.request import urlretrieve
 
 from hnn_core import Dipole, Network, simulate_dipole
 from hnn_core.gui import HNNGUI
@@ -35,9 +39,8 @@ from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
 from hnn_core.hnn_io import (
     dict_to_network,
     read_network_configuration,
+    write_network_configuration,
 )
-from IPython.display import IFrame
-from ipywidgets import Tab, Text, link
 
 matplotlib.use("agg")
 hnn_core_root = Path(__file__).parents[1]
@@ -51,6 +54,22 @@ def setup_gui():
     gui.widget_dt.value = 0.5  # speed up tests
     gui.widget_tstop.value = 70  # speed up tests
     return gui
+
+
+def _conn_widget_lookup(gui, src_type, target_type):
+    """Convenience function for searching the connectivity accordion."""
+    conn_widget = None
+    for connectivity_field in gui.connectivity_widgets:
+        for widget in connectivity_field:
+            if (
+                widget._belongsto["src_gids"] == src_type
+                and widget._belongsto["target_gids"] == target_type
+            ):
+                conn_widget = widget
+                break
+        if conn_widget is not None:
+            break
+    return conn_widget
 
 
 def check_equal_networks(net1, net2):
@@ -202,6 +221,51 @@ def test_gui_upload_connectivity():
     # Load drives and make sure connectivity does not change
     gui._simulate_upload_drives(file1_path)
     assert gui.connectivity_widgets[0][0].children[1].children[0].value == 0.01
+
+
+def test_gui_smart_gains_upload_connectivity():
+    """Test if gui 'smartly' handles upload of Network with non-default global gains."""
+    gui = HNNGUI()
+    _ = gui.compose()
+
+    # Let's set some custom global gains
+    gui.global_gain_widgets["i_e"].value = 1.2
+    gui.global_gain_widgets["i_i"].value = 0.9
+
+    # We need to run a simulation in order to download a Network
+    sim_name = "sim1"
+    gui.widget_simulation_name.value = sim_name
+    gui.widget_tstop.value = 70
+    gui.widget_dt.value = 0.5
+    gui.widget_backend_selection.value = "Joblib"
+    gui.widget_ntrials.value = 1
+    gui.run_button.click()
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Get network from data dictionary and save it to temporary file
+        net = gui.data["simulation_data"][sim_name]["net"]
+        file1_path = Path(tmp_dir) / "custom_global_gains.json"
+        write_network_configuration(net, file1_path)
+
+        # Set the GUI global gains back to defaults
+        gui.global_gain_widgets["i_e"].value = 1.0
+        gui.global_gain_widgets["i_i"].value = 1.0
+
+        gui._simulate_upload_connectivity(file1_path)
+
+    # Check that our GUI global gains are "smartly" loaded properly
+    assert gui.global_gain_widgets["i_e"].value == 1.2
+    assert gui.global_gain_widgets["i_i"].value == 0.9
+
+    # Finally, check that the GUI single gain for one of the synapses affected is NOT
+    # the changed value, but instead the default:
+    conn_widget = _conn_widget_lookup(gui, "L2_basket", "L2_pyramidal")
+    single_gain_widget = conn_widget.children[2].children[0]
+    assert single_gain_widget.value == 1.0
+
+    conn_widget = _conn_widget_lookup(gui, "L2_basket", "L2_basket")
+    single_gain_widget = conn_widget.children[2].children[0]
+    assert single_gain_widget.value == 1.0
 
     plt.close("all")
 
@@ -1580,17 +1644,7 @@ def test_combined_gain_indicator_updates(setup_gui):
 
     # Get a connectivity widget that has gain indicators
     # Find a L2_pyramidal->L2_pyramidal connection to test e_e type
-    conn_widget = None
-    for connectivity_field in gui.connectivity_widgets:
-        for widget in connectivity_field:
-            if (
-                widget._belongsto["src_gids"] == "L2_pyramidal"
-                and widget._belongsto["target_gids"] == "L2_pyramidal"
-            ):
-                conn_widget = widget
-                break
-        if conn_widget is not None:
-            break
+    conn_widget = _conn_widget_lookup(gui, "L2_pyramidal", "L2_pyramidal")
 
     # Extract single gain widget and combined gain indicator
     # Structure: children[2] is HBox containing [single_gain_input, combined_indicator]
@@ -1629,17 +1683,8 @@ def test_custom_gains_simulate_and_download(setup_gui):
     src_type = "L5_basket"
     target_type = "L5_basket"
     single_custom_gain = 2.0
-    conn_widget = None
-    for connectivity_field in gui.connectivity_widgets:
-        for widget in connectivity_field:
-            if (widget._belongsto["src_gids"] == src_type) and (
-                widget._belongsto["target_gids"] == target_type
-            ):
-                widget.children[2].children[0].value = single_custom_gain
-                break
-        if conn_widget is not None:
-            break
-
+    conn_widget = _conn_widget_lookup(gui, src_type, target_type)
+    conn_widget.children[2].children[0].value = single_custom_gain
     # Run a simulation to create a network with these gains
     sim_name = "test_gains"
     gui.widget_simulation_name.value = sim_name

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -228,6 +228,10 @@ def test_gui_upload_connectivity():
 def test_gui_smart_gains_upload_connectivity(setup_gui):
     """Test if gui 'smartly' handles upload of Network with non-default global gains."""
     gui = setup_gui
+    # The non-uniform-gain warning is emitted via ``print`` and only reaches the
+    # GUI log window because, in a notebook, the GUI globally redirects stdout to
+    # its logger (``_GUI_PrintToLogger``). pytest's stdout capture clobbers that
+    # redirect, so we reuse it here to ensure we catch everything.
     sys.stdout = _GUI_PrintToLogger()
 
     global_gain_test_value_1 = 1.2

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import os
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -28,6 +29,7 @@ from hnn_core.gui._viz_manager import (
     unlink_relink,
 )
 from hnn_core.gui.gui import (
+    _GUI_PrintToLogger,
     _init_network_from_widgets,
     _simulate_prepare_upload_file,
     _update_nested_dict,
@@ -225,11 +227,8 @@ def test_gui_upload_connectivity():
 
 def test_gui_smart_gains_upload_connectivity(setup_gui):
     """Test if gui 'smartly' handles upload of Network with non-default global gains."""
-    logger = logging.getLogger("hnn_gui")
-
-    # gui = HNNGUI()
-    # _ = gui.compose()
     gui = setup_gui
+    sys.stdout = _GUI_PrintToLogger()
 
     global_gain_test_value_1 = 1.2
     global_gain_test_value_2 = 0.9

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -306,9 +306,10 @@ def test_gui_smart_gains_upload_connectivity(setup_gui):
         file1_path = Path(tmp_dir) / "custom_global_gains_nonuniform.json"
         write_network_configuration(net2, file1_path)
 
-        # Set the GUI global gains back to defaults
-        gui.global_gain_widgets["i_e"].value = 1.0
-        gui.global_gain_widgets["i_i"].value = 1.0
+        # Set the GUI global gains back to their custom test values JUST IN CASE
+        # in order to ensure the upload of the file resets the global gain values back to 1.0
+        gui.global_gain_widgets["i_e"].value = global_gain_test_value_1
+        gui.global_gain_widgets["i_i"].value = global_gain_test_value_2
 
         gui._simulate_upload_connectivity(file1_path)
 


### PR DESCRIPTION
This resolves the undocumented issue we discussed in the Dev meeting on 2025-10-27,
Notion meeting notes here:
https://www.notion.so/jonescompneurolab/HNN-Core-dev-meeting-2025-10-27-29644dbbcce6800c8275de7b12260b8f where we discussed how, if a user makes a change in the GUI to a Global synaptic gain value, then downloads that Network to a file, and then uploads the same Network to continue where they left off, we needed better handling of the loaded synaptic weights.

Before, since every connection has only one gain value according to the API/NEURON, each single gain entry in the Network Connectivity "accordion" was loaded with whatever the value is in the Network file. In the above case, this would have been whatever they changed the Global gain to. However, in the GUI, after loading the Network file, the Global synaptic gains would have been reset to their default values, which could confuse users, and would make it very inconvenient to make further Global synaptic gain modifications.

Instead, what this commit does is, when a user uploads a Network file (or when the GUI first initializes), the global gains of that Network are checked. If they pass the
`_check_global_synaptic_gains_uniformity` check (discussed in #918), meaning that all global gains are uniform within their class, AND if those global gains appear to not be the default values, then the GUI stores the Network's custom global gains for display later, but then overwrites the *single* gains used in the Network object. This is because, when the user later runs a sim or downloads the Network anew, the GUI will create a *new* Network object using the various gain value states stored in the GUI itself, *not* in the loaded Network object. This will then re-apply the global gains all over again, but make it easier for the user to see and understand the current state.

If the above check *fails*, then we should *not* do "smart" loading of the global gains, because the uniformity assumption is violated. Instead, in this case, the GUI global gains will simply display their default values, the user will receive a warning in the log window that the assumption is violated, and the single gain entries in the Network Connectivity accordion *will* display their individual values.