### PR TITLE
MAINT: Replace os.path with pathlib in test suite

### DIFF
--- a/hnn_core/tests/conftest.py
+++ b/hnn_core/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import Dict, Tuple
 import pytest
 import pickle
 
-import os.path as op
+from pathlib import Path
 import hnn_core
 from hnn_core import read_params, jones_2009_model, simulate_dipole
 from hnn_core import MPIBackend, JoblibBackend
@@ -82,10 +82,10 @@ def run_hnn_core_fixture():
         postproc=False,
         electrode_array=None,
     ):
-        hnn_core_root = op.dirname(hnn_core.__file__)
+        hnn_core_root = Path(hnn_core.__file__).parent
 
         # default params
-        params_fname = op.join(hnn_core_root, "param", "default.json")
+        params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
 
         tstop = 170.0

--- a/hnn_core/tests/test_batch_simulate.py
+++ b/hnn_core/tests/test_batch_simulate.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import time
 import pytest
 import numpy as np
-import os
+from pathlib import Path
 
 from hnn_core.batch_simulate import BatchSimulate
 from hnn_core import jones_2009_model
@@ -210,8 +210,8 @@ def test_save_load_and_overwrite(batch_simulate_instance, param_grid, tmp_path):
 
     batch_simulate_instance._save(results, start_idx, end_idx)
 
-    file_name = os.path.join(tmp_path, f"sim_run_{start_idx}-{end_idx}.npz")
-    assert os.path.exists(file_name)
+    file_name = tmp_path / f"sim_run_{start_idx}-{end_idx}.npz"
+    assert file_name.exists()
 
     loaded_data = np.load(file_name, allow_pickle=True)
     loaded_results = {key: loaded_data[key].tolist() for key in loaded_data.files}
@@ -261,8 +261,8 @@ def test_load_results(batch_simulate_instance, param_grid, tmp_path):
     end_idx = len(results)
     batch_simulate_instance._save(results, start_idx, end_idx)
 
-    file_name = os.path.join(tmp_path, f"sim_run_{start_idx}-{end_idx}.npz")
-    assert os.path.exists(file_name)
+    file_name = tmp_path / f"sim_run_{start_idx}-{end_idx}.npz"
+    assert file_name.exists()
 
     # single result file
     loaded_results = batch_simulate_instance.load_results(file_name)

--- a/hnn_core/tests/test_cell.py
+++ b/hnn_core/tests/test_cell.py
@@ -3,6 +3,7 @@ import pickle
 import numpy as np
 
 import matplotlib
+from pathlib import Path
 
 from hnn_core.network_builder import load_custom_mechanisms
 from hnn_core.cell import _ArtificialCell, Cell, Section

--- a/hnn_core/tests/test_cell_response.py
+++ b/hnn_core/tests/test_cell_response.py
@@ -5,6 +5,7 @@ from glob import glob
 import matplotlib.pyplot as plt
 import pytest
 import numpy as np
+from pathlib import Path
 
 from hnn_core import CellResponse, read_spikes
 

--- a/hnn_core/tests/test_cells_default.py
+++ b/hnn_core/tests/test_cells_default.py
@@ -2,6 +2,7 @@ import pytest
 
 from neuron import h
 import numpy as np
+from pathlib import Path
 
 from hnn_core.cells_default import pyramidal, basket, _exp_g_at_dist, _linear_g_at_dist
 from hnn_core.network_builder import load_custom_mechanisms

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -1,4 +1,3 @@
-import os.path as op
 from urllib.request import urlretrieve
 from pathlib import Path
 
