### PR TITLE
Fix _hammfilt input validation and improve test coverage

### DIFF
--- a/hnn_core/tests/test_utils.py
+++ b/hnn_core/tests/test_utils.py
@@ -26,7 +26,7 @@ def test_hamming_smoothing():
     # Tests of data argument
     # ---------------------------------------------------------------
     # Even one sample short should raise an error
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Window size is too long"):
         smooth_waveform(
             np.arange((1e-3 * default_window_len * default_sfreq) - 1),
             default_window_len,
@@ -37,24 +37,42 @@ def test_hamming_smoothing():
     test_window_len, test_sfreq = 1, 1
     # data must be 1D
     for data in [[[1, 2], [3, 4]], np.array([[1, 2], [3, 4]])]:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="Smoothing currently only sup"):
             smooth_waveform(data, test_window_len, test_sfreq)
 
     # Tests of window_len
     # ---------------------------------------------------------------
     data, test_sfreq = np.random.random((100,)), 1
     # window_len is positive number, longer than data, >1ms, and not a float
-    for test_window_len in [None, -1, 1e6, 1e-1, 2.5]:
-        with pytest.raises(ValueError):
-            smooth_waveform(data, test_window_len, test_sfreq)
+    with pytest.raises(ValueError, match="Window length must be a non-negative number"):
+        smooth_waveform(data, None, test_sfreq)
+    with pytest.raises(ValueError, match="Window length must be a non-negative number"):
+        smooth_waveform(data, -1, test_sfreq)
+    with pytest.raises(ValueError, match="Window length less than 1 ms is"):
+        smooth_waveform(data, 1e-1, test_sfreq)
+    with pytest.raises(ValueError, match="Window size is too long"):
+        smooth_waveform(data, 1e6, test_sfreq)
+    with pytest.raises(ValueError, match="Window size is too small"):
+        smooth_waveform(data, 500, test_sfreq)
+    # Goldlocks: Window size is just right:
+    #     np.round(1e-3 * 501 * 1) = rounded to 1 sample
+    smooth_waveform(data, 501, test_sfreq)
 
     # Tests of sfreq
     # ---------------------------------------------------------------
     # sfreq is positive number
     data, test_window_len = np.random.random((100,)), 1
-    for test_sfreq in [None, [1], -1]:
-        with pytest.raises((TypeError, AssertionError, ValueError)):
-            smooth_waveform(data, test_window_len, test_sfreq)
+    with pytest.raises(TypeError):
+        smooth_waveform(data, test_window_len, None)
+    with pytest.raises(TypeError):
+        smooth_waveform(data, test_window_len, [1])
+    with pytest.raises(ValueError, match="Sampling frequency must be positive"):
+        smooth_waveform(data, test_window_len, -1)
+    with pytest.raises(ValueError, match="Window size is too small"):
+        smooth_waveform(data, test_window_len, 500)
+    # Goldlocks: Window size is just right:
+    #     np.round(1e-3 * 1 * 501) = rounded to 1 sample
+    smooth_waveform(data, test_window_len, 501)
 
 
 def test_savgol_filter():

--- a/hnn_core/tests/test_utils.py
+++ b/hnn_core/tests/test_utils.py
@@ -5,25 +5,38 @@ from hnn_core.utils import smooth_waveform, _hammfilt, _savgol_filter
 
 def test_hamming_smoothing():
     """Test hamming window convolution smoothing"""
-    # length of data must be > window size (in samples)
-    pytest.raises(AssertionError, _hammfilt, np.arange(10), 11)
+    with pytest.raises(ValueError, match="winsz must be smaller than input length"):
+        _hammfilt(np.arange(10), 11)
+
+    # invalid x type
+    with pytest.raises(TypeError):
+        _hammfilt("not_array", 5)
+
+    # invalid winsz type
+    with pytest.raises(TypeError):
+        _hammfilt(np.arange(10), "five")
+
+    # negative winsz
+    with pytest.raises(ValueError):
+        _hammfilt(np.arange(10), -1)
 
     window_len, sfreq = 1, 1
     # data must be 1D
     for data in [[[1, 2], [3, 4]], np.array([[1, 2], [3, 4]])]:
