### PR TITLE
[MRG] maint: read in pos_dict and cell_types

### DIFF
--- a/hnn_core/hnn_io.py
+++ b/hnn_core/hnn_io.py
@@ -528,11 +528,15 @@ def dict_to_network(net_data, read_drives=True, read_external_biases=True):
     mesh_shape = (net_data["N_pyr_x"], net_data["N_pyr_y"])
 
     # Instantiating network
-    net = Network(params, mesh_shape=mesh_shape, legacy_mode=net_data["legacy_mode"])
+    net = Network(
+        params,
+        mesh_shape=mesh_shape,
+        legacy_mode=net_data["legacy_mode"],
+        pos_dict=_read_pos_dict(net_data["pos_dict"]),
+        cell_types=_read_cell_types(net_data["cell_types"]),
+    )
 
     # Setting attributes
-    # Set cell types
-    net.cell_types = _read_cell_types(net_data["cell_types"])
     # Set gid ranges
     gid_ranges_data = dict()
     for key in net_data["gid_ranges"]:
@@ -540,8 +544,6 @@ def dict_to_network(net_data, read_drives=True, read_external_biases=True):
         stop = net_data["gid_ranges"][key]["stop"]
         gid_ranges_data[key] = range(start, stop)
     net.gid_ranges = OrderedDict(gid_ranges_data)
-    # Set pos_dict
-    net.pos_dict = _read_pos_dict(net_data["pos_dict"])
     # Set cell_response
     net.cell_response = _read_cell_response(
         net_data["cell_response"], read_output=False


### PR DESCRIPTION
This is related to #1168, and is required in order for @katduecker's new
model to be successfully read in from Network JSON files.

This makes a very tiny change in `hnn_io::dict_to_network`, affecting
`hnn_io::read_network_configuration` among others. When a dictionary
of `Network` parameters is being read in (such as from file), the
`Network.pos_dict` and `Network.cell_types` data is passed from the
originating dictionary to the `Network` initializer, instead of being
added to the `Network` object after creation. This takes advantage of
Chetan's updates to `Network` that can use these new arguments. This
allows Network JSON files with custom `cell_types` and/or `pos_dict` to
have that information read in, instead of having it overwritten with the
defaults, which is what is done currently.