### PR TITLE
[MRG] ACS: GUI accessibility improvements

### DIFF
--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -34,8 +34,11 @@ _fig_placeholder = HTML(
     value="""
         Visualizations will become available in this window after a simulation has been
         run or data have been loaded
-    """
-).add_class("fig-placeholder")
+    """,
+    description="Visualization placeholder",
+)
+_fig_placeholder.add_class("fig-placeholder")
+_fig_placeholder.add_class("hide-label")
 
 _plot_types = [
     "current dipole",

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -657,7 +657,10 @@ def _plot_on_axes(
 
     existing_plots.children = (
         *existing_plots.children,
-        Label(f"{sim_name}: {plot_type}"),
+        Label(
+            f"{sim_name}: {plot_type}",
+            description=f"{sim_name}: {plot_type}",
+        ).add_class("hide-label"),
     )
     if data["use_ipympl"] is False:
         _static_rerender(widgets, fig, fig_idx)

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -809,6 +809,7 @@ class HNNGUI:
         self.simulation_list_widget = Dropdown(
             options=["Simulation Output to Save"],
             value="Simulation Output to Save",
+            description="Simulation output:",
             disabled=True,
             layout=Layout(
                 width="50%",
@@ -816,6 +817,7 @@ class HNNGUI:
                 min_width="0",  # forces text to truncate
             ),
         ).add_class("simulation-list-widget")
+        self.simulation_list_widget.add_class("hide-label")
 
         # ==================================================
         # Network tab
@@ -948,7 +950,7 @@ class HNNGUI:
         </a>
         """
         # Create widget wrapper
-        return HTML(
+        html_widget = HTML(
             self.html_download_button.format(
                 payload=payload,
                 filename={""},
@@ -958,8 +960,11 @@ class HNNGUI:
                 color_theme=self.layout["theme_color"],
                 title=title,
                 mimetype=mimetype,
-            )
+            ),
+            description=title,
         )
+        html_widget.add_class("hide-label")
+        return html_widget
 
     def add_logging_window_logger(self):
         handler = _OutputWidgetHandler(self._log_out)
@@ -1000,6 +1005,7 @@ class HNNGUI:
         # toggle button
         self._log_toggle_btn = Button(
             icon="chevron-down",
+            description="Toggle Log View",
             layout=Layout(width="30px", height="30px"),
             tooltip="Toggle Log View",
         ).add_class("log-toggle-icon")
@@ -1071,11 +1077,16 @@ class HNNGUI:
                         height: 20px;
                         display: flex;
                         align-items: center;
-                        cursor: pointer;
                     ">
-                        <div style="width: 20px; height: 20px; display: flex;"
-                            onclick="hnnToggleTheme()">
-                            <svg id="sun-svg" viewBox="0 0 512 512" style="
+                        <button style="
+                            width: 20px; height: 20px; display: flex;
+                            background: none; border: none; padding: 0;
+                            cursor: pointer;
+                            "
+                            onclick="hnnToggleTheme()"
+                            aria-label="Toggle dark mode">
+                            <svg id="sun-svg" viewBox="0 0 512 512"
+                                aria-hidden="true" style="
                                 fill: white;
                                 display: block;
                                 width: 100%;
@@ -1083,7 +1094,8 @@ class HNNGUI:
                             ">
                                 <path d="{sun_icon}"></path>
                             </svg>
-                            <svg id="moon-svg" viewBox="0 0 384 512" style="
+                            <svg id="moon-svg" viewBox="0 0 384 512"
+                                aria-hidden="true" style="
                                 fill: white;
                                 display: none;
                                 width: 100%;
@@ -1091,7 +1103,7 @@ class HNNGUI:
                             ">
                                 <path d="{moon_icon}"></path>
                             </svg>
