### PR TITLE
[MRG] Add test etc files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,19 +26,30 @@ tags
 cover
 
 # IDE programs
-.cursor
+.cursor/
 .idea/
 .vscode/
 
 # AI and LLMs
+.claude/
+.codex/
 AGENTS.md
 CLAUDE.md
 GEMINI.md
 
-# Testing
+# Downloaded or created during testing
+.pytest_cache
 dpl.txt
 dpl2.txt
-.pytest_cache
+saved_network.json
+survey_seen.json
+yes_trial_S1_ERP_all_avg.txt
+hnn_core/param/base.json
+hnn_core/param/default.param
+hnn_core/param/empty.json
+hnn_core/param/ERPYes100Trials.json
+hnn_core/param/ERPYes100Trials.param
+
 
 # Caches, compilations, and other
 *.pyc


### PR DESCRIPTION
This adds gitignores for the remaining files that are downloaded or created as a result of tests being run. This is helpful because new users tend to run tests and then stage their files using `git add --all`, which unnecessarily adds these files to their PR. This will help prevent this in the future.

This also adds ignores for any local config directories for both Anthropic's Claude Code and OpenAI's Codex.