@@ -21,8 +20,8 @@ matplotlib.use("agg")
 
 def test_dipole(tmp_path, run_hnn_core_fixture):
     """Test dipole object."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root / "param" / "default.json"
     dpl_out_fname = tmp_path / "dpl1.txt"
     dpl_out_hdf5_fname = tmp_path / "dpl.hdf5"
     params = read_params(params_fname)
@@ -187,8 +186,8 @@ def test_dipole(tmp_path, run_hnn_core_fixture):
 
 def test_dipole_simulation():
     """Test data produced from simulate_dipole() call."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     params.update(
         {"dipole_smooth_win": 5, "t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20}
@@ -320,7 +319,7 @@ def test_rmse():
         "https://raw.githubusercontent.com/jonescompneurolab/hnn/"
         "master/data/MEG_detection_data/yes_trial_S1_ERP_all_avg.txt"
     )
-    if not op.exists("yes_trial_S1_ERP_all_avg.txt"):
+    if not Path("yes_trial_S1_ERP_all_avg.txt").exists():
         urlretrieve(data_url, "yes_trial_S1_ERP_all_avg.txt")
     extdata = np.loadtxt("yes_trial_S1_ERP_all_avg.txt")
 
@@ -328,8 +327,8 @@ def test_rmse():
         times=extdata[:, 0], data=np.c_[extdata[:, 1], extdata[:, 1], extdata[:, 1]]
     )
 
-    hnn_core_root = op.join(op.dirname(hnn_core.__file__))
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).resolve().parent
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
 
     expected_rmse = 0.1

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -2,7 +2,7 @@
 #          Christopher Bailey <bailey.cj@gmail.com>
 
 import pytest
-import os.path as op
+from pathlib import Path
 
 import numpy as np
 
@@ -18,13 +18,13 @@ from hnn_core.network import pick_connection
 from hnn_core.network_models import jones_2009_model
 from hnn_core import simulate_dipole
 
-hnn_core_root = op.dirname(hnn_core.__file__)
+hnn_core_root = Path(hnn_core.__file__).parent
 
 
 @pytest.fixture
 def setup_net():
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     net = jones_2009_model(params, mesh_shape=(3, 3))
 
@@ -219,8 +219,8 @@ def test_clear_drives(setup_net):
 
 def test_add_drives():
     """Test methods for adding drives to a Network."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     net = Network(params, legacy_mode=False)
 

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -2,7 +2,7 @@
 #          Christopher Bailey <cjb@cfin.au.dk>
 
 from copy import deepcopy
-import os.path as op
+from pathlib import Path
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
@@ -19,8 +19,8 @@ from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
 import matplotlib.pyplot as plt
 
 
-hnn_core_root = op.dirname(hnn_core.__file__)
-params_fname = op.join(hnn_core_root, "param", "default.json")
+hnn_core_root = Path(hnn_core.__file__).parent
+params_fname = hnn_core_root / "param" / "default.json"
 params = read_params(params_fname)
 
 
@@ -266,8 +266,8 @@ def test_extracellular_backends(run_hnn_core_fixture):
 
 def test_rec_array_calculation():
     """Test LFP/CSD calculation."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     params.update({"t_evprox_1": 7, "t_evdist_1": 17})
     net = jones_2009_model(params, mesh_shape=(3, 3), add_drives_from_params=True)
