### PR TITLE
[MRG] feat: Add support for new, custom synapse types

### DIFF
--- a/hnn_core/cell.py
+++ b/hnn_core/cell.py
@@ -315,10 +315,8 @@ class Cell:
     sections : dict of Section
         Dictionary with keys as section name.
     synapses : dict of dict
-        Keys are name of synaptic mechanism. Each synaptic mechanism
-        has keys for parameters of the mechanism, e.g., 'e', 'tau1',
-        'tau2'.
-        sections.
+        Keys are name of synaptic mechanism. Each synaptic mechanism dict has keys for
+        parameters of the mechanism, e.g., 'e', 'tau1', 'tau2'.  sections.
     sect_loc : dict of list
         Can have keys 'proximal' or 'distal' each containing
         names of section locations that are proximal or distal.
@@ -843,33 +841,93 @@ class Cell:
                     self.ca[sec_name] = h.Vector()
                     self.ca[sec_name].record(self._nrn_sections[sec_name](0.5)._ref_cai)
 
-    def syn_create(self, secloc, e, tau1, tau2):
-        """Create an h.Exp2Syn synapse.
+    def syn_create(self, secloc, **kwargs):
+        """Create a NEURON synapse at the given section location.
+
+        By default (or when ``mechname='Exp2Syn'``), creates an ``h.Exp2Syn`` two-state
+        kinetic synapse. A custom NEURON synapse mechanism can be used instead by
+        passing ``mechname=<synapse_class_name>`` along with any parameters that
+        synapse accepts.
 
         Parameters
         ----------
         secloc : instance of nrn.Segment
