### PR TITLE
[WIP] VIZ: Add depth units [um] to LFP and CSD plots

### DIFF
--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -216,7 +216,7 @@ def plot_laminar_lfp(
             ax.set_xlim(left=times[0], right=times[-1])
     if voltage_offset is not None:
         ax.set_ylim(-voltage_offset, n_offsets * voltage_offset)
-        ylabel = "Individual contact traces"
+        ylabel = "Individual contact traces\nat depth [um]"
         if len(contact_labels) != n_offsets:
             raise ValueError(
                 f"contact_labels is length {len(contact_labels)},"
@@ -1857,7 +1857,7 @@ def plot_laminar_csd(
         times, new_depths, data, cmap=cmap, shading="auto", vmin=vmin, vmax=vmax
     )
     ax.set_xlabel("time (s)")
-    ax.set_ylabel("electrode depth")
+    ax.set_ylabel("Electrode depth [um]")
     if colorbar:
         color_axis = ax.inset_axes([1.05, 0, 0.02, 1], transform=ax.transAxes)
         plt.colorbar(im, ax=ax, cax=color_axis).set_label(r"$CSD (uV/um^{2})$")


### PR DESCRIPTION
### Summary
This PR updates visualization labels in `plot_laminar_lfp()` and `plot_csd()` to include depth units (µm).

### Changes
- Updated LFP y-axis label to:
  "Individual contact traces at depth [um]"
- Updated CSD y-axis label to:
  "Electrode depth [um]"

### Motivation
Depth values in laminar LFP and CSD plots represent electrode positions in micrometers. Adding units improves clarity and scientific correctness of the visualizations.

### Scope
This PR only updates axis label text. No functional or computational changes were made.

### Testing
Verified that:
- LFP plots display updated y-axis label
- CSD plots display updated y-axis label
- No changes to plotting behavior or scaling