-        pytest.raises(RuntimeError, smooth_waveform, data, window_len, sfreq)
+        with pytest.raises(RuntimeError):
+            smooth_waveform(data, window_len, sfreq)
 
     # window_len is positive number, longer than data, and >1ms
     data, sfreq = np.random.random((100,)), 1
     for window_len in [None, -1, 1e6, 1e-1]:
-        pytest.raises(ValueError, smooth_waveform, data, window_len, sfreq)
+        with pytest.raises(ValueError):
+            smooth_waveform(data, window_len, sfreq)
 
     # sfreq is positive number
     data, window_len = np.random.random((100,)), 1
     for sfreq in [None, [1], -1]:
-        pytest.raises(
-            (TypeError, AssertionError), smooth_waveform, data, window_len, sfreq
-        )
+        with pytest.raises((TypeError, AssertionError)):
+            smooth_waveform(data, window_len, sfreq)
 
 
 def test_savgol_filter():
@@ -32,13 +45,40 @@ def test_savgol_filter():
 
     # h_freq is positive number and less than half the sampling rate
     for h_freq in [None, [1], -1, sfreq / 2]:
-        pytest.raises(
-            (TypeError, AssertionError, ValueError), _savgol_filter, data, h_freq, sfreq
-        )
+        with pytest.raises((TypeError, AssertionError, ValueError)):
+            _savgol_filter(data, h_freq, sfreq)
 
     h_freq = 0.6
     # sfreq is positive number and at least twice the cutoff frequency
     for sfreq in [None, [1], -1, 1]:
-        pytest.raises(
-            (TypeError, AssertionError, ValueError), _savgol_filter, data, h_freq, sfreq
-        )
+        with pytest.raises((TypeError, AssertionError, ValueError)):
+            _savgol_filter(data, h_freq, sfreq)
+
+
+def test_hammfilt_basic():
+    x = np.array([1, 2, 3, 4, 5])
+    result = _hammfilt(x, 3)
+    assert len(result) == len(x)
+
+
+def test_hammfilt_invalid_winsz():
+    x = np.array([1, 2, 3])
+    with pytest.raises(ValueError):
+        _hammfilt(x, 5)
+
+
+def test_hammfilt_invalid_type():
+    with pytest.raises(TypeError):
+        _hammfilt("abc", 3)
+
+
+def test_hammfilt_zero_window():
+    x = np.array([1, 2, 3])
+    with pytest.raises(ValueError):
+        _hammfilt(x, 0)
+
+
+def test_hammfilt_float_winsz():
+    x = np.array([1, 2, 3, 4])
+    result = _hammfilt(x, 2.5)
+    assert len(result) == len(x)

--- a/hnn_core/tests/test_utils.py
+++ b/hnn_core/tests/test_utils.py
@@ -5,8 +5,10 @@ from hnn_core.utils import smooth_waveform, _savgol_filter
 
 def test_hamming_smoothing():
     """Test hamming window convolution smoothing"""
-    with pytest.raises(ValueError, match="Window length too long.*"):
-        smooth_waveform(np.arange(10), 11000, 1)
+
+    # length of data must be > window size (in samples)
+    with pytest.raises(ValueError):
+        smooth_waveform(np.arange(10), 11, 1000)
 
     window_len, sfreq = 1, 1
     # data must be 1D
@@ -16,15 +18,19 @@ def test_hamming_smoothing():
 
     # window_len is positive number, longer than data, and >1ms
     data, sfreq = np.random.random((100,)), 1
-    for window_len in [-1, 1e6, 1e-1]:
+    for window_len in [None, -1, 1e6, 1e-1]:
         with pytest.raises(ValueError):
             smooth_waveform(data, window_len, sfreq)
 
     # sfreq is positive number
     data, window_len = np.random.random((100,)), 1