-            The section location. E.g., soma(0.5).
-        e: float
-            Reverse potential (in mV)
-        tau1: float
-            Rise time (in ms)
-        tau2: float
-            Decay time (in ms)
+            The section location. E.g., ``soma(0.5)``.
+        **kwargs : dict
+            Synapse parameters. The following keys are recognised:
+
+            mechname : str, optional
+                Name of the NEURON synapse class to instantiate (must be available in
+                NEURON's hoc interpreter). Custom synapse mechanisms must be compiled
+                from a MOD file. Defaults to ``'Exp2Syn'``.
+            e : float
+                Reversal potential (mV). Required for ``Exp2Syn``.
+            tau1 : float
+                Rise time constant (ms). Required for ``Exp2Syn``.
+            tau2 : float
+                Decay time constant (ms). Required for ``Exp2Syn``.
+
+            For custom synapse mechanisms, pass any parameters accepted by that synapse
+            as additional keyword arguments. Unknown or invalid parameter names will
+            raise a ``ValueError``.
 
         Returns
         -------
-        syn : instance of h.Exp2Syn
-            A two state kinetic scheme synapse.
+        syn : NEURON synapse object
+            The instantiated synapse object (e.g. ``h.Exp2Syn`` or a custom mechanism).
         """
         if not isinstance(secloc, nrn.Segment):
             raise TypeError(
-                f"secloc must be instance ofnrn.Segment. Got {type(secloc)}"
+                f"secloc must be instance of nrn.Segment. Got {type(secloc)}"
             )
-        syn = h.Exp2Syn(secloc)
-        syn.e = e
-        syn.tau1 = tau1
-        syn.tau2 = tau2
+
+        # Check for no "mechname" (including backwards compatibility), or case of mechname being
+        # explicitly "Exp2Syn"
+        if ("mechname" not in kwargs.keys()) or (kwargs["mechname"] == "Exp2Syn"):
+            syn = h.Exp2Syn(secloc)
+            try:
+                for param_name in ["e", "tau1", "tau2"]:
+                    setattr(syn, param_name, kwargs[param_name])
+            except KeyError:
+                raise KeyError(
+                    f"The Exp2Syn synapse in segment {secloc} is missing a required parameter."
+                )
+        else:
+            # Otherwise, there is a custom synapse mechanism to be used. Create a
+            # synapse of that mechanism, then use all remaining kwargs to set its
+            # attributes.
+            # -------------------------------------------------------------------------
+            try:
+                # This tries to obtain the synapse object as if it is an attribute of
+                # the HOC interpreter as a whole, which all valid synapse mechanisms
+                # should be. In other words, if you have compiled a synapse mechanism
+                # called e.g. 'NMDA_gao', then `h.NMDA_gao` should exist.
+                synapse_class = getattr(h, kwargs["mechname"])
+            except AttributeError:
+                raise ValueError(
+                    f"Synapse mechanism '{kwargs['mechname']}' not found in NEURON's "
+                    "hoc interpreter. You probably either need to recompile your MOD "
+                    "mechanism files or you are missing a required MOD file for this "
+                    "synapse mechanism."
+                )
+            # Create the synapse
+            syn = synapse_class(secloc)
+
+            # Set attributes of this synapse from their entry in kwargs, if present
+            for param_name, param_value in kwargs.items():
+                if hasattr(syn, param_name):
+                    setattr(syn, param_name, param_value)
+                elif param_name == "mechname":
+                    # Ignore "mechname" since it's only used in the control flow of
+                    # this function, but is never an actual attribute of the NEURON
+                    # Synapse object.
+                    continue
+                else:
+                    raise ValueError(
+                        f"Synapse mechanism '{kwargs['mechname']}' does not have a parameter "
+                        f"named '{param_name}'."
+                    )
+
         return syn
 
     def setup_source_netcon(self, threshold):

--- a/hnn_core/cells_default.py
+++ b/hnn_core/cells_default.py
@@ -284,7 +284,7 @@ def _cell_L2Pyr(override_params, pos=(0.0, 0.0, 0), gid=0):
         "distal": ["apical_tuft"],
     }
 
-    synapses = _get_pyr_syn_props(p_all, "L2Pyr")
+    synapses = _get_syn_props(p_all, "L2Pyr")
     return Cell(
         "L2Pyr",
         pos,
@@ -450,7 +450,7 @@ def _cell_L5Pyr(override_params, pos=(0.0, 0.0, 0), gid=0):
         "distal": ["apical_tuft"],
     }
 
-    synapses = _get_pyr_syn_props(p_all, "L5Pyr")
+    synapses = _get_syn_props(p_all, "L5Pyr")
     return Cell(
         "L5Pyr",
         pos,
@@ -507,11 +507,18 @@ def _get_basket_soma(v_init=-64.9737):
     )
 
 
-def _get_pyr_syn_props(p_all, cell_type):
-    """Return the default synaptic parameters for a given Pyramidal cell_type.
+def _get_syn_props(p_all, cell_type, syn_types=["ampa", "nmda", "gabaa", "gabab"]):
+    """Get synaptic properties for a specific cell type.
 
-    Extracts the 'e', 'tau1', and 'tau2' parameters for all synapse types for a
-    particular cell_type.
+    When parameters in `p_all` are provided for a "syn_type" (of the set {ampa, nmda,
+    gabaa, gabab}), and no "syn_type_mechname" key is present in p_all, then this will
+    *always* return the default synapse mechanism of "Exp2Syn". In order to use a custom
+    "mechanism" (such as "NMDA_gao" or "gabab_destexhe"), the incoming parameters in
+    `p_all` should include a key of the form `f"{cell_type}_{syn_type}_mechname"` with
+    the value being the name of the custom mechanism.
+
+    This was formerly called `_get_pyr_syn_props`, but `_pyr` was dropped from name due
+    to this function's future usage by interneurons in the upcoming Duecker model.
 
     Parameters
     ----------
@@ -521,39 +528,46 @@ def _get_pyr_syn_props(p_all, cell_type):
         dictionary is expected to be constructed using functions like
         `params_default.py::get_L2Pyr_params_default`.
     cell_type : {'L2Pyr', 'L5Pyr'}
-        Cell type identifier used as prefix in parameter key lookups.
+        The "short-name" type of cell
+    syn_types : list of str, optional
+        List of synapse types to extract properties for. Default: ["ampa", "nmda",
+        "gabaa", "gabab"]
 
     Returns
     -------
-    dict
-        A dictionary where the keys are the four synapse types {'ampa', 'nmda', 'gabaa',
-        'gabab'}, and where the values are dictionaries whose keys are {'e', 'tau1',
-        'tau2'} and whose values are the parameter values of that case from default
-        parameter dictionaries such as from
-        `params_default.py::get_L2Pyr_params_default`.
+    syn_props : dict
+        Dictionary where keys are synapse types and values are dictionaries containing
+        synapse properties. At minimum includes 'mechname' (synapse mechanism name,
+        e.g., 'Exp2Syn'). For `Exp2Syn` synapses, includes 'e' (reversal potential),
+        'tau1' (rise time constant), and 'tau2' (decay time constant). Custom synapse
+        mechanisms may include additional parameters specific to that mechanism.
     """
-    return {
-        "ampa": {
-            "e": p_all["%s_ampa_e" % cell_type],
-            "tau1": p_all["%s_ampa_tau1" % cell_type],
-            "tau2": p_all["%s_ampa_tau2" % cell_type],
-        },
-        "nmda": {
-            "e": p_all["%s_nmda_e" % cell_type],
-            "tau1": p_all["%s_nmda_tau1" % cell_type],
-            "tau2": p_all["%s_nmda_tau2" % cell_type],
-        },
-        "gabaa": {
-            "e": p_all["%s_gabaa_e" % cell_type],
-            "tau1": p_all["%s_gabaa_tau1" % cell_type],
-            "tau2": p_all["%s_gabaa_tau2" % cell_type],
-        },
-        "gabab": {
-            "e": p_all["%s_gabab_e" % cell_type],
-            "tau1": p_all["%s_gabab_tau1" % cell_type],
-            "tau2": p_all["%s_gabab_tau2" % cell_type],
-        },
-    }
+    syn_props = dict()
+    for syn in syn_types:
+        # Backwards compatibility check: if syn_type key is missing or None, default to
+        # Exp2Syn
+        if (f"{cell_type}_{syn}_mechname" not in p_all.keys()) or (
+            p_all[f"{cell_type}_{syn}_mechname"] == "Exp2Syn"
+        ):
+            syn_props[syn] = {
+                key: p_all[f"{cell_type}_{syn}_{key}"] for key in ["e", "tau1", "tau2"]
+            }
+            syn_props[syn].update({"mechname": "Exp2Syn"})
+        else:
+            # We should only be here if there is a `f"{cell_type}_{syn}_mechname"` key
+            # in p_all!
+            # Get all parameter keys for this synapse mechanism
+            syn_custom_var_keys = [
+                key.split(f"{cell_type}_{syn}_")[1]
+                for key in p_all.keys()
+                if key.startswith(f"{cell_type}_{syn}_")
+            ]
+            # Build synapse properties dict from available parameters
+            # (This should include 'mechname' as well)
+            syn_props[syn] = {
+                key: p_all[f"{cell_type}_{syn}_{key}"] for key in syn_custom_var_keys
+            }
+    return syn_props
 
 
 def _get_basket_syn_props():
@@ -569,9 +583,9 @@ def _get_basket_syn_props():
         'tau1', 'tau2'} and whose values are hard-coded.
     """
     return {
-        "ampa": {"e": 0, "tau1": 0.5, "tau2": 5.0},
-        "gabaa": {"e": -80, "tau1": 0.5, "tau2": 5.0},
-        "nmda": {"e": 0, "tau1": 1.0, "tau2": 20.0},
+        "ampa": {"e": 0, "tau1": 0.5, "tau2": 5.0, "mechname": "Exp2Syn"},
+        "gabaa": {"e": -80, "tau1": 0.5, "tau2": 5.0, "mechname": "Exp2Syn"},
+        "nmda": {"e": 0, "tau1": 1.0, "tau2": 20.0, "mechname": "Exp2Syn"},
     }
 
 

--- a/hnn_core/mod/NMDA_gao.mod
+++ b/hnn_core/mod/NMDA_gao.mod
@@ -1,0 +1,170 @@
+
+
+TITLE simple NMDA receptors
+
+COMMENT
+-----------------------------------------------------------------------------
+
+Essentially the same as /examples/nrniv/netcon/ampa.mod in the NEURON
+distribution - i.e. Alain Destexhe's simple AMPA model - but with
+different binding and unbinding rates and with a magnesium block.
+Modified by Andrew Davison, The Babraham Institute, May 2000
+
+
+	Simple model for glutamate AMPA receptors
+	=========================================
+
+  - FIRST-ORDER KINETICS, FIT TO WHOLE-CELL RECORDINGS
+
+    Whole-cell recorded postsynaptic currents mediated by AMPA/Kainate
+    receptors (Xiang et al., J. Neurophysiol. 71: 2552-2556, 1994) were used
+    to estimate the parameters of the present model; the fit was performed
+    using a simplex algorithm (see Destexhe et al., J. Computational Neurosci.
+    1: 195-230, 1994).
+
+  - SHORT PULSES OF TRANSMITTER (0.3 ms, 0.5 mM)
+
+    The simplified model was obtained from a detailed synaptic model that
+    included the release of transmitter in adjacent terminals, its lateral
+    diffusion and uptake, and its binding on postsynaptic receptors (Destexhe
+    and Sejnowski, 1995).  Short pulses of transmitter with first-order
+    kinetics were found to be the best fast alternative to represent the more
+    detailed models.
+
+  - ANALYTIC EXPRESSION
+
+    The first-order model can be solved analytically, leading to a very fast
+    mechanism for simulating synapses, since no differential equation must be
+    solved (see references below).
+
+
+
+References
+
+   Destexhe, A., Mainen, Z.F. and Sejnowski, T.J.  An efficient method for
+   computing synaptic conductances based on a kinetic model of receptor binding
+   Neural Computation 6: 10-14, 1994.
+
+   Destexhe, A., Mainen, Z.F. and Sejnowski, T.J. Synthesis of models for
+   excitable membranes, synaptic transmission and neuromodulation using a
+   common kinetic formalism, Journal of Computational Neuroscience 1:
+   195-230, 1994.
+
+Orignal file by:
+Kiki Sidiropoulou
+Adjusted Cdur = 1 and Beta= 0.01 for better nmda spikes
+PROCEDURE rate: FROM -140 TO 80 WITH 1000
+
+Modified by Penny under the instruction of M.L.Hines on Oct 03, 2017
+	Change gmax
+
+-----------------------------------------------------------------------------
+ENDCOMMENT
+
+
+
+NEURON {
+	POINT_PROCESS NMDA_gao
+	RANGE g, Alpha, Beta, e, gmax, ica, Cdur, iNMDA, i
+	USEION ca WRITE ica
+	NONSPECIFIC_CURRENT i, iNMDA
+	GLOBAL mg, Cmax
+}
+UNITS {
+	(nA) = (nanoamp)
+	(mV) = (millivolt)
+	(uS) = (microsiemens)
+	(mM) = (milli/liter)
+}
+
+PARAMETER {
+	Cmax	= 1	 (mM)           : max transmitter concentration
+	Cdur	= 1	 (ms)		: transmitter duration (rising phase)
+	Alpha	= 4 (/ms /mM)	: forward (binding) rate (4)
+	Beta 	= 0.01   (/ms)   : backward (unbinding) rate
+	e	= 0	 (mV)		: reversal potential
+    mg   = 1      (mM)           : external magnesium concentration
+	gmax = 1   (uS)
+
+}
+
+
+ASSIGNED {
+	v		(mV)		: postsynaptic voltage
+	iNMDA 		(nA)		: current = g*(v - e)
+	i
+	g 		(uS)		: conductance
+	Rinf				: steady state channels open
+	Rtau		(ms)		: time constant of channel binding
+	synon
+    B                       : magnesium block
+	ica
+}
+
+STATE {Ron Roff}
+
+INITIAL {
+	Rinf = Cmax*Alpha / (Cmax*Alpha + Beta)
+	Rtau = 1 / (Cmax*Alpha + Beta)
+	synon = 0
+}
+
+BREAKPOINT {
+	SOLVE release METHOD cnexp
+    B = mgblock(v)
+	g = (Ron + Roff)* gmax * B
+	iNMDA = g*(v - e)
+	i = iNMDA
+    	ica = iNMDA/10   :(5-10 times more permeable to Ca++ than Na+ or K+, Ascher and Nowak, 1988)
+   : iNMDA = 3*iNMDA/10
+
+}
+
+DERIVATIVE release {
+	Ron' = (synon*Rinf - Ron)/Rtau
+	Roff' = -Beta*Roff
+}
+
+FUNCTION mgblock(v(mV)) {
+        TABLE
+        DEPEND mg
+        FROM -140 TO 80 WITH 1000
+
+        : from Jahr & Stevens
+
+
+	 mgblock = 1 / (1 + exp(0.072 (/mV) * -v) * (mg / 3.57 (mM)))  :was 0.062, changed to 0.072 to get a better voltage-dependence of NMDA currents, july 2008, kiki
+
+}
+
+: following supports both saturation from single input and
+: summation from multiple inputs
+: if spike occurs during CDur then new off time is t + CDur
+: ie. transmitter concatenates but does not summate
+: Note: automatic initialization of all reference args to 0 except first
+
+
+NET_RECEIVE(weight, on, nspike, r0, t0 (ms)) {
+	: flag is an implicit argument of NET_RECEIVE and  normally 0
+        if (flag == 0) { : a spike, so turn on if not already in a Cdur pulse
+		nspike = nspike + 1
+		if (!on) {
+			r0 = r0*exp(-Beta*(t - t0))
+			t0 = t
+			on = 1
+			synon = synon + weight
+			state_discontinuity(Ron, Ron + r0)
+			state_discontinuity(Roff, Roff - r0)
+		}
+:		 come again in Cdur with flag = current value of nspike
+		net_send(Cdur, nspike)
+       }
+	if (flag == nspike) { : if this associated with last spike then turn off
+		r0 = weight*Rinf + (r0 - weight*Rinf)*exp(-(t - t0)/Rtau)
+		t0 = t
+		synon = synon - weight
+		state_discontinuity(Ron, Ron - r0)
+		state_discontinuity(Roff, Roff + r0)
+		on = 0
+	}
+}

--- a/hnn_core/mod/gabab_destexhe.mod
+++ b/hnn_core/mod/gabab_destexhe.mod
@@ -102,7 +102,7 @@ INDEPENDENT {t FROM 0 TO 1 WITH 1 (ms)}
 
 NEURON {
 	POINT_PROCESS gabab_destexhe
-	RANGE R, G, g, e, tau1, tau2
+	RANGE R, G, g
 	NONSPECIFIC_CURRENT i
 	GLOBAL Cmax, Cdur
 	GLOBAL K1, K2, K3, K4, KD, Erev, warn, cutoff
@@ -131,9 +131,6 @@ PARAMETER {
 	Erev	= -95	(mV)		: reversal potential (E_K)
 	warn	= 0			: too large G warning has/has not been issued
         cutoff = 1e12
-	tau1 = 1
-	tau2 = 20
-	e = -80
 }
 
 

--- a/hnn_core/mod/gabab_destexhe.mod
+++ b/hnn_core/mod/gabab_destexhe.mod
@@ -1,0 +1,214 @@
+: $Id: gabab.mod,v 1.9 2004/06/17 16:04:05 billl Exp $
+
+COMMENT
+-----------------------------------------------------------------------------
+
+	Kinetic model of GABA-B receptors
+	=================================
+
+  MODEL OF SECOND-ORDER G-PROTEIN TRANSDUCTION AND FAST K+ OPENING
+  WITH COOPERATIVITY OF G-PROTEIN BINDING TO K+ CHANNEL
+
+  PULSE OF TRANSMITTER
+
+  SIMPLE KINETICS WITH NO DESENSITIZATION
+
+	Features:
+
+  	  - peak at 100 ms; time course fit to Tom Otis' PSC
+	  - SUMMATION (psc is much stronger with bursts)
+
+
+	Approximations:
+
+	  - single binding site on receptor
+	  - model of alpha G-protein activation (direct) of K+ channel
+	  - G-protein dynamics is second-order; simplified as follows:
+		- saturating receptor
+		- no desensitization
+		- Michaelis-Menten of receptor for G-protein production
+		- "resting" G-protein is in excess
+		- Quasi-stat of intermediate enzymatic forms
+	  - binding on K+ channel is fast
+
+
+	Kinetic Equations:
+
+	  dR/dt = K1 * T * (1-R-D) - K2 * R
+
+	  dG/dt = K3 * R - K4 * G
+
+	  R : activated receptor
+	  T : transmitter
+	  G : activated G-protein
+	  K1,K2,K3,K4 = kinetic rate cst
+
+  n activated G-protein bind to a K+ channel:
+
+	n G + C <-> O		(Alpha,Beta)
+
+  If the binding is fast, the fraction of open channels is given by:
+
+	O = G^n / ( G^n + KD )
+
+  where KD = Beta / Alpha is the dissociation constant
+
+-----------------------------------------------------------------------------
+
+  Parameters estimated from patch clamp recordings of GABAB PSP's in
+  rat hippocampal slices (Otis et al, J. Physiol. 463: 391-407, 1993).
+
+-----------------------------------------------------------------------------
+
+  PULSE MECHANISM
+
+  Kinetic synapse with release mechanism as a pulse.
+
+  Warning: for this mechanism to be equivalent to the model with diffusion
+  of transmitter, small pulses must be used...
+
+  For a detailed model of GABAB:
+
+  Destexhe, A. and Sejnowski, T.J.  G-protein activation kinetics and
+  spill-over of GABA may account for differences between inhibitory responses
+  in the hippocampus and thalamus.  Proc. Natl. Acad. Sci. USA  92:
+  9515-9519, 1995.
+
+  For a review of models of synaptic currents:
+
+  Destexhe, A., Mainen, Z.F. and Sejnowski, T.J.  Kinetic models of
+  synaptic transmission.  In: Methods in Neuronal Modeling (2nd edition;
+  edited by Koch, C. and Segev, I.), MIT press, Cambridge, 1996.
+
+  This simplified model was introduced in:
+
+  Destexhe, A., Bal, T., McCormick, D.A. and Sejnowski, T.J.
+  Ionic mechanisms underlying synchronized oscillations and propagating
+  waves in a model of ferret thalamic slices. Journal of Neurophysiology
+  76: 2049-2070, 1996.
+
+  See also http://www.cnl.salk.edu/~alain
+
+
+
+  Alain Destexhe, Salk Institute and Laval University, 1995
+
+-----------------------------------------------------------------------------
+ENDCOMMENT
+
+
+
+INDEPENDENT {t FROM 0 TO 1 WITH 1 (ms)}
+
+NEURON {
+	POINT_PROCESS gabab_destexhe
+	RANGE R, G, g, e, tau1, tau2
+	NONSPECIFIC_CURRENT i
+	GLOBAL Cmax, Cdur
+	GLOBAL K1, K2, K3, K4, KD, Erev, warn, cutoff
+}
+
+UNITS {
+	(nA) = (nanoamp)
+	(mV) = (millivolt)
+	(umho) = (micromho)
+	(mM) = (milli/liter)
+}
+
+PARAMETER {
+
+	Cmax	= 0.5	(mM)		: max transmitter concentration
+	Cdur	= 0.3	(ms)		: transmitter duration (rising phase)
+:
+:	From Kfit with long pulse (5ms 0.5mM)
+:
+	K1	= 0.52	(/ms mM)	: forward binding rate to receptor
+	K2	= 0.0013 (/ms)		: backward (unbinding) rate of receptor
+	K3	= 0.098 (/ms)		: rate of G-protein production
+	K4	= 0.033 (/ms)		: rate of G-protein decay
+	KD	= 100			: dissociation constant of K+ channel
+	n	= 4			: nb of binding sites of G-protein on K+
+	Erev	= -95	(mV)		: reversal potential (E_K)
+	warn	= 0			: too large G warning has/has not been issued
+        cutoff = 1e12
+	tau1 = 1
+	tau2 = 20
+	e = -80
+}
+
+
+ASSIGNED {
+	v		(mV)		: postsynaptic voltage
+	i 		(nA)		: current = g*(v - Erev)
+	g 		(umho)		: conductance
+	Gn
+	R				: fraction of activated receptor
+	edc
+	synon
+	Rinf
+	Rtau (ms)
+	Beta (/ms)
+}
+
+STATE {
+	Ron Roff
+	G				: fraction of activated G-protein
+}
+
+
+INITIAL {
+	R = 0
+	G = 0
+	Ron = 0
+	Roff = 0
+	synon = 0
+	Rinf = K1*Cmax/(K1*Cmax + K2)
+	Rtau = 1/(K1*Cmax + K2)
+	Beta = K2
+
+}
+
+BREAKPOINT {
+	SOLVE bindkin METHOD derivimplicit
+	if (G < cutoff) {
+		Gn = G*G*G*G : ^n = 4
+		g = Gn / (Gn+KD)
+	} else {
+		if(!warn){
+			printf("gabab.mod WARN: G = %g too large\n", G)
+			warn = 1
+		}
+		g = 1
+	}
+	i = g*(v - Erev)
+}
+
+
+DERIVATIVE bindkin {
+	Ron' = synon*K1*Cmax - (K1*Cmax + K2)*Ron
+	Roff' = -K2*Roff
+	R = Ron + Roff
+	G' = K3 * R - K4 * G
+}
+
+: following supports both saturation from single input and
+: summation from multiple inputs
+: Note: automatic initialization of all reference args to 0 except first
+
+NET_RECEIVE(weight,  r0, t0 (ms)) {
+	if (flag == 1) { : at end of Cdur pulse so turn off
+		r0 = weight*(Rinf + (r0 - Rinf)*exp(-(t - t0)/Rtau))
+		t0 = t
+		synon = synon - weight
+		state_discontinuity(Ron, Ron - r0)
+		state_discontinuity(Roff, Roff + r0)
+        }else{ : at beginning of Cdur pulse so turn on
+		r0 = weight*r0*exp(-Beta*(t - t0))
+		t0 = t
+		synon = synon + weight
+		state_discontinuity(Ron, Ron + r0)
+		state_discontinuity(Roff, Roff - r0)
+		:come again in Cdur
+		net_send(Cdur, 1)
+        }
+}

--- a/hnn_core/param/neymotin2020_base.json
+++ b/hnn_core/param/neymotin2020_base.json
@@ -47,17 +47,20 @@
                     "ampa": {
                         "e": 0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabaa": {
                         "e": -80,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "nmda": {
                         "e": 0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     }
                 },
                 "cell_tree": null,
@@ -392,22 +395,26 @@
                     "ampa": {
                         "e": 0.0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "nmda": {
                         "e": 0.0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabaa": {
                         "e": -80.0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabab": {
                         "e": -80.0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     }
                 },
                 "cell_tree": {
@@ -518,17 +525,20 @@
                     "ampa": {
                         "e": 0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabaa": {
                         "e": -80,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "nmda": {
                         "e": 0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     }
                 },
                 "cell_tree": null,
@@ -1181,22 +1191,26 @@
                     "ampa": {
                         "e": 0.0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "nmda": {
                         "e": 0.0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabaa": {
                         "e": -80.0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabab": {
                         "e": -80.0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     }
                 },
                 "cell_tree": {

--- a/hnn_core/params_default.py
+++ b/hnn_core/params_default.py
@@ -227,15 +227,17 @@ def get_L2Pyr_params_default():
         "L2Pyr_ampa_e": 0.0,
         "L2Pyr_ampa_tau1": 0.5,
         "L2Pyr_ampa_tau2": 5.0,
+        "L2Pyr_ampa_mechname": "Exp2Syn",
         "L2Pyr_nmda_e": 0.0,
         "L2Pyr_nmda_tau1": 1.0,
-        "L2Pyr_nmda_tau2": 20.0,
+        "L2Pyr_nmda_tau2": 20.0,  # Intentionally not adding mechname here for testing backwards compat
         "L2Pyr_gabaa_e": -80.0,
         "L2Pyr_gabaa_tau1": 0.5,
         "L2Pyr_gabaa_tau2": 5.0,
         "L2Pyr_gabab_e": -80.0,
         "L2Pyr_gabab_tau1": 1.0,
         "L2Pyr_gabab_tau2": 20.0,
+        "L2Pyr_gabab_mechname": "Exp2Syn",
         # Biophysics soma
         "L2Pyr_soma_gkbar_hh2": 0.01,
         "L2Pyr_soma_gnabar_hh2": 0.18,

--- a/hnn_core/tests/assets/neymotin2020_3x3_drives.json
+++ b/hnn_core/tests/assets/neymotin2020_3x3_drives.json
@@ -47,17 +47,20 @@
                     "ampa": {
                         "e": 0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabaa": {
                         "e": -80,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "nmda": {
                         "e": 0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     }
                 },
                 "cell_tree": null,
@@ -392,22 +395,26 @@
                     "ampa": {
                         "e": 0.0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "nmda": {
                         "e": 0.0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabaa": {
                         "e": -80.0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabab": {
                         "e": -80.0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     }
                 },
                 "cell_tree": {
@@ -518,17 +525,20 @@
                     "ampa": {
                         "e": 0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabaa": {
                         "e": -80,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "nmda": {
                         "e": 0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     }
                 },
                 "cell_tree": null,
@@ -1181,22 +1191,26 @@
                     "ampa": {
                         "e": 0.0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "nmda": {
                         "e": 0.0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabaa": {
                         "e": -80.0,
                         "tau1": 0.5,
-                        "tau2": 5.0
+                        "tau2": 5.0,
+                        "mechname": "Exp2Syn"
                     },
                     "gabab": {
                         "e": -80.0,
                         "tau1": 1.0,
-                        "tau2": 20.0
+                        "tau2": 20.0,
+                        "mechname": "Exp2Syn"
                     }
                 },
                 "cell_tree": {

--- a/hnn_core/tests/test_cell.py
+++ b/hnn_core/tests/test_cell.py
@@ -324,7 +324,7 @@ def test_create_synapses_gabab_destexhe():
     _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
 
     # syn_create with valid custom 'mechname' kwarg should create the specified synapse.
-    custom_synapse_config = dict(e=50.0, tau1=1.0, tau2=20.0, mechname="gabab_destexhe")
+    custom_synapse_config = dict(g=1.0, mechname="gabab_destexhe")
     _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
 
     # syn_create with invalid parameter for custom 'mechname' should raise an error.

--- a/hnn_core/tests/test_cell.py
+++ b/hnn_core/tests/test_cell.py
@@ -4,9 +4,9 @@ import numpy as np
 
 import matplotlib
 
-from hnn_core.network_builder import load_custom_mechanisms
-from hnn_core.cell import _ArtificialCell, Cell, Section
 from hnn_core import pyramidal
+from hnn_core.cell import _ArtificialCell, Cell, Section
+from hnn_core.network_builder import load_custom_mechanisms
 
 matplotlib.use("agg")
 
@@ -42,7 +42,7 @@ def test_cell():
 
     # test that ExpSyn always takes nrn.Segment, not float
     with pytest.raises(TypeError, match="secloc must be instance of"):
-        cell.syn_create(0.5, e=0.0, tau1=0.5, tau2=5.0)
+        cell.syn_create(0.5, e=0.0, tau1=0.5, tau2=5.0, type="Exp2Syn")
 
     pickle.dumps(cell)  # check cell object is picklable until built
 
@@ -182,3 +182,152 @@ def test_artificial_cell():
         match="gid must be an integer",
     ):
         cell = _ArtificialCell(event_times, threshold, gid="one")
+
+
+def _helper_create_cell_and_run_synapse_checks(input_synapse_config):
+    """Helper function to create Cell with input synapse config.
+
+    This is used for tests that use `Cell.build` to test both
+    `Cell._create_synapses` and `Cell.syn_create`.
+    """
+    load_custom_mechanisms()
+    name = "asdf"
+    pos = (0.0, 0.0, 0.0)
+
+    sections = {
+        "soma": Section(
+            L=39, diam=20, cm=0.85, Ra=200.0, end_pts=[[0, 0, 0], [0, 39.0, 0]]
+        )
+    }
+    # Set the name of every future synapse we will test to be "ampa"
+    sections["soma"].syns = ["ampa"]
+
+    sect_loc = {"proximal": "soma"}
+    cell_tree = {("soma", 0): [("soma", 1)]}
+
+    # Create our unique synapse config for this test:
+    synapses = {"ampa": input_synapse_config}
+
+    # Create the HNN-Core Cell object with this custom synapse config:
+    cell = Cell(name, pos, sections, synapses, sect_loc, cell_tree)
+    # Checking that we have no NEURON synapses present before building the cell
+    assert not cell._nrn_synapses
+    # Build cell into NEURON
+    cell.build()
+
+    # Grab the new NEURON synapse object (which also checks that it exists)
+    syn = cell._nrn_synapses["soma_ampa"]
+    # NEURON HocObjects use hname() to identify mechname (e.g. "Exp2Syn[0]")
+    if "mechname" in input_synapse_config.keys():
+        assert syn.hname().startswith(input_synapse_config["mechname"])
+    else:
+        assert syn.hname().startswith("Exp2Syn")
+
+    # Remove 'mechname' from the custom synapse config since it's not an actual
+    # parameter of the NEURON synapse object
+    if "mechname" in input_synapse_config.keys():
+        input_synapse_config.pop("mechname")
+    # Check that all custom synapse parameters are present and set correctly on the
+    # NEURON synapse object
+    for param_name, expected_value in input_synapse_config.items():
+        if hasattr(syn, param_name):
+            actual_value = getattr(syn, param_name)
+            assert actual_value == expected_value, (
+                f"Expected {param_name}={expected_value}, got {actual_value}"
+            )
+
+
+def test_create_synapses_builtin():
+    """Test builtin (Exp2Syn, ExpSyn) synapse creation with various configurations
+
+    This uses `Cell.build` to test both `Cell._create_synapses` and `Cell.syn_create`.
+    """
+
+    # Begin actual tests using the above helper function
+    # ----------------------------------------------------------------------------------
+    # syn_create without 'mechname' kwarg should create an Exp2Syn (backwards compat).
+    custom_synapse_config = dict(e=0, tau1=0.5, tau2=5.0)
+    _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+    # syn_create with no 'mechname' kwarg but missing a required parameter should raise
+    # error. This is because the default 'mechname' is 'Exp2Syn', which requires the
+    # parameters 'e', 'tau1', and 'tau2'.
+    custom_synapse_config = dict(tau1=1.0, tau2=20.0)
+    with pytest.raises(KeyError, match="missing a required parameter"):
+        _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+    # syn_create with 'Exp2Syn' 'mechname' should create an Exp2Syn.
+    custom_synapse_config = dict(e=-80.0, tau1=1.0, tau2=20.0, mechname="Exp2Syn")
+    _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+    # syn_create with 'Exp2Syn' 'mechname' missing a required parameter should raise
+    # error.
+    custom_synapse_config = dict(tau1=1.0, tau2=20.0, mechname="Exp2Syn")
+    with pytest.raises(KeyError, match="missing a required parameter"):
+        _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+    # syn_create with invalid 'mechname' kwarg should raise an error.
+    custom_synapse_config = dict(mechname="NonExistentSynapseXYZ", e=0.0)
+    with pytest.raises(ValueError, match="not found in NEURON's hoc interpreter"):
+        _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+    # syn_create with valid custom 'mechname' kwarg should create the specified synapse.
+    # NOTE: This uses `ExpSyn` as an example of a "custom" synapse mechname, and it
+    # looks similar to `Exp2Syn` but it's NOT! This is a different, built-in NEURON
+    # synapse mechname.
+    custom_synapse_config = dict(e=50.0, tau=1.0, mechname="ExpSyn")
+    _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+    # syn_create with invalid parameter for custom 'mechname' should raise an error.
+    # NOTE: This usese `ExpSyn` as an example of a "custom" synapse mechname, and it
+    # looks similar to `Exp2Syn` but it's NOT! This is a different, built-in NEURON
+    # synapse mechname.
+    custom_synapse_config = dict(
+        tau1=1.0, tau2=20.0, mechname="ExpSyn", unknown_param=9
+    )
+    with pytest.raises(ValueError, match="does not have a parameter named"):
+        _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+
+def test_create_synapses_NMDA_gao():
+    """Test custom `NMDA_gao` synapse creation with various configurations
+
+    This requires the following synapse mechanisms to be present and compiled by `nrnivmodl`:
+    - hnn_core/mod/NMDA_gao.mod
+
+    This uses `Cell.build` to test both `Cell._create_synapses` and `Cell.syn_create`.
+    """
+    # Test syn_create with new synapse mechname 'NMDA_gao'.
+    custom_synapse_config = dict(mechname="NMDA_gao")
+    _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+    # syn_create with valid custom 'mechname' kwarg should create the specified synapse.
+    custom_synapse_config = dict(e=50.0, Beta=0.02, Cdur=1.5, mechname="NMDA_gao")
+    _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+    # syn_create with invalid parameter for custom 'mechname' should raise an error.
+    custom_synapse_config = dict(tau=1.0, mechname="NMDA_gao")
+    with pytest.raises(ValueError, match="does not have a parameter named"):
+        _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+
+def test_create_synapses_gabab_destexhe():
+    """Test custom `gabab_destexhe` synapse creation with various configurations
+
+    This requires the following synapse mechanisms to be present and compiled by `nrnivmodl`:
+    - hnn_core/mod/gabab_destexhe.mod
+
+    This uses `Cell.build` to test both `Cell._create_synapses` and `Cell.syn_create`.
+    """
+    # Test syn_create with new synapse mechname 'gabab_destexhe'.
+    custom_synapse_config = dict(mechname="gabab_destexhe")
+    _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+    # syn_create with valid custom 'mechname' kwarg should create the specified synapse.
+    custom_synapse_config = dict(e=50.0, tau1=1.0, tau2=20.0, mechname="gabab_destexhe")
+    _helper_create_cell_and_run_synapse_checks(custom_synapse_config)
+
+    # syn_create with invalid parameter for custom 'mechname' should raise an error.
+    custom_synapse_config = dict(Beta=1.0, mechname="gabab_destexhe")
+    with pytest.raises(ValueError, match="does not have a parameter named"):
+        _helper_create_cell_and_run_synapse_checks(custom_synapse_config)

--- a/hnn_core/tests/test_cells_default.py
+++ b/hnn_core/tests/test_cells_default.py
@@ -268,6 +268,7 @@ def test_basket_voltage_init():
             expected_v0 = expected_basket_v0[sec_name]
             assert np.isclose(v0, expected_v0), (
                 f"HNN-Core Basket cell {sec_name} v0={v0}, expected {expected_v0}"
+            )
     # Build NEURON cells and sections, then initialize
     for cell in cells.values():
         cell.build()
@@ -281,6 +282,8 @@ def test_basket_voltage_init():
             expected_v = expected_basket_v0[sec_name]
             assert np.isclose(v, expected_v, atol=0.1), (
                 f"NEURON-built Basket cell {sec_name} initial voltage is {v}, expected {expected_v}"
+            )
+
 
 def test_get_syn_props_backwards_compat():
     """_get_syn_props with no type key in p_all defaults to Exp2Syn.