@@ -323,8 +323,8 @@ def test_rec_array_calculation():
 
 def test_extracellular_viz():
     """Test if deprecation warning is raised in plot_laminar_lfp."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     params.update({"t_evprox_1": 7, "t_evdist_1": 17})
     net = jones_2009_model(params, mesh_shape=(3, 3), add_drives_from_params=True)

--- a/hnn_core/tests/test_general_optimization.py
+++ b/hnn_core/tests/test_general_optimization.py
@@ -7,6 +7,7 @@ import pytest
 
 from hnn_core import jones_2009_model, simulate_dipole
 from hnn_core.optimization import Optimizer
+from pathlib import Path
 
 
 @pytest.mark.parametrize("solver", ["bayesian", "cobyla"])

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import traitlets
-import os
 
 from pathlib import Path
 from hnn_core import Dipole, Network, simulate_dipole
@@ -959,7 +958,7 @@ def test_gui_upload_csv_simulation(setup_gui):
     # Formulate path to the file
     file_path = assets_path / "test_default.csv"
     absolute_path = str(file_path.resolve())
-    if os.name == "nt":  # Windows
+    if Path().anchor == "\\":  # Windows
         # Convert backslashes to forward slashes and
         # ensure we have three slashes after 'file:'
         file_url = "file:///" + absolute_path.replace("\\", "/")

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -2,7 +2,6 @@
 #          Rajat Partani <rajatpartani@gmail.com>
 
 import json
-import os.path as op
 from pathlib import Path
 from time import sleep
 from urllib.request import urlretrieve
@@ -384,8 +383,8 @@ def test_read_run_tutorial_json():
         "hnn-data/refs/heads/main/"
         "network-configurations/ERPYes100Trials.json"
     )
-    net_fname = op.join(hnn_core_root, "param", "ERPYes100Trials.json")
-    if not op.exists(net_fname):
+    net_fname = hnn_core_root / "param" / "ERPYes100Trials.json"
+    if not Path(net_fname).exists():
         urlretrieve(net_url, net_fname)
 
     # Test that Network can be created without error.

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -1,4 +1,4 @@
-import os.path as op
+from pathlib import Path
 import io
 from contextlib import redirect_stdout, redirect_stderr
 from queue import Queue
@@ -78,10 +78,10 @@ def test_extract_data_length():
 def test_str_to_net():
     """Test reading the network via a string"""
 
-    hnn_core_root = op.dirname(hnn_core.__file__)
+    hnn_core_root = Path(hnn_core.__file__).parent
 
     # prepare network
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     net = jones_2009_model(params, add_drives_from_params=True)
 
@@ -115,10 +115,10 @@ def test_str_to_net():
 def test_child_run():
     """Test running the child process without MPI"""
 
-    hnn_core_root = op.dirname(hnn_core.__file__)
+    hnn_core_root = Path(hnn_core.__file__).parent
 
     # prepare params
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     params_reduced = params.copy()
     params_reduced.update({"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20})

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -2,7 +2,7 @@
 
 from contextlib import redirect_stdout
 import io
-import os.path as op
+from pathlib import Path
 import tempfile
 
 import numpy as np
@@ -31,14 +31,14 @@ from hnn_core.network_builder import NetworkBuilder
 from hnn_core.network_models import add_erp_drives_to_jones_model
 from hnn_core.viz import plot_dipole
 
-hnn_core_root = op.dirname(hnn_core.__file__)
-params_fname = op.join(hnn_core_root, "param", "default.json")
+hnn_core_root = Path(hnn_core.__file__).parent
+params_fname = hnn_core_root / "param" / "default.json"
 
 
 @pytest.fixture(scope="class")
 def base_network():
     """Base Network with connections and drives"""
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     net = Network(params, legacy_mode=False)
     # add some basic local network connectivity
@@ -1094,10 +1094,10 @@ def test_add_cell_type():
 
 def test_tonic_biases():
     """Test tonic biases."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
+    hnn_core_root = Path(hnn_core.__file__).parent
 
     # default params
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
 
     net = Network(params)