-    for sfreq in [-1]:
-        with pytest.raises(AssertionError):
+    for sfreq in [None, [1], -1]:
+        with pytest.raises((TypeError, AssertionError)):
             smooth_waveform(data, window_len, sfreq)
+
+    x = np.array([1, 2, 3, 4])
+    with pytest.raises(ValueError):
+        smooth_waveform(x, 2.5, 1)
 
 
 def test_savgol_filter():
@@ -32,26 +38,13 @@ def test_savgol_filter():
     data, sfreq = np.random.random((100,)), 1
 
     # h_freq is positive number and less than half the sampling rate
-    # negative h_freq → AssertionError
-    with pytest.raises(AssertionError):
-        _savgol_filter(data, -1, sfreq)
-
-    # too large h_freq → ValueError
-    with pytest.raises(ValueError):
-        _savgol_filter(data, sfreq / 2, sfreq)
+    for h_freq in [None, [1], -1, sfreq / 2]:
+        with pytest.raises((TypeError, AssertionError, ValueError)):
+            _savgol_filter(data, h_freq, sfreq)
 
     h_freq = 0.6
+
     # sfreq is positive number and at least twice the cutoff frequency
-    # invalid sfreq (<=0) → AssertionError
-    with pytest.raises(AssertionError):
-        _savgol_filter(data, h_freq, -1)
-
-    # too small sfreq → ValueError
-    with pytest.raises(ValueError):
-        _savgol_filter(data, h_freq, 1)
-
-
-def test_smooth_window_float_winsz():
-    x = np.array([1, 2, 3, 4])
-    result = smooth_waveform(x, 2.5, 1)
-    assert len(result) == len(x)
+    for sfreq in [None, [1], -1, 1]:
+        with pytest.raises((TypeError, AssertionError, ValueError)):
+            _savgol_filter(data, h_freq, sfreq)

--- a/hnn_core/tests/test_utils.py
+++ b/hnn_core/tests/test_utils.py
@@ -1,24 +1,12 @@
 import pytest
 import numpy as np
-from hnn_core.utils import smooth_waveform, _hammfilt, _savgol_filter
+from hnn_core.utils import smooth_waveform, _savgol_filter
 
 
 def test_hamming_smoothing():
     """Test hamming window convolution smoothing"""
-    with pytest.raises(ValueError, match="winsz must be smaller than input length"):
-        _hammfilt(np.arange(10), 11)
-
-    # invalid x type
-    with pytest.raises(TypeError):
-        _hammfilt("not_array", 5)
-
-    # invalid winsz type
-    with pytest.raises(TypeError):
-        _hammfilt(np.arange(10), "five")
-
-    # negative winsz
-    with pytest.raises(ValueError):
-        _hammfilt(np.arange(10), -1)
+    with pytest.raises(ValueError, match="Window length too long.*"):
+        smooth_waveform(np.arange(10), 11000, 1)
 
     window_len, sfreq = 1, 1
     # data must be 1D
@@ -28,14 +16,14 @@ def test_hamming_smoothing():
 
     # window_len is positive number, longer than data, and >1ms
     data, sfreq = np.random.random((100,)), 1
-    for window_len in [None, -1, 1e6, 1e-1]:
+    for window_len in [-1, 1e6, 1e-1]:
         with pytest.raises(ValueError):
             smooth_waveform(data, window_len, sfreq)
 
     # sfreq is positive number
     data, window_len = np.random.random((100,)), 1
-    for sfreq in [None, [1], -1]:
-        with pytest.raises((TypeError, AssertionError)):
+    for sfreq in [-1]:
+        with pytest.raises(AssertionError):
             smooth_waveform(data, window_len, sfreq)
 
 
@@ -44,41 +32,26 @@ def test_savgol_filter():
     data, sfreq = np.random.random((100,)), 1
 
     # h_freq is positive number and less than half the sampling rate
