### PR TITLE
[WIP]Refactor test_drives into smaller focused tests for evoked, bursty and poisson drives 

### DIFF
--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -217,39 +217,23 @@ def test_clear_drives(setup_net):
     assert net._n_gids == n_gids + len(net.gid_ranges["L5_pyramidal"])
 
 
-def test_add_drives():
-    """Test methods for adding drives to a Network."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
-    params = read_params(params_fname)
-    net = Network(params, legacy_mode=False)
+@pytest.fixture
+def net():
+    hnn_core_root=op.dirname(hnn_core.__file__)
+    params_fname=op.join(hnn_core_root,"param","default.json")
+    params=read_params(params_fname)
+    return Network(params,legacy_mode=False)
 
-    # Ensure weights and delays are updated
-    weights_ampa = {"L2_basket": 1.0, "L2_pyramidal": 3.0, "L5_pyramidal": 4.0}
-    syn_delays = {"L2_basket": 1.0, "L2_pyramidal": 2.0, "L5_pyramidal": 4.0}
 
-    n_drive_cells = 10
-    cell_specific = False  # default for bursty drive
-    net.add_bursty_drive(
-        "bursty",
-        location="distal",
-        burst_rate=10,
-        weights_ampa=weights_ampa,
-        synaptic_delays=syn_delays,
-        n_drive_cells=n_drive_cells,
-    )
+#Tests Creation
+def test_evoked_create(net):
+    """Test methods for adding evoked drives to a Network."""
 
-    assert net.external_drives["bursty"]["n_drive_cells"] == n_drive_cells
-    assert net.external_drives["bursty"]["cell_specific"] == cell_specific
-    conn_idxs = pick_connection(net, src_gids="bursty")
-    for conn_idx in conn_idxs:
-        drive_conn = net.connectivity[conn_idx]
-        target_type = drive_conn["target_type"]
-        assert drive_conn["nc_dict"]["A_weight"] == weights_ampa[target_type]
-        assert drive_conn["nc_dict"]["A_delay"] == syn_delays[target_type]
+    weights_ampa={"L2_basket":1.0,"L2_pyramidal":3.0,"L5_pyramidal":4.0}
+    syn_delays={"L2_basket":1.0,"L2_pyramidal":2.0,"L5_pyramidal":4.0}
 
-    n_drive_cells = "n_cells"  # default for evoked drive
-    cell_specific = True
+    cell_specific=True
+
     net.add_evoked_drive(
         "evoked_dist",
         mu=1.0,
@@ -258,101 +242,33 @@ def test_add_drives():
         weights_ampa=weights_ampa,
         location="distal",
         synaptic_delays=syn_delays,
-        cell_specific=True,
-    )
-
-    n_dist_targets = 235  # 270 with legacy mode
-    assert net.external_drives["evoked_dist"]["n_drive_cells"] == n_dist_targets
-    assert net.external_drives["evoked_dist"]["cell_specific"] == cell_specific
-    conn_idxs = pick_connection(net, src_gids="evoked_dist")
-    for conn_idx in conn_idxs:
-        drive_conn = net.connectivity[conn_idx]
-        target_type = drive_conn["target_type"]
-        assert drive_conn["nc_dict"]["A_weight"] == weights_ampa[target_type]
-        assert drive_conn["nc_dict"]["A_delay"] == syn_delays[target_type]
-
-    n_drive_cells = "n_cells"  # default for poisson drive
-    cell_specific = True
-    net.add_poisson_drive(
-        "poisson",
-        rate_constant=1.0,
-        weights_ampa=weights_ampa,
-        location="distal",
-        synaptic_delays=syn_delays,
         cell_specific=cell_specific,
     )
 
-    n_dist_targets = 235  # 270 with non-legacy mode
-    assert net.external_drives["poisson"]["n_drive_cells"] == n_dist_targets
-    assert net.external_drives["poisson"]["cell_specific"] == cell_specific
-    conn_idxs = pick_connection(net, src_gids="poisson")
+    n_dist_targets=235
+
+    assert net.external_drives["evoked_dist"]["n_drive_cells"]==n_dist_targets
+    assert net.external_drives["evoked_dist"]["cell_specific"]==cell_specific
+
+    conn_idxs=pick_connection(net,src_gids="evoked_dist")
+
     for conn_idx in conn_idxs:
-        drive_conn = net.connectivity[conn_idx]
-        target_type = drive_conn["target_type"]
-        assert drive_conn["nc_dict"]["A_weight"] == weights_ampa[target_type]
-        assert drive_conn["nc_dict"]["A_delay"] == syn_delays[target_type]
+        drive_conn=net.connectivity[conn_idx]
+        target_type=drive_conn["target_type"]
 
-    # Test drive targeting specific section
-    # Section present on all cells indicated
-    location = "apical_tuft"
-    weights_ampa_tuft = {"L2_pyramidal": 1.0, "L5_pyramidal": 2.0}
-    syn_delays_tuft = {"L2_pyramidal": 1.0, "L5_pyramidal": 2.0}
-    net.add_bursty_drive(
-        "bursty_tuft",
-        location=location,
-        burst_rate=10,
-        weights_ampa=weights_ampa_tuft,
-        synaptic_delays=syn_delays_tuft,
-        n_drive_cells=10,
-    )
-    assert net.connectivity[-1]["loc"] == location
+        assert drive_conn["nc_dict"]["A_weight"]==weights_ampa[target_type]
+        assert drive_conn["nc_dict"]["A_delay"]==syn_delays[target_type]
 
-    # Section not present on cells indicated
-    location = "apical_tuft"
-    weights_ampa_no_tuft = {"L2_pyramidal": 1.0, "L5_basket": 2.0}
-    syn_delays_no_tuft = {"L2_pyramidal": 1.0, "L5_basket": 2.0}
-    match = "Invalid value for"
-    with pytest.raises(ValueError, match=match):
-        net.add_bursty_drive(
-            "bursty_no_tuft",
-            location=location,
-            burst_rate=10,
-            weights_ampa=weights_ampa_no_tuft,
-            synaptic_delays=syn_delays_no_tuft,
-            n_drive_cells=n_drive_cells,
-        )
 
-    # Test probabilistic drive connections.
-    # drive with cell_specific=False
-    n_drive_cells = 10
-    probability = 0.5  # test that only half of possible connections are made
-    weights_nmda = {"L2_basket": 1.0, "L2_pyramidal": 3.0, "L5_pyramidal": 4.0}
-    net.add_bursty_drive(
-        "bursty_prob",
-        location="distal",
-        burst_rate=10,
-        weights_ampa=weights_ampa,
-        weights_nmda=weights_nmda,
-        synaptic_delays=syn_delays,
-        n_drive_cells=n_drive_cells,
-        probability=probability,
-    )
+#Test probability
+def test_evoked_probability(net):
 
-    for cell_type in weights_ampa.keys():
-        conn_idxs = pick_connection(net, src_gids="bursty_prob", target_gids=cell_type)
-        gid_pairs_comparison = net.connectivity[conn_idxs[0]]["gid_pairs"]
-        for conn_idx in conn_idxs:
-            conn = net.connectivity[conn_idx]
-            num_connections = np.sum([len(gids) for gids in conn["gid_pairs"].values()])
-            # Ensures that AMPA and NMDA connections target the same gids.
-            # Necessary when weights of both are non-zero.
-            assert gid_pairs_comparison == conn["gid_pairs"]
-            assert num_connections == np.around(
-                len(net.gid_ranges[cell_type]) * n_drive_cells * probability
-            ).astype(int)
+    weights_ampa={"L2_basket":1.0,"L2_pyramidal":3.0,"L5_pyramidal":4.0}
+    weights_nmda={"L2_basket":1.0,"L2_pyramidal":3.0,"L5_pyramidal":4.0}
+    syn_delays={"L2_basket":1.0,"L2_pyramidal":2.0,"L5_pyramidal":4.0}
 
-    # drives with cell_specific=True
-    probability = {"L2_basket": 0.1, "L2_pyramidal": 0.25, "L5_pyramidal": 0.5}
+    probability={"L2_basket":0.1,"L2_pyramidal":0.25,"L5_pyramidal":0.5}
+
     net.add_evoked_drive(
         "evoked_prob",
         mu=1.0,
@@ -366,18 +282,32 @@ def test_add_drives():
         probability=probability,
     )
 
-    for cell_type in weights_ampa.keys():
-        conn_idxs = pick_connection(net, src_gids="evoked_prob", target_gids=cell_type)
-        gid_pairs_comparison = net.connectivity[conn_idxs[0]]["gid_pairs"]
+    for cell_type in weights_ampa:
+
+        conn_idxs=pick_connection(net,src_gids="evoked_prob",target_gids=cell_type)
+
+        gid_pairs_comparison=net.connectivity[conn_idxs[0]]["gid_pairs"]
+
         for conn_idx in conn_idxs:
-            conn = net.connectivity[conn_idx]
-            num_connections = np.sum([len(gids) for gids in conn["gid_pairs"].values()])
-            assert gid_pairs_comparison == conn["gid_pairs"]
-            assert num_connections == np.around(
-                len(net.gid_ranges[cell_type]) * probability[cell_type]
+
+            conn=net.connectivity[conn_idx]
+
+            num_connections=np.sum([len(gids) for gids in conn["gid_pairs"].values()])
+
+            assert gid_pairs_comparison==conn["gid_pairs"]
+
+            assert num_connections==np.around(
+                len(net.gid_ranges[cell_type])*probability[cell_type]
             ).astype(int)
 
-    # Test adding just the NMDA weights (no AMPA)
+
+#Test nmda only
+def test_evoked_nmda(net):
+
+    weights_nmda={"L2_basket":1.0,"L2_pyramidal":3.0,"L5_pyramidal":4.0}
+    syn_delays={"L2_basket":1.0,"L2_pyramidal":2.0,"L5_pyramidal":4.0}
+    probability={"L2_basket":0.1,"L2_pyramidal":0.25,"L5_pyramidal":0.5}
+
     net.add_evoked_drive(
         "evoked_nmda",
         mu=1.0,
@@ -390,38 +320,63 @@ def test_add_drives():
         probability=probability,
     )
 
-    # Round trip test to ensure drives API produces a functioning Network
-    simulate_dipole(net, tstop=1)
+    simulate_dipole(net,tstop=1)
 
-    # evoked
-    with pytest.raises(ValueError, match="Standard deviation cannot be negative"):
-        net.add_evoked_drive("evdist1", mu=10, sigma=-1, numspikes=1, location="distal")
-    with pytest.raises(ValueError, match="Number of spikes must be greater than zero"):
-        net.add_evoked_drive("evdist1", mu=10, sigma=1, numspikes=0, location="distal")
 
-    # Test Network._attach_drive()
-    with pytest.raises(ValueError, match="Invalid value for"):
+#tests parameter validation
+def test_evoked_value_error(net):
+
+    with pytest.raises(ValueError,match="Standard deviation cannot be negative"):
+        net.add_evoked_drive("evdist1",mu=10,sigma=-1,numspikes=1,location="distal")
+
+    with pytest.raises(ValueError,match="Number of spikes must be greater than zero"):
+        net.add_evoked_drive("evdist1",mu=10,sigma=1,numspikes=0,location="distal")
+
+
+#tests attach_drive errors
+def test_evoked_drive_error(net):
+
+    weights_ampa={"L2_basket":1.0,"L2_pyramidal":3.0,"L5_pyramidal":4.0}
+    syn_delays={"L2_basket":1.0,"L2_pyramidal":2.0,"L5_pyramidal":4.0}
+
+    with pytest.raises(ValueError,match="Invalid value for"):
         net.add_evoked_drive(
             "evdist1",
             mu=10,
             sigma=1,
             numspikes=1,
             location="bogus_location",
-            weights_ampa={"L5_basket": 1.0},
-            synaptic_delays={"L5_basket": 0.1},
+            weights_ampa={"L5_basket":1.0},
+            synaptic_delays={"L5_basket":0.1},
         )
+
+    net.add_evoked_drive(
+    "evoked_dist",
+    mu=10,
+    sigma=1,
+    numspikes=1,
+    location="distal",
+    weights_ampa=weights_ampa,
+    synaptic_delays=syn_delays,
+    )
+
     with pytest.raises(ValueError, match="Drive evoked_dist already defined"):
         net.add_evoked_drive(
-            "evoked_dist", mu=10, sigma=1, numspikes=1, location="distal"
-        )
-    with pytest.raises(
-        ValueError, match="No target cell types have been given a synaptic weight"
-    ):
-        net.add_evoked_drive("evdist1", mu=10, sigma=1, numspikes=1, location="distal")
+        "evoked_dist",
+        mu=10,
+        sigma=1,
+        numspikes=1,
+        location="distal",
+        weights_ampa=weights_ampa,
+        synaptic_delays=syn_delays,
+    )
+
+    with pytest.raises(ValueError,match="No target cell types have been given a synaptic weight"):
+        net.add_evoked_drive("evdist1",mu=10,sigma=1,numspikes=1,location="distal")
+
     with pytest.raises(
         ValueError,
-        match="Due to physiological/anatomical constraints, "
-        "a distal drive cannot target L5_basket cell types. ",
+        match="Due to physiological/anatomical constraints, a distal drive cannot target L5_basket cell types. ",
     ):
         net.add_evoked_drive(
             "evdist1",
@@ -429,10 +384,11 @@ def test_add_drives():
             sigma=1,
             numspikes=1,
             location="distal",
-            weights_ampa={"L5_basket": 1.0},
-            synaptic_delays={"L5_basket": 0.1},
+            weights_ampa={"L5_basket":1.0},
+            synaptic_delays={"L5_basket":0.1},
         )
-    with pytest.raises(ValueError, match="If cell_specific is True, n_drive_cells"):
+
+    with pytest.raises(ValueError,match="If cell_specific is True, n_drive_cells"):
         net.add_evoked_drive(
             "evdist1",
             mu=10,
@@ -444,7 +400,8 @@ def test_add_drives():
             weights_ampa=weights_ampa,
             synaptic_delays=syn_delays,
         )
-    with pytest.raises(ValueError, match="If cell_specific is False, n_drive_cells"):
+
+    with pytest.raises(ValueError,match="If cell_specific is False, n_drive_cells"):
         net.add_evoked_drive(
             "evdist1",
             mu=10,
@@ -456,9 +413,8 @@ def test_add_drives():
             weights_ampa=weights_ampa,
             synaptic_delays=syn_delays,
         )
-    with pytest.raises(
-        ValueError, match="Number of drive cells must be greater than 0"
-    ):
+
+    with pytest.raises(ValueError,match="Number of drive cells must be greater than 0"):
         net.add_evoked_drive(
             "evdist1",
             mu=10,
@@ -471,26 +427,336 @@ def test_add_drives():
             synaptic_delays=syn_delays,
         )
 
-    # Poisson
     with pytest.raises(
-        ValueError, match="End time of Poisson drive cannot be negative"
+        ValueError,
+        match="synaptic_delays is either a common float or needs to be specified as a dict",
     ):
-        net.add_poisson_drive(
-            "poisson1", tstart=0, tstop=-1, location="distal", rate_constant=10.0
+        net.add_evoked_drive(
+            "cell_unknown",
+            mu=10,
+            sigma=1,
+            numspikes=1,
+            location="proximal",
+            weights_ampa={"L2_pyramidal":1.0},
+            synaptic_delays={"L5_pyramidal":1.0},
         )
+
+
+def test_evoked_random_state():
+
+    weights_ampa={
+        "L2_basket":0.08,
+        "L2_pyramidal":0.02,
+        "L5_basket":0.2,
+        "L5_pyramidal":0.00865,
+    }
+
+    synaptic_delays={
+        "L2_basket":0.1,
+        "L2_pyramidal":0.1,
+        "L5_basket":1.0,
+        "L5_pyramidal":1.0,
+    }
+
+    net=jones_2009_model()
+
+    for drive_name in ["evprox1","evprox2"]:
+
+        net.add_evoked_drive(
+            drive_name,
+            mu=137.12,
+            sigma=8,
+            numspikes=1,
+            weights_ampa=weights_ampa,
+            weights_nmda=None,
+            location="proximal",
+            synaptic_delays=synaptic_delays,
+            event_seed=4,
+        )
+
+    net._instantiate_drives(tstop=170.0)
+
+    assert(
+        net.external_drives["evprox1"]["events"]
+        ==net.external_drives["evprox2"]["events"]
+    )
+
+
+#Bursty test creation
+def test_bursty_create(net):
+    """Test bursty drive functionality in a Network."""
+
+    weights_ampa={
+        "L2_basket":1.0,
+        "L2_pyramidal":3.0,
+        "L5_pyramidal":4.0,
+    }
+
+    syn_delays={
+        "L2_basket":1.0,
+        "L2_pyramidal":2.0,
+        "L5_pyramidal":4.0,
+    }
+
+    n_drive_cells=10
+    cell_specific=False
+
+    net.add_bursty_drive(
+        "bursty",
+        location="distal",
+        burst_rate=10,
+        weights_ampa=weights_ampa,
+        synaptic_delays=syn_delays,
+        n_drive_cells=n_drive_cells,
+    )
+
+    assert net.external_drives["bursty"]["n_drive_cells"]==n_drive_cells
+    assert net.external_drives["bursty"]["cell_specific"]==cell_specific
+
+    conn_idxs=pick_connection(net,src_gids="bursty")
+
+    for conn_idx in conn_idxs:
+        drive_conn=net.connectivity[conn_idx]
+        target_type=drive_conn["target_type"]
+
+        assert drive_conn["nc_dict"]["A_weight"]==weights_ampa[target_type]
+        assert drive_conn["nc_dict"]["A_delay"]==syn_delays[target_type]
+
+
+def test_bursty_location(net):
+
+    location="apical_tuft"
+
+    weights_ampa_tuft={
+        "L2_pyramidal":1.0,
+        "L5_pyramidal":2.0,
+    }
+
+    syn_delays_tuft={
+        "L2_pyramidal":1.0,
+        "L5_pyramidal":2.0,
+    }
+
+    net.add_bursty_drive(
+        "bursty_tuft",
+        location=location,
+        burst_rate=10,
+        weights_ampa=weights_ampa_tuft,
+        synaptic_delays=syn_delays_tuft,
+        n_drive_cells=10,
+    )
+
+    assert net.connectivity[-1]["loc"]==location
+
+
+def test_bursty_section(net):
+
+    location="apical_tuft"
+    match="Invalid value for"
+
+    weights_ampa_no_tuft={
+        "L2_pyramidal":1.0,
+        "L5_basket":2.0,
+    }
+
+    syn_delays_no_tuft={
+        "L2_pyramidal":1.0,
+        "L5_basket":2.0,
+    }
+
+    with pytest.raises(ValueError,match=match):
+        net.add_bursty_drive(
+            "bursty_no_tuft",
+            location=location,
+            burst_rate=10,
+            weights_ampa=weights_ampa_no_tuft,
+            synaptic_delays=syn_delays_no_tuft,
+            n_drive_cells=10,
+        )
+
+
+def test_bursty_probability(net):
+
+    n_drive_cells=10
+    probability=0.5
+
+    weights_ampa={
+        "L2_basket":1.0,
+        "L2_pyramidal":3.0,
+        "L5_pyramidal":4.0,
+    }
+
+    syn_delays={
+        "L2_basket":1.0,
+        "L2_pyramidal":2.0,
+        "L5_pyramidal":4.0,
+    }
+
+    weights_nmda={
+        "L2_basket":1.0,
+        "L2_pyramidal":3.0,
+        "L5_pyramidal":4.0,
+    }
+
+    net.add_bursty_drive(
+        "bursty_prob",
+        location="distal",
+        burst_rate=10,
+        weights_ampa=weights_ampa,
+        weights_nmda=weights_nmda,
+        synaptic_delays=syn_delays,
+        n_drive_cells=n_drive_cells,
+        probability=probability,
+    )
+
+    for cell_type in weights_ampa:
+
+        conn_idxs=pick_connection(net,src_gids="bursty_prob",target_gids=cell_type)
+
+        gid_pairs_comparison=net.connectivity[conn_idxs[0]]["gid_pairs"]
+
+        for conn_idx in conn_idxs:
+
+            conn=net.connectivity[conn_idx]
+
+            num_connections=np.sum([len(gids) for gids in conn["gid_pairs"].values()])
+
+            assert gid_pairs_comparison==conn["gid_pairs"]
+
+            expected=np.around(
+                len(net.gid_ranges[cell_type])*n_drive_cells*probability
+            ).astype(int)
+
+            assert num_connections==expected
+
+
+def test_bursty_time_error(net):
+
+    with pytest.raises(ValueError,match="End time of bursty drive cannot be negative"):
+        net.add_bursty_drive("bursty_drive",tstop=-1,location="distal",burst_rate=10)
+
+    with pytest.raises(ValueError,match="Start time of bursty drive cannot be negative"):
+        net.add_bursty_drive("bursty_drive",tstart=-1,location="distal",burst_rate=10)
+
+    with pytest.raises(ValueError,match="Duration of bursty drive cannot be negative"):
+        net.add_bursty_drive("bursty_drive",tstart=10,tstop=1,location="distal",burst_rate=10)
+
+
+def test_bursty_probability_error(net):
+
+    with pytest.raises(ValueError,match=r"probability must be in the range \(0\,1\)"):
+        net.add_bursty_drive(
+            "cell_unknown",
+            location="distal",
+            burst_rate=10,
+            weights_ampa={"L2_pyramidal":1.0},
+            synaptic_delays={"L2_pyramidal":1.0},
+            probability=2.0,
+        )
+
     with pytest.raises(
-        ValueError, match="Start time of Poisson drive cannot be negative"
+        TypeError,
+        match="probability must be an instance of float or dict, got \<class 'str'\> instead",
     ):
-        net.add_poisson_drive(
-            "poisson1", tstart=-1, location="distal", rate_constant=10.0
+        net.add_bursty_drive(
+            "cell_unknown2",
+            location="distal",
+            burst_rate=10,
+            weights_ampa={"L2_pyramidal":1.0},
+            synaptic_delays={"L2_pyramidal":1.0},
+            probability="1.0",
         )
+
     with pytest.raises(
-        ValueError, match="Duration of Poisson drive cannot be negative"
+        TypeError,
+        match="probability must be an instance of float, got \<class 'str'\> instead",
     ):
-        net.add_poisson_drive(
-            "poisson1", tstart=10, tstop=1, location="distal", rate_constant=10.0
+        net.add_bursty_drive(
+            "cell_unknown2",
+            location="distal",
+            burst_rate=10,
+            weights_ampa={"L2_pyramidal":1.0},
+            synaptic_delays={"L2_pyramidal":1.0},
+            probability={"L2_pyramidal":"1.0"},
         )
-    with pytest.raises(ValueError, match="Rate constant must be positive"):
+
+
+def test_bursty_drive_error(net):
+
+    with pytest.warns(UserWarning,match="No external drives or biases load"):
+        net.clear_drives()
+        simulate_dipole(net,tstop=10)
+    
+
+
+#Tests Creation
+def test_poisson_create(net):
+
+    weights_ampa={"L2_basket":1.0,"L2_pyramidal":3.0,"L5_pyramidal":4.0}
+    syn_delays={"L2_basket":1.0,"L2_pyramidal":2.0,"L5_pyramidal":4.0}
+
+    cell_specific=True
+
+    net.add_poisson_drive(
+        "poisson",
+        rate_constant=1.0,
+        weights_ampa=weights_ampa,
+        location="distal",
+        synaptic_delays=syn_delays,
+        cell_specific=cell_specific,
+    )
+
+    n_dist_targets=235
+
+    assert net.external_drives["poisson"]["n_drive_cells"]==n_dist_targets
+    assert net.external_drives["poisson"]["cell_specific"]==cell_specific
+
+    conn_idxs=pick_connection(net,src_gids="poisson")
+
+    for conn_idx in conn_idxs:
+        drive_conn=net.connectivity[conn_idx]
+        target_type=drive_conn["target_type"]
+
+        assert drive_conn["nc_dict"]["A_weight"]==weights_ampa[target_type]
+        assert drive_conn["nc_dict"]["A_delay"]==syn_delays[target_type]
+
+
+def test_poisson_time_error(net):
+
+    with pytest.raises(ValueError,match="End time of Poisson drive cannot be negative"):
+        net.add_poisson_drive(
+            "poisson1",
+            tstart=0,
+            tstop=-1,
+            location="distal",
+            rate_constant=10.0,
+        )
+
+    with pytest.raises(ValueError,match="Start time of Poisson drive cannot be negative"):
+        net.add_poisson_drive(
+            "poisson1",
+            tstart=-1,
+            location="distal",
+            rate_constant=10.0,
+        )
+
+    with pytest.raises(ValueError,match="Duration of Poisson drive cannot be negative"):
+        net.add_poisson_drive(
+            "poisson1",
+            tstart=10,
+            tstop=1,
+            location="distal",
+            rate_constant=10.0,
+        )
+
+
+#tests rate -ve error
+def test_poisson_rate_error(net):
+
+    weights_ampa={"L2_basket":1.0,"L2_pyramidal":3.0,"L5_pyramidal":4.0}
+    syn_delays={"L2_basket":1.0,"L2_pyramidal":2.0,"L5_pyramidal":4.0}
+
+    with pytest.raises(ValueError,match="Rate constant must be positive"):
         net.add_poisson_drive(
             "poisson1",
             location="distal",
@@ -499,24 +765,37 @@ def test_add_drives():
             synaptic_delays=syn_delays,
         )
 
-    with pytest.raises(ValueError, match="Rate constants not provided for all target"):
+
+#tests rate constant 
+def test_poisson_rate_dict_error(net):
+
+    weights_ampa={"L2_basket":1.0,"L2_pyramidal":3.0,"L5_pyramidal":4.0}
+    syn_delays={"L2_basket":1.0,"L2_pyramidal":2.0,"L5_pyramidal":4.0}
+
+    with pytest.raises(ValueError,match="Rate constants not provided for all target"):
         net.add_poisson_drive(
             "poisson1",
             location="distal",
-            rate_constant={"L2_pyramidal": 10.0},
+            rate_constant={"L2_pyramidal":10.0},
             weights_ampa=weights_ampa,
             synaptic_delays=syn_delays,
         )
-    with pytest.raises(
-        ValueError, match="Rate constant provided for unknown target cell"
-    ):
+
+    with pytest.raises(ValueError,match="Rate constant provided for unknown target cell"):
         net.add_poisson_drive(
             "poisson1",
             location="distal",
-            rate_constant={"L2_pyramidal": 10.0, "bogus_celltype": 20.0},
-            weights_ampa={"L2_pyramidal": 0.01, "bogus_celltype": 0.01},
+            rate_constant={"L2_pyramidal":10.0,"bogus_celltype":20.0},
+            weights_ampa={"L2_pyramidal":0.01,"bogus_celltype":0.01},
             synaptic_delays=0.1,
         )
+
+
+#tests cell_specific constraint
+def test_poisson_cell_specific_error(net):
+
+    weights_ampa={"L2_basket":1.0,"L2_pyramidal":3.0,"L5_pyramidal":4.0}
+    syn_delays={"L2_basket":1.0,"L2_pyramidal":2.0,"L5_pyramidal":4.0}
 
     with pytest.raises(
         ValueError,
@@ -526,10 +805,10 @@ def test_add_drives():
             "poisson1",
             location="distal",
             rate_constant={
-                "L2_basket": 10.0,
-                "L2_pyramidal": 11.0,
-                "L5_basket": 12.0,
-                "L5_pyramidal": 13.0,
+                "L2_basket":10.0,
+                "L2_pyramidal":11.0,
+                "L5_basket":12.0,
+                "L5_pyramidal":13.0,
             },
             n_drive_cells=1,
             cell_specific=False,
@@ -537,33 +816,22 @@ def test_add_drives():
             synaptic_delays=syn_delays,
         )
 
-    # bursty
-    with pytest.raises(ValueError, match="End time of bursty drive cannot be negative"):
-        net.add_bursty_drive("bursty_drive", tstop=-1, location="distal", burst_rate=10)
-    with pytest.raises(
-        ValueError, match="Start time of bursty drive cannot be negative"
-    ):
-        net.add_bursty_drive(
-            "bursty_drive", tstart=-1, location="distal", burst_rate=10
-        )
-    with pytest.raises(ValueError, match="Duration of bursty drive cannot be negative"):
-        net.add_bursty_drive(
-            "bursty_drive", tstart=10, tstop=1, location="distal", burst_rate=10
-        )
 
-    msg = (
-        r"(?s)Burst duration .* cannot be greater than "
-        "burst period"
-    )
-    with pytest.raises(ValueError, match=msg):
-        net.add_bursty_drive(
-            "bursty_drive",
-            location="distal",
-            burst_rate=10,
-            burst_std=20.0,
-            numspikes=4,
-            spike_isi=50,
-        )
+def test_drive_attach_errors(net):
+
+    weights_ampa={"L2_basket":1.0,"L2_pyramidal":3.0,"L5_pyramidal":4.0}
+    syn_delays={"L2_basket":1.0,"L2_pyramidal":2.0,"L5_pyramidal":4.0}
+
+    # create evoked drive first
+    net.add_evoked_drive(
+    "evoked_dist",
+    mu=1.0,
+    sigma=1.0,
+    numspikes=1,
+    location="distal",
+    weights_ampa=weights_ampa,
+    synaptic_delays=syn_delays,
+)
 
     # attaching drives
     with pytest.raises(ValueError, match="Drive evoked_dist already defined"):
@@ -574,6 +842,7 @@ def test_add_drives():
             weights_ampa=weights_ampa,
             synaptic_delays=syn_delays,
         )
+
     with pytest.raises(ValueError, match="Invalid value for the"):
         net.add_poisson_drive(
             "weird_poisson",
@@ -582,6 +851,7 @@ def test_add_drives():
             weights_ampa=weights_ampa,
             synaptic_delays=syn_delays,
         )
+
     with pytest.raises(ValueError, match="Allowed drive target cell types are:"):
         net.add_poisson_drive(
             "cell_unknown",
@@ -590,84 +860,6 @@ def test_add_drives():
             weights_ampa={"CA1_pyramidal": 1.0},
             synaptic_delays=0.01,
         )
-    with pytest.raises(
-        ValueError,
-        match="synaptic_delays is either a common float or "
-        "needs to be specified as a dict for each of the cell",
-    ):
-        net.add_poisson_drive(
-            "cell_unknown",
-            location="proximal",
-            rate_constant=10.0,
-            weights_ampa={"L2_pyramidal": 1.0},
-            synaptic_delays={"L5_pyramidal": 1.0},
-        )
-    with pytest.raises(ValueError, match=r"probability must be in the range \(0\,1\)"):
-        net.add_bursty_drive(
-            "cell_unknown",
-            location="distal",
-            burst_rate=10,
-            weights_ampa={"L2_pyramidal": 1.0},
-            synaptic_delays={"L2_pyramidal": 1.0},
-            probability=2.0,
-        )
-
-    with pytest.raises(
-        TypeError,
-        match="probability must be an instance of "
-        r"float or dict, got \<class 'str'\> instead",
-    ):
-        net.add_bursty_drive(
-            "cell_unknown2",
-            location="distal",
-            burst_rate=10,
-            weights_ampa={"L2_pyramidal": 1.0},
-            synaptic_delays={"L2_pyramidal": 1.0},
-            probability="1.0",
-        )
-
-    with pytest.raises(
-        ValueError,
-        match="probability is either a common "
-        "float or needs to be specified as a dict for "
-        "each of the cell",
-    ):
-        net.add_bursty_drive(
-            "cell_unknown2",
-            location="distal",
-            burst_rate=10,
-            weights_ampa={"L2_pyramidal": 1.0},
-            synaptic_delays={"L2_pyramidal": 1.0},
-            probability={"L5_pyramidal": 1.0},
-        )
-
-    with pytest.raises(
-        TypeError,
-        match="probability must be an instance of "
-        r"float, got \<class 'str'\> instead",
-    ):
-        net.add_bursty_drive(
-            "cell_unknown2",
-            location="distal",
-            burst_rate=10,
-            weights_ampa={"L2_pyramidal": 1.0},
-            synaptic_delays={"L2_pyramidal": 1.0},
-            probability={"L2_pyramidal": "1.0"},
-        )
-
-    with pytest.raises(ValueError, match=r"probability must be in the range \(0\,1\)"):
-        net.add_bursty_drive(
-            "cell_unknown3",
-            location="distal",
-            burst_rate=10,
-            weights_ampa={"L2_pyramidal": 1.0},
-            synaptic_delays={"L2_pyramidal": 1.0},
-            probability={"L2_pyramidal": 2.0},
-        )
-
-    with pytest.warns(UserWarning, match="No external drives or biases load"):
-        net.clear_drives()
-        simulate_dipole(net, tstop=10)
 
 
 def test_drive_random_state():
@@ -685,6 +877,7 @@ def test_drive_random_state():
         "L5_basket": 1.0,
         "L5_pyramidal": 1.0,
     }
+
 
     net = jones_2009_model()
     for drive_name in ["evprox1", "evprox2"]:


### PR DESCRIPTION
This PR refactors the large test_drives test into smaller, focused test functions for evoked, bursty, and Poisson drives.

This change follows the discussion in #1118 (REF/TEST: Large test refactors), where it was suggested that long tests should be split into smaller, independent tests to improve readability, debugging, and maintainability of the test suite.

Change->
Split the large test_drives test into multiple smaller tests.

Added focused tests for:
evoked drives
bursty drives
poisson drives

Preserved existing assertions and behavior.

Testing->

All tests pass locally using pytest.
Code formatted with Ruff