@@ -1234,10 +1234,10 @@ def test_tonic_biases():
 
 def test_network_mesh():
     """Test mesh for defining cell positions biases."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
+    hnn_core_root = Path(hnn_core.__file__).parent
 
     # default params
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
 
     # Test custom mesh_shape
@@ -1655,7 +1655,7 @@ def test_rename_cell_types(base_network):
 
     # Test the other main network we use for testing
     net4 = hnn_core.hnn_io.read_network_configuration(
-        op.join(hnn_core_root, "tests", "assets", "jones2009_3x3_drives.json")
+        hnn_core_root / "tests" / "assets" / "jones2009_3x3_drives.json"
     )
     net4._rename_cell_types(cell_type_rename_mapping)
     dpls4 = simulate_dipole(net4, tstop=10.0, n_trials=1)
@@ -1674,6 +1674,7 @@ def test_spike_train_drive_formats_and_simulation():
 
     # File format will be tested in a temporary directory
     with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir = Path(tmp_dir)
         # Create dictionary format (Format 1)
         dict_format = {
             "L2_pyramidal": [10.0, 20.0, 30.0],
@@ -1714,9 +1715,9 @@ def test_spike_train_drive_formats_and_simulation():
         )
 
         # Write spike data to file
-        spike_file_pattern = op.join(tmp_dir, "spk_%d.txt")
+        spike_file_pattern = tmp_dir / "spk_%d.txt"
         cell_response.write(spike_file_pattern)
-        file_format = op.join(tmp_dir, "spk_*.txt")
+        file_format = str(tmp_dir / "spk_*.txt")
 
         # Add drives to networks with different formats
         net_dict.add_spike_train_drive(

--- a/hnn_core/tests/test_optimize_evoked.py
+++ b/hnn_core/tests/test_optimize_evoked.py
@@ -1,6 +1,6 @@
 # Authors: Mainak Jas <mainakjas@gmail.com>
 
-import os.path as op
+from pathlib import Path
 import numpy as np
 import pytest
 
@@ -90,8 +90,8 @@ def test_split_by_evinput():
 
 def test_optimize_evoked():
     """Test running the full routine in a reduced network."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
 
     tstop = 10.0

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -1,4 +1,4 @@
-import os.path as op
+from pathlib import Path
 from os import environ
 import io
 import itertools
@@ -169,8 +169,8 @@ class TestParallelBackends:
     @requires_psutil
     def test_terminate_mpibackend(self, run_hnn_core_fixture):
         """Test terminating MPIBackend from thread"""