-    for h_freq in [None, [1], -1, sfreq / 2]:
-        with pytest.raises((TypeError, AssertionError, ValueError)):
-            _savgol_filter(data, h_freq, sfreq)
+    # negative h_freq → AssertionError
+    with pytest.raises(AssertionError):
+        _savgol_filter(data, -1, sfreq)
+
+    # too large h_freq → ValueError
+    with pytest.raises(ValueError):
+        _savgol_filter(data, sfreq / 2, sfreq)
 
     h_freq = 0.6
     # sfreq is positive number and at least twice the cutoff frequency
-    for sfreq in [None, [1], -1, 1]:
-        with pytest.raises((TypeError, AssertionError, ValueError)):
-            _savgol_filter(data, h_freq, sfreq)
+    # invalid sfreq (<=0) → AssertionError
+    with pytest.raises(AssertionError):
+        _savgol_filter(data, h_freq, -1)
 
-
-def test_hammfilt_basic():
-    x = np.array([1, 2, 3, 4, 5])
-    result = _hammfilt(x, 3)
-    assert len(result) == len(x)
-
-
-def test_hammfilt_invalid_winsz():
-    x = np.array([1, 2, 3])
+    # too small sfreq → ValueError
     with pytest.raises(ValueError):
-        _hammfilt(x, 5)
+        _savgol_filter(data, h_freq, 1)
 
 
-def test_hammfilt_invalid_type():
-    with pytest.raises(TypeError):
-        _hammfilt("abc", 3)
-
-
-def test_hammfilt_zero_window():
-    x = np.array([1, 2, 3])
-    with pytest.raises(ValueError):
-        _hammfilt(x, 0)
-
-
-def test_hammfilt_float_winsz():
+def test_smooth_window_float_winsz():
     x = np.array([1, 2, 3, 4])
-    result = _hammfilt(x, 2.5)
+    result = smooth_waveform(x, 2.5, 1)
     assert len(result) == len(x)

--- a/hnn_core/tests/test_utils.py
+++ b/hnn_core/tests/test_utils.py
@@ -5,18 +5,13 @@ from hnn_core.utils import smooth_waveform, _savgol_filter
 
 def test_hamming_smoothing():
     """Test hamming window convolution smoothing"""
-    # This uses our true default simulation window length of 30 samples and sampling
+    # This uses our true default simulation window length of 30 ms and sampling
     # rate of 40 kHz
     default_window_len = 30
     default_sfreq = 40000
 
