### PR TITLE
[MRG] install: provide an "all" pip install variant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,9 @@ if __name__ == "__main__":
                  'sphinx-copybutton', 'tdqm'],
         'gui': ['ipywidgets>=8.0.0', 'ipykernel', 'ipympl', 'voila'],
     }
+    extras['all'] = (extras['opt'] + extras['parallel'] + extras['gui'])
     extras['dev'] = (extras['opt'] + extras['parallel'] + extras['test'] +
                      extras['docs'] + extras['gui'])
-
 
     setup(name=DISTNAME,
           maintainer=MAINTAINER,


### PR DESCRIPTION
This provides a new variant to the ways that users can install hnn_core through pip, by letting them install via

```
pip install "hnn_core[all]"
```

This is meant to make it easier for users to install all the features they are likely to want to use (optimization, parallelization support except for MPI, and most importantly, GUI usage), without having to know what features they want ahead of time, and without installing any unnecessary development features (`doc` and `test`).

After we get `pip install openmpi` working as well (see https://github.com/jonescompneurolab/hnn-core/issues/950#issuecomment-3292888207 ), this is likely to become the new default-recommended way to install HNN-core.