### PR TITLE
[WIP]: viz functions for between-layer current exchange

### DIFF
--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -283,6 +283,7 @@ def plot_layer_comparison(
     plt_show(show)
     return fig
 
+
 def _lighten_color(color, amount=0.5):
     import matplotlib.colors as mc
 


### PR DESCRIPTION
Hey @asoplata 

_a very rough draft right now, will add docstrings, and ofcourse tests(!) later_

this is in ref: https://github.com/jonescompneurolab/hnn-core/issues/1128
for the "Cartesian product" of the elements
i set the sources as drives + cell types and for the targets, cell types only, as drives can't receive current? mentioned it as a temp comment in the code too

Added two new viz funcs for analyzing synaptic current dynamics in networks, sprinkled in the use of metadata here 

- **`plot_current_exchange()`**: matrix view of currents between all source-target pairs (drives + cells → cells)
- **`plot_layer_comparison()`**: aggregates layer-wise current flow (L2/L5 + drives → L2/L5)

added a few helper functions for this
- **`_aggregate_connection_currents()`**: aggregates synaptic currents by `(src_type, target_type)` pairs

- **`_get_layer_groups()`**: extracts layer groups from metadata {maybe it need not be a seperate function, i can use it directly as code chunk in plot_layer_comparison too, used it as a style of helper functions like __lighten_color, __decimate_plot_data, etc, if there is scope for reuse in future funcs}

i followed the viz's function style to have Normalize option (0-1 scale or absolute), inspired from the existing plot_drive_strength function

I validated on Jones 2009 model with 3 drives (evdist1, evprox1, evprox2)
```
import matplotlib.pyplot as plt
from hnn_core import jones_2009_model, simulate_dipole
from hnn_core.viz import plot_current_exchange, plot_layer_comparison

net = jones_2009_model()

net.add_evoked_drive(
    "evdist1",
    mu=63.0,
    sigma=3.85,
    numspikes=1,
    location="distal",
    weights_ampa={"L2_pyramidal": 5.4e-5, "L5_pyramidal": 5.4e-4},
    synaptic_delays=0.1,
)

net.add_evoked_drive(
    "evprox1",
    mu=26.0,
    sigma=2.5,
    numspikes=1,
    location="proximal",
    weights_ampa={
        "L2_basket": 1.4e-4,
        "L2_pyramidal": 4.8e-5,
        "L5_basket": 1.9e-4,
        "L5_pyramidal": 7.9e-5,
    },
    synaptic_delays=0.1,
)

net.add_evoked_drive(
    "evprox2",
    mu=135.0,
    sigma=8.0,
    numspikes=1,
    location="proximal",
    weights_ampa={
        "L2_basket": 3.0e-6,
        "L2_pyramidal": 1.4,
        "L5_basket": 9.0e-3,
        "L5_pyramidal": 0.68,
    },
    synaptic_delays=0.1,
)

dpl = simulate_dipole(net, tstop=200.0, dt=0.5, record_isec="all", n_trials=1)

print("full current exchange matrix plot")
fig1 = plot_current_exchange(net, trial_idx=0, normalize=True, decim=5)

# absolute current
print(" layer comparison")
fig2 = plot_layer_comparison(net, trial_idx=0, normalize=False, decim=5)

# layer comparison as percentage
print("Creating percentage-based layer comparison...")
fig3 = plot_layer_comparison(net, trial_idx=0, normalize=True, decim=5)

plt.show()
```
<img width="1643" height="904" alt="image" src="https://github.com/user-attachments/assets/c781e7ab-76e3-4b11-98cf-8fe727cbedb3" />
<img width="1776" height="970" alt="image" src="https://github.com/user-attachments/assets/ca6ad94c-0556-4b81-b839-29e7364a256b" />
<img width="1740" height="964" alt="image" src="https://github.com/user-attachments/assets/fcde50e6-5500-4742-ab8f-d8be7ca4def2" />