### PR TITLE
[WIP] Add unit test for _any_positive_weights function

### DIFF
--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -198,3 +198,22 @@ class TestConvertToJson:
             TypeError, match="out_fname must be an instance of str or Path"
         ):
             convert_to_json(good_path, bad_path)
+
+def test_any_positive_weights():
+    """Test detection of positive synaptic weights"""
+
+    from hnn_core.params import _any_positive_weights
+
+    drive = {
+        "weights_ampa": {"cell1": 0.0},
+        "weights_nmda": {"cell1": 0.0},
+    }
+
+    assert _any_positive_weights(drive) is False
+
+    drive_positive = {
+        "weights_ampa": {"cell1": 0.5},
+        "weights_nmda": {"cell1": 0.0},
+    }
+
+    assert _any_positive_weights(drive_positive) is True


### PR DESCRIPTION
### Summary

Adds a unit test for the `_any_positive_weights` helper function in `hnn_core.params`.

### Motivation

The `_any_positive_weights` function determines whether a drive contains any positive synaptic weights and is used in the `remove_nulled_drives` logic. Adding a direct unit test improves coverage and ensures correct behavior when all weights are zero versus when at least one weight is positive.

### Changes

* Added `test_any_positive_weights` in `hnn_core/tests/test_params.py`
* Verified tests locally using pytest

### Testing

Ran:

pytest hnn_core/tests/test_params.py

All tests pass successfully.