@@ -337,6 +340,7 @@ def test_l2pyr_voltage_init():
     for sec_name, sec in l2pyr.sections.items():
         assert np.isclose(sec.v0, expected_l2pyr_v0), (
             f"HNN-Core L2Pyr {sec_name} v0={sec.v0}, expected {expected_l2pyr_v0}"
+        )
     # Build NEURON cells and sections, then initialize
     l2pyr.build(sec_name_apical="apical_trunk")
     h.finitialize()
@@ -347,9 +351,7 @@ def test_l2pyr_voltage_init():
         v = l2pyr._nrn_sections[sec_name](0.5).v
         assert np.isclose(v, expected_l2pyr_v0, atol=0.1), (
             f"NEURON-built L2Pyr {sec_name} initial voltage is {v}, expected {expected_l2pyr_v0}"
-
-
-
+        )
 
 
 def test_get_syn_props_custom_type():
@@ -370,6 +372,7 @@ def test_get_syn_props_custom_type():
     assert "tau1" not in result[syn_type]
     assert "tau2" not in result[syn_type]
 
+
 def test_get_syn_props_NMDA_gao_mechname_params():
     """_get_syn_props with the new NMDA_gao synapse mechname works for all custom params."""
     cell_type = "L5Pyr"
@@ -389,6 +392,7 @@ def test_get_syn_props_NMDA_gao_mechname_params():
     # tau1/tau2 should NOT be present since they weren't in p_all
     assert "tau1" not in result[syn_type]
     assert "tau2" not in result[syn_type]
