### PR TITLE
[MRG] bugfix: Update args to fix GUI viz tests

### DIFF
--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -440,7 +440,11 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
                 io_buf.seek(0)
                 img_arr = np.reshape(
                     np.frombuffer(io_buf.getvalue(), dtype=np.uint8),
-                    shape=(int(_fig.bbox.bounds[3]), int(_fig.bbox.bounds[2]), -1),
+                    (
+                        int(_fig.bbox.bounds[3]),
+                        int(_fig.bbox.bounds[2]),
+                        -1,
+                    ),
                 )
                 io_buf.close()
                 _ = ax.imshow(img_arr)


### PR DESCRIPTION
This is a tiny, trivial bugfix that fixes the currently failing tests on `master`.

`master` currently fails
`test_gui.py::test_gui_visualization`
due to an error in the `"network"` plot_type case of the main `for` loop.

The failing testing code is here:

```python
setup_gui = <hnn_core.gui.gui.HNNGUI object at 0x10a36f050>

    def test_gui_visualization(setup_gui):
        """Tests updating a figure creates plots with data."""

        gui = setup_gui
        # Spectrogram needs longer time for wavelet analysis
        gui.widget_tstop.value = 500
        gui.run_button.click()

        gui._simulate_viz_action("switch_fig_template", "[Blank] single figure")
        gui._simulate_viz_action("add_fig")
        figid = 2
        figname = f"Figure {figid}"
        axname = "ax0"

        for viz_type in _plot_types:
            gui._simulate_viz_action(
                "edit_figure", figname, axname, "default", viz_type, {}, "clear"
            )
            # Check that extra axes have been successfully removed
            assert len(gui.viz_manager.figs[figid].axes) == 1
            # Check if data on the axes has been successfully cleared
            assert not gui.viz_manager.figs[figid].axes[0].has_data()

            gui._simulate_viz_action(
                "edit_figure", figname, axname, "default", viz_type, {}, "plot"
            )
            # Check if data is plotted on the axes
>           assert gui.viz_manager.figs[figid].axes[0].has_data()
E           AssertionError: assert False
E            +  where False = has_data()
E            +    where has_data = <Axes: label='Spike histogram'>.has_data

hnn_core/tests/test_gui.py:718: AssertionError
```

while the actual problem is in the provided Traceback here:

```python
Traceback (most recent call last):
  File "/opt/anaconda3/envs/hc11/lib/python3.11/site-packages/ipywidgets/widgets/widget.py", line 191, in __call__
    local_value = callback(*args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/austinsoplata/rep/brn/hnn-core/hnn_core/gui/_viz_manager.py", line 577, in _plot_on_axes
    dpls_processed = _update_ax(
                     ^^^^^^^^^^^
  File "/Users/austinsoplata/rep/brn/hnn-core/hnn_core/gui/_viz_manager.py", line 441, in _update_ax
    img_arr = np.reshape(
              ^^^^^^^^^^^
TypeError: reshape() got an unexpected keyword argument 'newshape'
```

Specifically, the root cause is that `_viz_manager.py::_update_ax()`, in the `plot_type == "network"` case, makes a call to `np.reshape`. The named parameter in that call is named `newshape`, however, in Numpy 2.4.0, this named arg was changed to `shape`, which you can see in the release notes here:
https://numpy.org/doc/stable/release/2.4.0-notes.html#removed-newshape-parameter-from-numpy-reshape Renaming the named arg allows all tests to pass once more.

Note that after merge, this change will need to be merged/rebased into any existing PRs in order for them to pass tests.