### PR TITLE
Doc:Add BatchSimulate section to API documentation

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -25,7 +25,6 @@ Simulation (:py:mod:`hnn_core`):
    CellResponse
    pick_connection
 
-
 Network Models (:py:mod:`hnn_core`):
 ------------------------------------
 
@@ -57,7 +56,6 @@ Batch Simulation (:py:mod:`hnn_core.batch_simulate`):
    :toctree: generated/
 
    BatchSimulate
-
 
 Dipole (:py:mod:`hnn_core.dipole`):
 -----------------------------------


### PR DESCRIPTION
Fixes #1204 
This PR adds the BatchSimulate class to the API documentation by including a new "Batch Simulation" section for "hnn_core.batch_simulate" in doc/api.rst.
I Verified locally by rebuilding the documentation with 'make html'.