-                        </div>
+                        </button>
                     </div>
                 </div>
             """,
@@ -1299,7 +1311,10 @@ class HNNGUI:
 
         simulation_box = VBox(
             [
-                HTML("Simulation Parameters").add_class("sim-tab-titles"),
+                HTML(
+                    "Simulation Parameters",
+                    description="Simulation parameters heading",
+                ).add_class("sim-tab-titles").add_class("hide-label"),
                 VBox(
                     [
                         self.widget_simulation_name,
@@ -1314,7 +1329,10 @@ class HNNGUI:
                 # help prevent any "smushing" or overlap that may appear on some
                 # OS/browser combinations but not others:
                 Box().add_class("dynamic-spacer"),
-                HTML("Default Visualization Parameters").add_class("sim-tab-titles"),
+                HTML(
+                    "Default Visualization Parameters",
+                    description="Default visualization parameters heading",
+                ).add_class("sim-tab-titles").add_class("hide-label"),
                 VBox(
                     [
                         self.widget_default_smoothing,
@@ -1531,6 +1549,7 @@ class HNNGUI:
                 src="{minimal_img_src}"
                 onload="{gui_scripts}"
                 style="display:none;"
+                alt=""
             >
         """
 
@@ -1831,7 +1850,10 @@ class HNNGUI:
         ).add_class("red-button")
         delete_button.on_click(self._delete_single_drive)
         drive_box.children += (
-            HTML(value="<p> </p>"),  # Adds blank space
+            HTML(
+                value="<p> </p>",
+                description="Spacer",
+            ).add_class("hide-label"),  # Adds blank space
             delete_button,
         )
 
