### PR TITLE
TST: should law_2021_model and calcium_model be tested with custom mesh_shape?

### DIFF
--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -34,8 +34,12 @@ merged into `master`! Use `git log` instead and cross-reference instead. -->
 - [Tushar Jamdade][]
 - [Karthikeya Kodlai][]
 - [M Yaswanth Reddy][]
+- [Satvik Saluja][]
 
 ### Changelog
+
+- Fix testing of `mesh_shape` to include all available network models,
+  by [Satvik Saluja][] in {gh}`1268`. This was their first PR, thanks Satvik!
 
 - Improve UX of GUI's "Delete all drives" button and small refactors of GUI codebase. 
   By [Muhammad Ahmad Amin][] in {gh}`1245`. This was their first PR, thanks Muhammad!
@@ -1282,3 +1286,4 @@ v0.4 represents a major milestone in development of `hnn_core` and the HNN ecosy
 [Tushar Jamdade]: https://github.com/Tusharjamdade
 [M Yaswanth Reddy]: https://github.com/Yaswanth8390
 [Muhammad Ahmad Amin]: https://github.com/m-ahmad-amin
+[Satvik Saluja]: https://github.com/SatvikSaluja

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -1265,10 +1265,9 @@ def test_network_mesh():
     with pytest.raises(TypeError, match="mesh_shape must be"):
         net = Network(params, mesh_shape="abc")  # noqa: F841
 
-
 @pytest.mark.parametrize(
     "network_model",
-    [jones_2009_model],  # TEMP JUST FOR DEBUGGING FOCUS ON JONES
+    [jones_2009_model, law_2021_model, calcium_model],
 )
 def test_network_models_mesh(network_model):
     mesh_shape = (2, 3)
@@ -1277,8 +1276,11 @@ def test_network_models_mesh(network_model):
     assert dp is not None
     assert len(dp[0].times) > 0
     assert np.all(np.isfinite(dp[0].data["agg"]))
+    assert net._N_pyr_x == mesh_shape[0]
+    assert net._N_pyr_y == mesh_shape[1]
+    assert len(net.pos_dict["L2_pyramidal"]) == mesh_shape[0] * mesh_shape[1]
+    assert len(net.pos_dict["L5_pyramidal"]) == mesh_shape[0] * mesh_shape[1]
     del net, dp
-
 
 def test_set_global_synaptic_gains():
     """Test synaptic gains setter"""

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -1265,6 +1265,7 @@ def test_network_mesh():
     with pytest.raises(TypeError, match="mesh_shape must be"):
         net = Network(params, mesh_shape="abc")  # noqa: F841
 
+
 @pytest.mark.parametrize(
     "network_model",
     [jones_2009_model, law_2021_model, calcium_model],
@@ -1281,6 +1282,7 @@ def test_network_models_mesh(network_model):
     assert len(net.pos_dict["L2_pyramidal"]) == mesh_shape[0] * mesh_shape[1]
     assert len(net.pos_dict["L5_pyramidal"]) == mesh_shape[0] * mesh_shape[1]
     del net, dp
+
 
 def test_set_global_synaptic_gains():
     """Test synaptic gains setter"""


### PR DESCRIPTION
While reviewing the test suite, I noticed `test_network_models_mesh` only 
tests `jones_2009_model` with a custom `mesh_shape`, with the comment 
`# TEMP JUST FOR DEBUGGING FOCUS ON JONES` suggesting the other models 
were intentionally skipped temporarily but never re-enabled.

Both `law_2021_model` and `calcium_model` already accept `mesh_shape` 
(passing it through to `jones_2009_model` internally), but are never 
tested with it. This matters because both models mutate the network after 
construction — `law_2021_model` modifies connectivity indices and synapse 
parameters, `calcium_model` swaps the L5 pyramidal cell object — so it's 
worth verifying mesh dimensions survive those modifications.

This PR extends the parametrize list to include all three models and adds 
assertions confirming mesh dimensions are correctly preserved. All 228 
tests pass locally.

Is there a reason `law_2021_model` and `calcium_model` were intentionally 
excluded here?