-    # Our minimum window is (1e-3 * window_len * sfreq) in samples. Length of data must
-    # be > window size (in samples).
-    #
-    # @ntolley TODO it turns out that our original tests did NOT actually include a test
-    # of successful `smooth_waveform` execution, and instead only tested failure modes.
-    # This adds a test of successful execution. This comment should be removed after
-    # review.
+    # Our minimum window size is (1e-3 * window_len * sfreq) in samples. The size of the
+    # data array must be > window size (in samples).
     smooth_waveform(
         np.arange(1e-3 * default_window_len * default_sfreq),
         default_window_len,

--- a/hnn_core/tests/test_utils.py
+++ b/hnn_core/tests/test_utils.py
@@ -26,7 +26,7 @@ def test_hamming_smoothing():
     # sfreq is positive number
     data, window_len = np.random.random((100,)), 1
     for sfreq in [None, [1], -1]:
-        with pytest.raises((TypeError, AssertionError)):
+        with pytest.raises((TypeError, AssertionError, ValueError)):
             smooth_waveform(data, window_len, sfreq)
 
     x = np.array([1, 2, 3, 4])

--- a/hnn_core/tests/test_utils.py
+++ b/hnn_core/tests/test_utils.py
@@ -7,8 +7,9 @@ def test_hamming_smoothing():
     """Test hamming window convolution smoothing"""
 
     # length of data must be > window size (in samples)
+    # This uses our true default simulation sampling rate of 40 kHz
     with pytest.raises(ValueError):
-        smooth_waveform(np.arange(10), 11, 1000)
+        smooth_waveform(np.arange(10), 11, 40000)
 
     window_len, sfreq = 1, 1
     # data must be 1D

--- a/hnn_core/tests/test_utils.py
+++ b/hnn_core/tests/test_utils.py
@@ -5,33 +5,56 @@ from hnn_core.utils import smooth_waveform, _savgol_filter
 
 def test_hamming_smoothing():
     """Test hamming window convolution smoothing"""
+    # This uses our true default simulation window length of 30 samples and sampling
+    # rate of 40 kHz
+    default_window_len = 30
+    default_sfreq = 40000
 
-    # length of data must be > window size (in samples)
-    # This uses our true default simulation sampling rate of 40 kHz
+    # Our minimum window is (1e-3 * window_len * sfreq) in samples. Length of data must
+    # be > window size (in samples).
+    #
+    # @ntolley TODO it turns out that our original tests did NOT actually include a test
+    # of successful `smooth_waveform` execution, and instead only tested failure modes.
+    # This adds a test of successful execution. This comment should be removed after
+    # review.
+    smooth_waveform(
+        np.arange(1e-3 * default_window_len * default_sfreq),
+        default_window_len,
+        default_sfreq,
+    )
+
+    # Tests of data argument
+    # ---------------------------------------------------------------
+    # Even one sample short should raise an error
     with pytest.raises(ValueError):
-        smooth_waveform(np.arange(10), 11, 40000)
+        smooth_waveform(
+            np.arange((1e-3 * default_window_len * default_sfreq) - 1),
+            default_window_len,
+            default_sfreq,
+        )
 
-    window_len, sfreq = 1, 1
+    # simpler values for other arguments
+    test_window_len, test_sfreq = 1, 1
     # data must be 1D
     for data in [[[1, 2], [3, 4]], np.array([[1, 2], [3, 4]])]:
         with pytest.raises(RuntimeError):
-            smooth_waveform(data, window_len, sfreq)
+            smooth_waveform(data, test_window_len, test_sfreq)
 
-    # window_len is positive number, longer than data, and >1ms
-    data, sfreq = np.random.random((100,)), 1
-    for window_len in [None, -1, 1e6, 1e-1]:
+    # Tests of window_len
+    # ---------------------------------------------------------------
+    data, test_sfreq = np.random.random((100,)), 1
+    # window_len is positive number, longer than data, >1ms, and not a float
+    for test_window_len in [None, -1, 1e6, 1e-1, 2.5]:
         with pytest.raises(ValueError):
-            smooth_waveform(data, window_len, sfreq)
+            smooth_waveform(data, test_window_len, test_sfreq)
 
+    # Tests of sfreq
+    # ---------------------------------------------------------------
     # sfreq is positive number
-    data, window_len = np.random.random((100,)), 1
-    for sfreq in [None, [1], -1]:
+    data, test_window_len = np.random.random((100,)), 1
+    for test_sfreq in [None, [1], -1]:
         with pytest.raises((TypeError, AssertionError, ValueError)):
-            smooth_waveform(data, window_len, sfreq)
-
-    x = np.array([1, 2, 3, 4])
-    with pytest.raises(ValueError):
-        smooth_waveform(x, 2.5, 1)
+            smooth_waveform(data, test_window_len, test_sfreq)
 
 
 def test_savgol_filter():

--- a/hnn_core/utils.py
+++ b/hnn_core/utils.py
@@ -148,11 +148,6 @@ def smooth_waveform(data, window_len, sfreq):
     # convolutional filter length is given in samples
     winsz = int(np.round(1e-3 * window_len * sfreq))
     if winsz < 1:
-        # @ntolley TODO AES: I now believe this check is correct. Since winsz must be an
-        # integer and cannot be negative, it can either be 0 or positive. If 0, then in
-        # `_hammfilt`, the window will be an empty array and np.convolve fails since
-        # then its second argument is empty, which it cannot be. Therefore, winsz must
-        # be >= 1 always. This comment should be removed after review.
         raise ValueError(
             f"Window size is too small: {winsz} samples. Window size is given by "
             "(1e-3 * window_len * sfreq) and must be >= 1."

--- a/hnn_core/utils.py
+++ b/hnn_core/utils.py
@@ -9,7 +9,16 @@ from .externals.mne import _validate_type
 
 
 def _hammfilt(x, winsz):
-    """Convolve with a hamming window."""
+    """Convolve with a hamming window.
+
+    Parameters
+    ----------
+    x : list | np.ndarray
+        The data to filter
+    winsz : int
+        The size (in samples) of a `~numpy.hamming` window to convolve the data with.
+        This must be an integer that is >= 1.
+    """
 
     win = np.hamming(winsz)
     win /= np.sum(win)
@@ -102,13 +111,19 @@ def _savgol_filter(data, h_freq, sfreq):
 def smooth_waveform(data, window_len, sfreq):
     """Smooth an arbitrary waveform using Hamming-windowed convolution
 
+    This takes ``window_len`` ("window length" in ms) and ``sfreq`` (sampling frequency
+    in Hz) to determine the ``winsz`` ("window size" in samples) of a Hamming window to
+    convolve with the data. The final "window size" must be >= 1 and is defined
+    by the following equation:
+
+        winsz = 1e-3 * window_len * sfreq
+
     Parameters
     ----------
     data : list | np.ndarray
         The data to filter
     window_len : float
-        The length (in ms) of a `~numpy.hamming` window to convolve the
-        data with.
+        The length (in ms) of a `~numpy.hamming` window to convolve the data with.
     sfreq : float
         The data sampling rate (in Hz).
 
@@ -120,7 +135,7 @@ def smooth_waveform(data, window_len, sfreq):
     if (isinstance(data, np.ndarray) and data.ndim > 1) or (
         isinstance(data, list) and isinstance(data[0], list)
     ):
-        raise RuntimeError("smoothing currently only supported for 1D-arrays")
+        raise RuntimeError("Smoothing currently only supported for 1D-arrays")
 
     if not isinstance(window_len, (float, int)) or window_len < 0:
         raise ValueError("Window length must be a non-negative number")
@@ -133,11 +148,18 @@ def smooth_waveform(data, window_len, sfreq):
     # convolutional filter length is given in samples
     winsz = int(np.round(1e-3 * window_len * sfreq))
     if winsz < 1:
-        raise ValueError("Window length too small")
+        # @ntolley TODO AES: I now believe this check is correct. Since winsz must be an
+        # integer and cannot be negative, it can either be 0 or positive. If 0, then in
+        # `_hammfilt`, the window will be an empty array and np.convolve fails since
+        # then its second argument is empty, which it cannot be. Therefore, winsz must
+        # be >= 1 always. This comment should be removed after review.
+        raise ValueError(
+            f"Window size is too small: {winsz} samples. Window size is given by "
+            "(1e-3 * window_len * sfreq) and must be >= 1."
+        )
     if winsz > len(data):
         raise ValueError(
-            f"Window length too long: {winsz} samples; data length is "
-            f"{len(data)} samples"
+            f"Window size is too long: {winsz} samples; data length is {len(data)} samples"
         )
 
     return _hammfilt(data, winsz)

--- a/hnn_core/utils.py
+++ b/hnn_core/utils.py
@@ -10,10 +10,6 @@ from .externals.mne import _validate_type
 
 def _hammfilt(x, winsz):
     """Convolve with a hamming window."""
-    winsz = int(winsz)
-
-    if winsz <= 0:
-        return x
 
     win = np.hamming(winsz)
     win /= np.sum(win)
@@ -132,7 +128,9 @@ def smooth_waveform(data, window_len, sfreq):
     _validate_type(sfreq, (float, int), "sfreq")
     assert sfreq > 0.0
     # convolutional filter length is given in samples
-    winsz = np.round(1e-3 * window_len * sfreq)
+    winsz = int(np.round(1e-3 * window_len * sfreq))
+    if winsz < 1:
+        raise ValueError("Window length too small")
     if winsz > len(data):
         raise ValueError(
             f"Window length too long: {winsz} samples; data length is "

--- a/hnn_core/utils.py
+++ b/hnn_core/utils.py
@@ -10,9 +10,21 @@ from .externals.mne import _validate_type
 
 def _hammfilt(x, winsz):
     """Convolve with a hamming window."""
-    assert len(x) > winsz
+    if not isinstance(x, (list, np.ndarray)):
+        raise TypeError("x must be a list or numpy array")
+
+    if not isinstance(winsz, (int, float)):
+        raise TypeError("winsz must be a number")
+
+    winsz = int(winsz)
+
+    if winsz <= 0:
+        raise ValueError("winsz must be positive")
+
+    if len(x) < winsz:
+        raise ValueError("winsz must be smaller than input length")
     win = np.hamming(winsz)
-    win /= sum(win)
+    win /= np.sum(win)
     return np.convolve(x, win, "same")
 
 

--- a/hnn_core/utils.py
+++ b/hnn_core/utils.py
@@ -82,9 +82,11 @@ def _savgol_filter(data, h_freq, sfreq):
     from scipy.signal import savgol_filter
 
     _validate_type(sfreq, (float, int), "sfreq")
-    assert sfreq > 0.0
+    if sfreq <= 0.0:
+        raise ValueError("Sampling frequency must be positive")
     _validate_type(h_freq, (float, int), "h_freq")
-    assert h_freq > 0.0
+    if h_freq <= 0.0:
+        raise ValueError("High cutoff frequency must be positive")
 
     h_freq = float(h_freq)
     if h_freq >= sfreq / 2.0:
@@ -126,7 +128,8 @@ def smooth_waveform(data, window_len, sfreq):
         raise ValueError("Window length less than 1 ms is not supported")
 
     _validate_type(sfreq, (float, int), "sfreq")
-    assert sfreq > 0.0
+    if sfreq <= 0.0:
+        raise ValueError("Sampling frequency must be positive")
     # convolutional filter length is given in samples
     winsz = int(np.round(1e-3 * window_len * sfreq))
     if winsz < 1:

--- a/hnn_core/utils.py
+++ b/hnn_core/utils.py
@@ -10,19 +10,11 @@ from .externals.mne import _validate_type
 
 def _hammfilt(x, winsz):
     """Convolve with a hamming window."""
-    if not isinstance(x, (list, np.ndarray)):
-        raise TypeError("x must be a list or numpy array")
-
-    if not isinstance(winsz, (int, float)):
-        raise TypeError("winsz must be a number")
-
     winsz = int(winsz)
 
     if winsz <= 0:
-        raise ValueError("winsz must be positive")
+        return x
 
-    if len(x) < winsz:
-        raise ValueError("winsz must be smaller than input length")
     win = np.hamming(winsz)
     win /= np.sum(win)
     return np.convolve(x, win, "same")

--- a/hnn_core/utils.py
+++ b/hnn_core/utils.py
@@ -108,7 +108,7 @@ def smooth_waveform(data, window_len, sfreq):
         The length (in ms) of a `~numpy.hamming` window to convolve the
         data with.
     sfreq : float
-        The data sampling rate.
+        The data sampling rate (in Hz).
 
     Returns
     -------


### PR DESCRIPTION
This PR replaces the use of `assert` in `_hammfilt` with explicit input validation and proper exception handling.

`assert` statements can be removed when Python is run with optimizations, which makes them unsuitable for validating user inputs or runtime conditions. Replacing them with explicit exceptions ensures consistent behavior and improves robustness.

Changes:
- Added type checks for `x` and `winsz`
- Ensured `winsz` is positive and smaller than input length
- Replaced assertion with appropriate exceptions
- Updated tests to use modern `pytest.raises` context manager
- Added additional test cases to cover edge conditions