@@ -2164,8 +2186,10 @@ def _get_connectivity_widgets(conn_data, global_gain_textfields):
             [
                 HTML(
                     value=f"""<p style='margin:5px;'><b>{html_tab}{html_tab}
-            Receptor: {display_name}</b></p>"""
-                ),
+            Receptor: {display_name}</b></p>""",
+                    description=f"Receptor: "
+                    f"{conn_data[receptor_name]['receptor']}",
+                ).add_class("hide-label"),
                 HBox(
                     [
                         weight_text_input,
@@ -2256,11 +2280,20 @@ def _get_drive_weight_widgets(layout, style, location, data=None):
         "delays": delays,
     }
     widgets_list = (
-        [HTML(value="<b>AMPA weights</b>")]
+        [HTML(
+            value="<b>AMPA weights</b>",
+            description="AMPA weights heading",
+        ).add_class("hide-label")]
         + list(weights_ampa.values())
-        + [HTML(value="<b>NMDA weights</b>")]
+        + [HTML(
+            value="<b>NMDA weights</b>",
+            description="NMDA weights heading",
+        ).add_class("hide-label")]
         + list(weights_nmda.values())
-        + [HTML(value="<b>Synaptic delays</b>")]
+        + [HTML(
+            value="<b>Synaptic delays</b>",
+            description="Synaptic delays heading",
+        ).add_class("hide-label")]
         + list(delays.values())
     )
     return widgets_list, widgets_dict
@@ -2488,7 +2521,10 @@ def _get_poisson_widget(
     )
     widgets_dict.update({"rate_constant": rate_constant})
     widgets_list.extend(
-        [HTML(value="<b>Rate constants</b>")]
+        [HTML(
+            value="<b>Rate constants</b>",
+            description="Rate constants heading",
+        ).add_class("hide-label")]
         + list(widgets_dict["rate_constant"].values())
     )
 
@@ -2644,9 +2680,15 @@ def _get_tonic_widget(name, tstop_widget, layout, style, data=None):
 
     widgets_dict = {"amplitude": amplitudes, "t0": start_times, "tstop": stop_times}
     widgets_list = (
-        [HTML(value="<b>Times (ms):</b>")]
+        [HTML(
+            value="<b>Times (ms):</b>",
+            description="Times heading",
+        ).add_class("hide-label")]
         + [start_times, stop_times]
-        + [HTML(value="<b>Amplitude (nA):</b>")]
+        + [HTML(
+            value="<b>Amplitude (nA):</b>",
+            description="Amplitude heading",
+        ).add_class("hide-label")]
         + list(amplitudes.values())
     )
 

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1314,7 +1314,9 @@ class HNNGUI:
                 HTML(
                     "Simulation Parameters",
                     description="Simulation parameters heading",
-                ).add_class("sim-tab-titles").add_class("hide-label"),
+                )
+                .add_class("sim-tab-titles")
+                .add_class("hide-label"),
                 VBox(
                     [
                         self.widget_simulation_name,
@@ -1332,7 +1334,9 @@ class HNNGUI:
                 HTML(
                     "Default Visualization Parameters",
                     description="Default visualization parameters heading",
-                ).add_class("sim-tab-titles").add_class("hide-label"),
+                )
+                .add_class("sim-tab-titles")
+                .add_class("hide-label"),
                 VBox(
                     [
                         self.widget_default_smoothing,
@@ -2187,8 +2191,7 @@ def _get_connectivity_widgets(conn_data, global_gain_textfields):
                 HTML(
                     value=f"""<p style='margin:5px;'><b>{html_tab}{html_tab}
             Receptor: {display_name}</b></p>""",
-                    description=f"Receptor: "
-                    f"{conn_data[receptor_name]['receptor']}",
+                    description=f"Receptor: {conn_data[receptor_name]['receptor']}",
                 ).add_class("hide-label"),
                 HBox(
                     [
@@ -2280,20 +2283,26 @@ def _get_drive_weight_widgets(layout, style, location, data=None):
         "delays": delays,
     }
     widgets_list = (
-        [HTML(
-            value="<b>AMPA weights</b>",
-            description="AMPA weights heading",
-        ).add_class("hide-label")]
+        [
+            HTML(
+                value="<b>AMPA weights</b>",
+                description="AMPA weights heading",
+            ).add_class("hide-label")
+        ]
         + list(weights_ampa.values())
-        + [HTML(
-            value="<b>NMDA weights</b>",
-            description="NMDA weights heading",
-        ).add_class("hide-label")]
+        + [
+            HTML(
+                value="<b>NMDA weights</b>",
+                description="NMDA weights heading",
+            ).add_class("hide-label")
+        ]
         + list(weights_nmda.values())
-        + [HTML(
-            value="<b>Synaptic delays</b>",
-            description="Synaptic delays heading",
-        ).add_class("hide-label")]
+        + [
+            HTML(
+                value="<b>Synaptic delays</b>",
+                description="Synaptic delays heading",
+            ).add_class("hide-label")
+        ]
         + list(delays.values())
     )
     return widgets_list, widgets_dict
@@ -2521,10 +2530,12 @@ def _get_poisson_widget(
     )
     widgets_dict.update({"rate_constant": rate_constant})
     widgets_list.extend(
-        [HTML(
-            value="<b>Rate constants</b>",
-            description="Rate constants heading",
-        ).add_class("hide-label")]
+        [
+            HTML(
+                value="<b>Rate constants</b>",
+                description="Rate constants heading",
+            ).add_class("hide-label")
+        ]
         + list(widgets_dict["rate_constant"].values())
     )
 
@@ -2680,15 +2691,19 @@ def _get_tonic_widget(name, tstop_widget, layout, style, data=None):
 
     widgets_dict = {"amplitude": amplitudes, "t0": start_times, "tstop": stop_times}
     widgets_list = (
-        [HTML(
-            value="<b>Times (ms):</b>",
-            description="Times heading",
-        ).add_class("hide-label")]
+        [
+            HTML(
+                value="<b>Times (ms):</b>",
+                description="Times heading",
+            ).add_class("hide-label")
+        ]
         + [start_times, stop_times]
-        + [HTML(
-            value="<b>Amplitude (nA):</b>",
-            description="Amplitude heading",
-        ).add_class("hide-label")]
+        + [
+            HTML(
+                value="<b>Amplitude (nA):</b>",
+                description="Amplitude heading",
+            ).add_class("hide-label")
+        ]
         + list(amplitudes.values())
     )
 

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -990,8 +990,10 @@ class HNNGUI:
         # static parts
         # Running status
         self._simulation_status_bar = HTML(
-            value=self._simulation_status_contents["not_running"]
+            value=self._simulation_status_contents["not_running"],
+            description="Simulation status",
         )
+        self._simulation_status_bar.add_class("hide-label")
 
         # log window with toggle
         # --------------------------------------------------
@@ -1093,7 +1095,9 @@ class HNNGUI:
                     </div>
                 </div>
             """,
+            description="AES TODO",
         )
+        self._header.add_class("hide-label")
 
     @property
     def analysis_config(self):