+
 
 def test_get_syn_props_gabab_destexhe_mechname_params():
     """_get_syn_props with the new gabab_destexhe synapse mechname works for all custom
@@ -411,6 +415,7 @@ def test_get_syn_props_gabab_destexhe_mechname_params():
     assert "tau1" in result[syn_type]
     assert "tau2" in result[syn_type]
 
+
 def test_l5pyr_voltage_init():
     """Test voltage initialization for Layer 5 Pyramidal cell type."""
     # Current section initial voltages. The original location of these values can be
@@ -426,6 +431,7 @@ def test_l5pyr_voltage_init():
         "basal_2": -72,
         "basal_3": -72,
         "apical_oblique": -72,
+    }
 
     # Initial setup
     load_custom_mechanisms()
@@ -449,6 +455,7 @@ def test_l5pyr_voltage_init():
         expected_v = expected_l5pyr_v0[sec_name]
         assert np.isclose(v, expected_v, atol=0.1), (
             f"NEURON-built L5Pyr {sec_name} initial voltage is {v}, expected {expected_v}"
+        )
 
 
 def test_get_syn_props_multiple_syn_types():

--- a/hnn_core/tests/test_cells_default.py
+++ b/hnn_core/tests/test_cells_default.py
@@ -3,7 +3,14 @@ import pytest
 from neuron import h
 import numpy as np
 
-from hnn_core.cells_default import pyramidal, basket, _exp_g_at_dist, _linear_g_at_dist
+from hnn_core.cells_default import (
+    pyramidal,
+    basket,
+    _exp_g_at_dist,
+    _linear_g_at_dist,
+    _get_syn_props,
+    _get_basket_syn_props,
+)
 from hnn_core.network_builder import load_custom_mechanisms
 
 
@@ -253,7 +260,6 @@ def test_basket_voltage_init():
         "L2_basket": basket(cell_name="L2_basket"),
         "L5_basket": basket(cell_name="L5_basket"),
     }
-
     # Test initial voltages (v0) for basket cells after HNN-Core Cell class creation,
     # but before NEURON cell building
     for _, cell in cells.items():
@@ -262,8 +268,6 @@ def test_basket_voltage_init():
             expected_v0 = expected_basket_v0[sec_name]
             assert np.isclose(v0, expected_v0), (
                 f"HNN-Core Basket cell {sec_name} v0={v0}, expected {expected_v0}"
-            )
-
     # Build NEURON cells and sections, then initialize
     for cell in cells.values():
         cell.build()
@@ -277,6 +281,45 @@ def test_basket_voltage_init():
             expected_v = expected_basket_v0[sec_name]
             assert np.isclose(v, expected_v, atol=0.1), (
                 f"NEURON-built Basket cell {sec_name} initial voltage is {v}, expected {expected_v}"
+
+def test_get_syn_props_backwards_compat():
+    """_get_syn_props with no type key in p_all defaults to Exp2Syn.
+
+    In particular, this illustrates that when parameters are only provided for a
+    "syn_type" (of the set {ampa, nmda, gabaa, gabab}), and no "syn_type_mechname" key
+    is present in p_all, the function should still return the synapse properties with
+    the default "mechname" of "Exp2Syn".
+    """
+    # Simulate a p_all dict without any _mechname keys (legacy / backwards-compat case)
+    cell_type = "L2Pyr"
+    syn_types = ["ampa", "nmda", "gabaa", "gabab"]
+    for syn_type in syn_types:
+        p_all = {
+            f"{cell_type}_{syn_type}_e": 0.0,
+            f"{cell_type}_{syn_type}_tau1": 0.5,
+            f"{cell_type}_{syn_type}_tau2": 5.0,
+        }
+        result1 = _get_syn_props(p_all, cell_type, syn_types=[syn_type])
+        for syn_param in ["e", "tau1", "tau2"]:
+            assert (
+                result1[syn_type][syn_param]
+                == p_all[f"{cell_type}_{syn_type}_{syn_param}"]
+            )
+        # Test that type defaults to Exp2Syn when no type key is present
+        assert result1[syn_type]["mechname"] == "Exp2Syn"
+
+        # Add the type key to test that "Exp2Syn" is correctly read when present
+        p_all.update(
+            {
+                f"{cell_type}_{syn_type}_mechname": "Exp2Syn",
+            }
+        )
+        result2 = _get_syn_props(p_all, cell_type, syn_types=[syn_type])
+        # Test that type key and value are correctly present
+        for syn_param in ["e", "tau1", "tau2", "mechname"]:
+            assert (
+                result2[syn_type][syn_param]
+                == p_all[f"{cell_type}_{syn_type}_{syn_param}"]
             )
 
 
@@ -286,18 +329,14 @@ def test_l2pyr_voltage_init():
     # value can be found at
     # https://github.com/jonescompneurolab/hnn-core/blob/8a0fffef8d8803e2404d7237f9adeabecd1285ed/hnn_core/network_builder.py#L667
     expected_l2pyr_v0 = -71.46
-
     # Initial setup
     load_custom_mechanisms()
     l2pyr = pyramidal(cell_name="L2_pyramidal")
-
     # Test initial voltages (v0) for L2Pyr cells after HNN-Core Cell class creation,
     # but before NEURON cell building
     for sec_name, sec in l2pyr.sections.items():
         assert np.isclose(sec.v0, expected_l2pyr_v0), (
             f"HNN-Core L2Pyr {sec_name} v0={sec.v0}, expected {expected_l2pyr_v0}"
-        )
-
     # Build NEURON cells and sections, then initialize
     l2pyr.build(sec_name_apical="apical_trunk")
     h.finitialize()
@@ -308,8 +347,69 @@ def test_l2pyr_voltage_init():
         v = l2pyr._nrn_sections[sec_name](0.5).v
         assert np.isclose(v, expected_l2pyr_v0, atol=0.1), (
             f"NEURON-built L2Pyr {sec_name} initial voltage is {v}, expected {expected_l2pyr_v0}"
-        )
 
+
+
+
+
+def test_get_syn_props_custom_type():
+    """_get_syn_props with a custom synapse type collects all custom params."""
+    cell_type = "L2Pyr"
+    syn_type = "ampa"
+    p_all = {
+        f"{cell_type}_{syn_type}_mechname": "ExpSyn",
+        f"{cell_type}_{syn_type}_e": 0.0,
+        f"{cell_type}_{syn_type}_tau": 5.0,
+    }
+    result = _get_syn_props(p_all, cell_type, syn_types=[syn_type])
+    for syn_param in ["e", "tau", "mechname"]:
+        assert (
+            result[syn_type][syn_param] == p_all[f"{cell_type}_{syn_type}_{syn_param}"]
+        )
+    # tau1/tau2 should NOT be present since they weren't in p_all
+    assert "tau1" not in result[syn_type]
+    assert "tau2" not in result[syn_type]
+
+def test_get_syn_props_NMDA_gao_mechname_params():
+    """_get_syn_props with the new NMDA_gao synapse mechname works for all custom params."""
+    cell_type = "L5Pyr"
+    syn_type = "nmda"
+    p_all = {
+        f"{cell_type}_{syn_type}_mechname": "NMDA_gao",
+        f"{cell_type}_{syn_type}_e": 0.0,
+        f"{cell_type}_{syn_type}_Beta": 5.0,
+        f"{cell_type}_{syn_type}_Cdur": 1.2,
+    }
+    result = _get_syn_props(p_all, cell_type, syn_types=[syn_type])
+    result = _get_syn_props(p_all, cell_type, syn_types=[syn_type])
+    for syn_param in ["e", "Beta", "Cdur", "mechname"]:
+        assert (
+            result[syn_type][syn_param] == p_all[f"{cell_type}_{syn_type}_{syn_param}"]
+        )
+    # tau1/tau2 should NOT be present since they weren't in p_all
+    assert "tau1" not in result[syn_type]
+    assert "tau2" not in result[syn_type]
+
+def test_get_syn_props_gabab_destexhe_mechname_params():
+    """_get_syn_props with the new gabab_destexhe synapse mechname works for all custom
+    params."""
+    cell_type = "L5Pyr"
+    syn_type = "gabab_destexhe"
+    p_all = {
+        f"{cell_type}_{syn_type}_mechname": "gabab_destexhe",
+        f"{cell_type}_{syn_type}_e": 0.0,
+        f"{cell_type}_{syn_type}_tau1": 1.0,
+        f"{cell_type}_{syn_type}_tau2": 20,
+    }
+    result = _get_syn_props(p_all, cell_type, syn_types=[syn_type])
+    result = _get_syn_props(p_all, cell_type, syn_types=[syn_type])
+    for syn_param in ["e", "tau1", "tau2", "mechname"]:
+        assert (
+            result[syn_type][syn_param] == p_all[f"{cell_type}_{syn_type}_{syn_param}"]
+        )
+    # tau1/tau2 should be present since they are in p_all
+    assert "tau1" in result[syn_type]
+    assert "tau2" in result[syn_type]
 
 def test_l5pyr_voltage_init():
     """Test voltage initialization for Layer 5 Pyramidal cell type."""
@@ -326,7 +426,6 @@ def test_l5pyr_voltage_init():
         "basal_2": -72,
         "basal_3": -72,
         "apical_oblique": -72,
-    }
 
     # Initial setup
     load_custom_mechanisms()
@@ -340,11 +439,9 @@ def test_l5pyr_voltage_init():
         assert np.isclose(v0, expected_v0), (
             f"HNN-Core L5Pyr {sec_name} v0={v0}, expected {expected_v0}"
         )
-
     # Build NEURON cells and sections, then initialize
     l5pyr.build(sec_name_apical="apical_trunk")
     h.finitialize()
-
     # Test that the initial voltages of the built NEURON sections (at the midpoint)
     # still match our expected values
     for sec_name in l5pyr._nrn_sections:
@@ -352,4 +449,100 @@ def test_l5pyr_voltage_init():
         expected_v = expected_l5pyr_v0[sec_name]
         assert np.isclose(v, expected_v, atol=0.1), (
             f"NEURON-built L5Pyr {sec_name} initial voltage is {v}, expected {expected_v}"
+
+
+def test_get_syn_props_multiple_syn_types():
+    """_get_syn_props returns all requested syn_types, including mixed custom types."""
+    p_all = {
+        "L2Pyr_ampa_e": 0.0,
+        "L2Pyr_ampa_tau1": 0.5,
+        "L2Pyr_ampa_tau2": 5.0,
+        "L2Pyr_gabaa_e": -80.0,
+        "L2Pyr_gabaa_tau1": 0.5,
+        "L2Pyr_gabaa_tau2": 5.0,
+        "L2Pyr_nmda_mechname": "NMDA_gao",
+        "L2Pyr_nmda_e": 0.0,
+        "L2Pyr_nmda_Beta": 5.0,
+        "L2Pyr_nmda_Cdur": 1.2,
+        "L2Pyr_gabab_mechname": "gabab_destexhe",
+        "L2Pyr_gabab_e": 42069.0,
+        "L2Pyr_gabab_tau1": 1.0,
+        "L2Pyr_gabab_tau2": 20.0,
+    }
+    # Test that requesting only ampa returns with just ampa
+    result1 = _get_syn_props(p_all, "L2Pyr", syn_types=["ampa"])
+    assert "ampa" in result1
+    assert result1["ampa"]["e"] == 0.0
+    assert result1["ampa"]["tau1"] == 0.5
+    assert result1["ampa"]["tau2"] == 5.0
+    # Assigned, but not present in original `p_all`
+    assert result1["ampa"]["mechname"] == "Exp2Syn"
+    assert "gabaa" not in result1
+    # Test that requesting only ampa and gaba return the two
+    result2 = _get_syn_props(p_all, "L2Pyr", syn_types=["ampa", "gabaa"])
+    assert set(result2.keys()) == {"ampa", "gabaa"}
+    assert result2["ampa"]["e"] == 0.0
+    assert result2["ampa"]["tau1"] == 0.5
+    assert result2["ampa"]["tau2"] == 5.0
+    # Assigned, but not present in original `p_all`
+    assert result2["ampa"]["mechname"] == "Exp2Syn"
+    assert result2["gabaa"]["e"] == -80.0
+    assert result2["gabaa"]["tau1"] == 0.5
+    assert result2["gabaa"]["tau2"] == 5.0
+    # Assigned, but not present in original `p_all`
+    assert result2["gabaa"]["mechname"] == "Exp2Syn"
+    # Test that requesting only ampa and nmda return the two
+    result3 = _get_syn_props(p_all, "L2Pyr", syn_types=["ampa", "nmda"])
+    assert set(result3.keys()) == {"ampa", "nmda"}
+    assert result3["ampa"]["e"] == 0.0
+    assert result3["ampa"]["tau1"] == 0.5
+    assert result3["ampa"]["tau2"] == 5.0
+    # Assigned, but not present in original `p_all`
+    assert result3["ampa"]["mechname"] == "Exp2Syn"
+    assert result3["nmda"]["e"] == 0.0
+    assert result3["nmda"]["Beta"] == 5.0
+    assert result3["nmda"]["Cdur"] == 1.2
+    assert result3["nmda"]["mechname"] == "NMDA_gao"
+    # Test that requesting only ampa and nmda return the two
+    result4 = _get_syn_props(p_all, "L2Pyr", syn_types=["nmda", "gabab"])
+    assert set(result4.keys()) == {"nmda", "gabab"}
+    assert result4["nmda"]["e"] == 0.0
+    assert result4["nmda"]["Beta"] == 5.0
+    assert result4["nmda"]["Cdur"] == 1.2
+    assert result4["nmda"]["mechname"] == "NMDA_gao"
+    assert result4["gabab"]["e"] == 42069.0
+    assert result4["gabab"]["tau1"] == 1.0
+    assert result4["gabab"]["tau2"] == 20.0
+    assert result4["gabab"]["mechname"] == "gabab_destexhe"
+
+
+def test_get_basket_syn_props_includes_type():
+    """_get_basket_syn_props should include 'type': 'Exp2Syn' for each synapse."""
+    result = _get_basket_syn_props()
+    for syn_name, syn_props in result.items():
+        assert "mechname" in syn_props, (
+            f"Missing 'mechname' key in basket synapse '{syn_name}'"
         )
+        assert syn_props["mechname"] == "Exp2Syn"
+
+
+def test_pyramidal_synapses_have_type():
+    """Pyramidal cells should have 'type' key in each synapse after construction."""
+    load_custom_mechanisms()
+    for cell_name in ["L2_pyramidal", "L5_pyramidal"]:
+        cell = pyramidal(cell_name=cell_name)
+        for syn_name, syn_props in cell.synapses.items():
+            assert "mechname" in syn_props, (
+                f"Synapse '{syn_name}' on {cell_name} is missing 'mechname' key"
+            )
+
+
+def test_basket_synapses_have_type():
+    """Basket cells should have 'type' key in each synapse after construction."""
+    load_custom_mechanisms()
+    for cell_name in ["L2_basket", "L5_basket"]:
+        cell = basket(cell_name=cell_name)
+        for syn_name, syn_props in cell.synapses.items():
+            assert "mechname" in syn_props, (
+                f"Synapse '{syn_name}' on {cell_name} is missing 'mechname' key"
+            )

--- a/hnn_core/tests/test_cells_default.py
+++ b/hnn_core/tests/test_cells_default.py
@@ -401,19 +401,17 @@ def test_get_syn_props_gabab_destexhe_mechname_params():
     syn_type = "gabab_destexhe"
     p_all = {
         f"{cell_type}_{syn_type}_mechname": "gabab_destexhe",
-        f"{cell_type}_{syn_type}_e": 0.0,
-        f"{cell_type}_{syn_type}_tau1": 1.0,
-        f"{cell_type}_{syn_type}_tau2": 20,
+        f"{cell_type}_{syn_type}_g": 1.0,
     }
     result = _get_syn_props(p_all, cell_type, syn_types=[syn_type])
     result = _get_syn_props(p_all, cell_type, syn_types=[syn_type])
-    for syn_param in ["e", "tau1", "tau2", "mechname"]:
+    for syn_param in ["g", "mechname"]:
         assert (
             result[syn_type][syn_param] == p_all[f"{cell_type}_{syn_type}_{syn_param}"]
         )
-    # tau1/tau2 should be present since they are in p_all
-    assert "tau1" in result[syn_type]
-    assert "tau2" in result[syn_type]
+    # tau1/tau2 should NOT be present since they are in p_all
+    assert "tau1" not in result[syn_type]
+    assert "tau2" not in result[syn_type]
 
 
 def test_l5pyr_voltage_init():
@@ -472,9 +470,7 @@ def test_get_syn_props_multiple_syn_types():
         "L2Pyr_nmda_Beta": 5.0,
         "L2Pyr_nmda_Cdur": 1.2,
         "L2Pyr_gabab_mechname": "gabab_destexhe",
-        "L2Pyr_gabab_e": 42069.0,
-        "L2Pyr_gabab_tau1": 1.0,
-        "L2Pyr_gabab_tau2": 20.0,
+        "L2Pyr_gabab_g": 42069.0,
     }
     # Test that requesting only ampa returns with just ampa
     result1 = _get_syn_props(p_all, "L2Pyr", syn_types=["ampa"])
@@ -517,9 +513,7 @@ def test_get_syn_props_multiple_syn_types():
     assert result4["nmda"]["Beta"] == 5.0
     assert result4["nmda"]["Cdur"] == 1.2
     assert result4["nmda"]["mechname"] == "NMDA_gao"
-    assert result4["gabab"]["e"] == 42069.0
-    assert result4["gabab"]["tau1"] == 1.0
-    assert result4["gabab"]["tau2"] == 20.0
+    assert result4["gabab"]["g"] == 42069.0
     assert result4["gabab"]["mechname"] == "gabab_destexhe"
 
 

--- a/hnn_core/tests/test_params_default.py
+++ b/hnn_core/tests/test_params_default.py
@@ -1,0 +1,31 @@
+from hnn_core.cells_default import _get_syn_props
+from hnn_core.params_default import get_L2Pyr_params_default, get_L5Pyr_params_default
+
+# AES: yeah yeah we're eventually going to deprecate params_default. Still, as we do
+# that, it may be useful to have a place to put tests for it.
+
+
+def test_get_syn_props_l2pyr_default_params_backwards_compat():
+    """L2Pyr default params have mixed type/no-type keys; all synapses should resolve."""
+    p_all = get_L2Pyr_params_default()
+    result = _get_syn_props(p_all, "L2Pyr")
+    # All four default synapse types should be present
+    for syn in ["ampa", "nmda", "gabaa", "gabab"]:
+        assert syn in result
+        # All should fall back to or explicitly declare Exp2Syn
+        assert result[syn]["mechname"] == "Exp2Syn"
+        assert "e" in result[syn]
+        assert "tau1" in result[syn]
+        assert "tau2" in result[syn]
+
+
+def test_get_syn_props_l5pyr_default_params_backwards_compat():
+    """L5Pyr default params have no type keys; all synapses should resolve via backwards compat."""
+    p_all = get_L5Pyr_params_default()
+    result = _get_syn_props(p_all, "L5Pyr")
+    for syn in ["ampa", "nmda", "gabaa", "gabab"]:
+        assert syn in result
+        assert result[syn]["mechname"] == "Exp2Syn"
+        assert "e" in result[syn]
+        assert "tau1" in result[syn]
+        assert "tau2" in result[syn]


### PR DESCRIPTION
This change is in anticipation of @katduecker's new model in #1227. This makes significant changes to
`cells_default.py::_get_syn_props` (renamed and refactored from its former name `cells_default.py::_get_pyr_syn_props`), `cells_default.py::_get_basket_syn_props`, and especially `Cell.syn_create`. These changes include a few things:

1. The "synaptic property" dictionaries (e.g. the `syn_props` as returned by `_get_baskey_syn_props`) can, but are not required to, have a new key-value pair where the key is "type" and the value is the name of the synapse type to use.

2. Later, when the `Cell` is constructing the actual synapses in `Cell.syn_create`, if there is no synapse "type" provided via the synaptic properties, or if the "type" is `Exp2Syn`, then everything proceeds as it did before. An `Exp2Syn` synapse is created at the provided segment, and its `e`, `tau1`, and `tau2` parameters are set for that synapse. Instead of these synaptic parameters being hardcoded into the arguments for `syn_create`, they are now included as part of `kwargs`.

3. If the "type" key exists and its value is *not* `Exp2Syn`, then things are different (this is the main point of this branch). For example, on the branch for #1227 , on the following line, there is a new synapse "type" used called `NMDA_gao`:
https://github.com/katduecker/hnn-core/blob/d736459b6df2f005784d644b316528cb935fa7f1/hnn_core/params_default.py#L358 This is a new synapse type that corresponds to the new `NMDA_gao.mod` file in that branch. In the current branch (here), in `Cell.syn_create`, this new, non-`Exp2Syn` synapse type will instead lead to the following:

    3.1. A new synapse of this class will be created (see this line on
    the current branch):

    ```
    syn = synapse_class(secloc)
    ```

    3.2. Then, the remaining `kwargs` arguments will be assumed to be
    key-value pairs that are expected to correspond to parameters that
    can be set in this particular synapse type. These will be used to
    set the attribute values of this instantiation of this synapse
    type.

All together, this is slightly different from Katharina's original implementation of the custom synapses used in here https://github.com/katduecker/hnn-core/blob/duecker_ET_model_rev_history/hnn_core/cell.py#L876-L877 but this approach has the advantage of supporting runtime setting of custom synapse type parameters that are unique to that synapse type (e.g. in `params_default.py`) which are different from the traditional `{e, tau1, tau2}` set. (@katduecker, in other words, this will allow you to provide custom `gabab.mod` or `NMDA_gao.mod` synaptic parameters in your `params_default.py` file, if you so choose).

A few random notes:
- If you look at `get_L2Pyr_params_default`, you will see that I did *not* universally add the new "..._type" key to all synapses, but only some. This was done to illustrate that this is backwards-compatible with synaptic-property-inputting data structures that do not have the "..._type" key.
- I did have to regenerate the default network JSON files, but this is not because this change is backwards-compatible (it is). This was necessary because one of our tests tests full in-memory equivalency between a newly generated `jones2009` model object versus a read-from-file version of the same object.

Final note: I have not yet tested this against the custom `gabab.mod` or `NMDA_gao.mod` synapse types from #1227 yet. I'm not sure, but perhaps the best way to test this implementation against the custom MODs in 1227 is to do testing on a separate PR into #1227.