-        hnn_core_root = op.dirname(hnn_core.__file__)
-        params_fname = op.join(hnn_core_root, "param", "default.json")
+        hnn_core_root = Path(hnn_core.__file__).parent
+        params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
         params.update(
             {"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20, "N_trials": 2}
@@ -203,8 +203,8 @@ class TestParallelBackends:
     @pytest.mark.parametrize("use_hwthreading_if_found", [True, False])
     def test_run_mpibackend_oversubscribed(self, use_hwthreading_if_found):
         """Test running MPIBackend with oversubscribed number of procs"""
-        hnn_core_root = op.dirname(hnn_core.__file__)
-        params_fname = op.join(hnn_core_root, "param", "default.json")
+        hnn_core_root = Path(hnn_core.__file__).parent
+        params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
         params.update(
             {"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20, "N_trials": 2}
@@ -303,8 +303,8 @@ class TestParallelBackends:
         override_oversubscribe_option,
     ):
         """Test running MPIBackend with oversubscribed number of procs"""
-        hnn_core_root = op.dirname(hnn_core.__file__)
-        params_fname = op.join(hnn_core_root, "param", "default.json")
+        hnn_core_root = Path(hnn_core.__file__).parent
+        params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
         params.update(
             {"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20, "N_trials": 2}
@@ -377,7 +377,7 @@ class TestParallelBackends:
             "https://raw.githubusercontent.com/jonescompneurolab/"
             "hnn-core/test_data/dpl.txt"
         )
-        if not op.exists("dpl.txt"):
+        if not Path("dpl.txt").exists():
             urlretrieve(data_url, "dpl.txt")
         dpl_master = loadtxt("dpl.txt")
 

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -1,7 +1,6 @@
 # Authors: Mainak Jas <mainakjas@gmail.com>
 #          Blake Caldwell <blake_caldwell@brown.edu>
 
-import os.path as op
 import json
 from pathlib import Path
 from urllib.request import urlretrieve
@@ -19,7 +18,7 @@ hnn_core_root = Path(__file__).parents[1]
 
 def test_read_params():
     """Test reading of params object."""
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     # Smoke test that network loads params
     _ = jones_2009_model(params, add_drives_from_params=True, legacy_mode=False)
@@ -30,7 +29,7 @@ def test_read_params():
     # unsupported extension
     pytest.raises(ValueError, read_params, "params.txt")
     # empty file
-    empty_fname = op.join(hnn_core_root, "param", "empty.json")
+    empty_fname = hnn_core_root / "param" / "empty.json"
     with open(empty_fname, "w") as json_data:
         json.dump({}, json_data)
     pytest.raises(ValueError, read_params, empty_fname)
@@ -44,11 +43,11 @@ def test_read_legacy_params():
     param_url = (
         "https://raw.githubusercontent.com/hnnsolver/hnn-core/test_data/default.param"
     )
-    params_legacy_fname = op.join(hnn_core_root, "param", "default.param")
-    if not op.exists(params_legacy_fname):
+    params_legacy_fname = hnn_core_root / "param" / "default.param"
+    if not Path(params_legacy_fname).exists():
         urlretrieve(param_url, params_legacy_fname)
 
-    params_new_fname = op.join(hnn_core_root, "param", "default.json")
+    params_new_fname = hnn_core_root / "param" / "default.json"
     params_legacy = read_params(params_legacy_fname)
     params_new = read_params(params_new_fname)
 
@@ -71,8 +70,8 @@ def test_base_params():
         "https://raw.githubusercontent.com/jonescompneurolab/"
         "hnn-core/test_data/base.json"
     )
-    params_base_fname = op.join(hnn_core_root, "param", "base.json")
-    if not op.exists(params_base_fname):
+    params_base_fname = hnn_core_root / "param" / "base.json"
+    if not Path(params_base_fname).exists():
         urlretrieve(param_url, params_base_fname)
 
     params_base = read_params(params_base_fname)
@@ -90,7 +89,7 @@ def test_remove_nulled_drives(tmp_path):
         "master/param/ERPYes100Trials.param"
     )
     params_fname = Path(hnn_core_root, "param", "ERPYes100Trials.param")
-    if not op.exists(params_fname):
+    if not Path(params_fname).exists():
         urlretrieve(param_url, params_fname)
 
     net = jones_2009_model(
@@ -158,7 +157,7 @@ class TestConvertToJson:
             "hnn-core/test_data/default.param"
         )
         params_base_fname = Path(hnn_core_root, "param", "default.param")
-        if not op.exists(params_base_fname):
+        if not Path(params_base_fname).exists():
             urlretrieve(param_url, params_base_fname)
         net_params = jones_2009_model(
             read_params(params_base_fname),

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -1,4 +1,4 @@
-import os.path as op
+from pathlib import Path
 
 import matplotlib
 from matplotlib import backend_bases
@@ -35,8 +35,8 @@ def cleanup_matplotlib():
 
 @pytest.fixture
 def setup_net():
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     net = jones_2009_model(params, mesh_shape=(3, 3))
 
@@ -324,8 +324,8 @@ class TestCellResponsePlotters:
     @pytest.fixture(scope="class")
     def class_setup_net(self):
         """Creates a base network for tests within this class"""
-        hnn_core_root = op.dirname(hnn_core.__file__)
-        params_fname = op.join(hnn_core_root, "param", "default.json")
+        hnn_core_root = Path(hnn_core.__file__).parent
+        params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
         net = jones_2009_model(params, mesh_shape=(3, 3))
 


### PR DESCRIPTION
This PR replaces os.path usage with pathlib.Path within the tests section of the codebase, with only minimal string conversions where necessary.

Changes include:
Replacing op.join, op.dirname, and op.exists with their Path equivalents

Removing import os.path as op where it is no longer needed

Laying groundwork that could be extended to the rest of the codebase

  All test cases passed locally
  tests pass: 225 