@@ -2071,8 +2075,10 @@ def _get_connectivity_widgets(conn_data, global_gain_textfields):
                     1
                     + (global_gain_textfields[global_gain_type].value - 1)
                     + (single_gain_text_input.value - 1)
-                ):.2f}</b></p>"""
+                ):.2f}</b></p>""",
+            description="Total computed gain",
         )
+        combined_gain_indicator_output.add_class("hide-label")
 
         # Create closure to capture current widget references
         def make_update_gain_indicator(gain_output, gain_input, gain_type):
@@ -2108,8 +2114,10 @@ def _get_connectivity_widgets(conn_data, global_gain_textfields):
                         + (global_gain_textfields[global_gain_type].value - 1)
                         + (single_gain_text_input.value - 1)
                     )
-                ):.4f}</b>"""
+                ):.4f}</b>""",
+            description="Final weight",
         )
+        final_weight_indicator_output.add_class("hide-label")
 
         # Create closure to capture current widget references
         def make_update_weight_indicator(
@@ -2802,8 +2810,10 @@ def add_network_connectivity_tab(
         ">
         Global Synaptic Gain Modifiers
         </div>
-        """
+        """,
+        description="Global synaptic gain modifiers",
     )
+    title_box.add_class("hide-label")
 
     left_box = VBox(
         [
@@ -2922,7 +2932,9 @@ def add_network_connectivity_tab(
         </style>
         """,
         layout=Layout(display="none"),
+        description="Connectivity styles",
     )
+    connectivity_out_style.add_class("hide-label")
 
     # Display the Accordion with styling
     with connectivity_out:

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -629,7 +629,7 @@ class HNNGUI:
                 <div
                 class='sim-status-box'
                 style='
-                    background:#545454;
+                    background:var(--acs-friendly-background);
                     padding-left:10px;
                     color:white;
                 '>
@@ -2859,7 +2859,7 @@ def add_network_connectivity_tab(
         """
         <div
         style="
-            background: #545454;
+            background: var(--acs-friendly-background);
             color: white;
             width: 100%;
             margin-bottom: 2px;

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -629,7 +629,7 @@ class HNNGUI:
                 <div
                 class='sim-status-box'
                 style='
-                    background:gray;
+                    background:#545454;
                     padding-left:10px;
                     color:white;
                 '>
@@ -642,7 +642,7 @@ class HNNGUI:
                 style='
                     background:var(--statusbar-running);
                     padding-left:10px;
-                    color:white;
+                    color:black;
                 '>
                     Running...
                 </div>
@@ -653,7 +653,7 @@ class HNNGUI:
                 style='
                     background:var(--gentle-green);
                     padding-left:10px;
-                    color:white;
+                    color:black;
                 '>
                     Simulation finished
                 </div>
@@ -664,7 +664,7 @@ class HNNGUI:
                 style='
                     background:var(--gentle-red);
                     padding-left:10px;
-                    color:white;
+                    color:black;
                 '>
                     Simulation failed
                 </div>
@@ -2859,7 +2859,7 @@ def add_network_connectivity_tab(
         """
         <div
         style="
-            background: gray;
+            background: #545454;
             color: white;
             width: 100%;
             margin-bottom: 2px;

--- a/hnn_core/gui/gui_styles.css
+++ b/hnn_core/gui/gui_styles.css
@@ -914,3 +914,23 @@ padding-bottom: 10px !important;
 .dark-mode .visualization-window .lm-TabBar-content::after {
     border-bottom: 2px solid var(--dm-theme) !important;
 }
+
+/*
+Source - https://stackoverflow.com/a/71369523
+Posted by GrahamTheDev
+Retrieved 2026-04-08, License - CC BY-SA 4.0
+*/
+/* AES: This "hide-label" part was adapted to our needs with Claude */
+.hide-label > .widget-label {
+    border: 0;
+    padding: 0;
+    margin: 0;
+    position: absolute !important;
+    height: 1px; 
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 - a 0 height clip, off to the bottom right of the visible 1px box */
+    clip: rect(1px, 1px, 1px, 1px); /*maybe deprecated but we need to support legacy browsers */
+    clip-path: inset(50%); /*modern browsers, clip-path works inwards from each corner*/
+    white-space: nowrap; /* added line to stop words getting smushed together (as they go onto separate lines and some screen readers do not understand line feeds as a space */
+}

--- a/hnn_core/gui/gui_styles.css
+++ b/hnn_core/gui/gui_styles.css
@@ -352,6 +352,7 @@ padding-bottom: 10px !important;
     color: var(--textbook-light-purple);
     background: transparent !important;
     border: none !important;
+    font-size: 0 !important;
 }
 
 /*  remove focus effects on the icon  */

--- a/hnn_core/gui/gui_styles.css
+++ b/hnn_core/gui/gui_styles.css
@@ -15,6 +15,7 @@
     --jp-error-color1: var(--gentle-red) !important;
     --tab-color: white;
     --tab-border: lightgrey;
+    --acs-friendly-background: #595959;
 }
 
 /*  center the entire AppLayout container
@@ -214,7 +215,7 @@ padding-bottom: 10px !important;
     default visualization parameters
 */
 .sim-tab-titles {
-    background: #545454;
+    background: var(--acs-friendly-background);
     color: white;
     width: 300px;
     padding: 0px 5px;
@@ -456,7 +457,7 @@ padding-bottom: 10px !important;
 
 /*  style figure placeholder text  */
 .fig-placeholder .widget-html-content {
-    color: #545454;
+    color: var(--acs-friendly-background);
     font-size: 13px;
     margin-top: 6px;
     text-align: center;
@@ -691,7 +692,7 @@ padding-bottom: 10px !important;
 /*  adjust the style for all TabBar tabs  */
 /* Change the non-dark-mode tab title color */
 .lm-TabBar-tab {
-    color: #545454 !important;
+    color: var(--acs-friendly-background) !important;
 }
 .dark-mode .lm-TabBar-tab {
     background-color: var(--dm-bg-secondary) !important;
@@ -866,7 +867,7 @@ padding-bottom: 10px !important;
 
 /*  restore background color for the simulation tab titles  */
 .dark-mode .widget-html.sim-tab-titles {
-    background-color: #545454 !important;
+    background-color: var(--acs-friendly-background) !important;
 
 }
 

--- a/hnn_core/gui/gui_styles.css
+++ b/hnn_core/gui/gui_styles.css
@@ -214,7 +214,7 @@ padding-bottom: 10px !important;
     default visualization parameters
 */
 .sim-tab-titles {
-    background: gray;
+    background: #545454;
     color: white;
     width: 300px;
     padding: 0px 5px;
@@ -456,7 +456,7 @@ padding-bottom: 10px !important;
 
 /*  style figure placeholder text  */
 .fig-placeholder .widget-html-content {
-    color: #969696;
+    color: #545454;
     font-size: 13px;
     margin-top: 6px;
     text-align: center;
@@ -689,6 +689,10 @@ padding-bottom: 10px !important;
 }
 
 /*  adjust the style for all TabBar tabs  */
+/* Change the non-dark-mode tab title color */
+.lm-TabBar-tab {
+    color: #545454 !important;
+}
 .dark-mode .lm-TabBar-tab {
     background-color: var(--dm-bg-secondary) !important;
     color: var(--dm-text-main) !important;
@@ -862,7 +866,7 @@ padding-bottom: 10px !important;
 
 /*  restore background color for the simulation tab titles  */
 .dark-mode .widget-html.sim-tab-titles {
-    background-color: gray !important;
+    background-color: #545454 !important;
 
 }
 


### PR DESCRIPTION
This is related to #1261 , where the HNN GUI itself had numerous WAVE accessibility errors. Fortunately, Claude was able to figure out how to fix all of the errors (except for contrast), as far as I can tell. I also got help from a StackOverflow post for this.

@xgao35 I'm out next week, but at some point before May 11, we should both sit down and double check that this (and other web content elsewhere!) satisfies at least having no WAVE errors. I also have some questions about what some of the non-error warnings mean and/or what else we need to fix (if anything).

**edit: I'll add that the GUI code itself is *very* difficult to understand and I wouldn't bother. However, it would be helpful if you checked that this branch's GUI webpage passes the WAVE plugin for you, and take note of anything else related to accessibility that you can see on it that we need to address.