### PR TITLE
Remove celltype hardcoding from visualization and response modules

### DIFF
--- a/hnn_core/cell_response.py
+++ b/hnn_core/cell_response.py
@@ -563,7 +563,8 @@ def read_spikes(fname, gid_ranges=None):
             spike_gids += [list()]
             spike_types += [list()]
 
-    network_cell_names = ["L2_basket", "L2_pyramidal", "L5_basket", "L5_pyramidal"]
+    from .network_models import default_cell_metadata
+    network_cell_names = list(default_cell_metadata.keys())
     cell_type_names = list(
         cell_name for cell_name in network_cell_names if cell_name in spike_types
     )

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -10,6 +10,45 @@ from .params import _short_name
 from .cells_default import pyramidal_ca, pyramidal, basket
 from .externals.mne import _validate_type
 
+default_cell_metadata = {
+    "L2_basket": {
+        "morpho_type": "basket",
+        "electro_type": "inhibitory",
+        "layer": "2",
+        "measure_dipole": False,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "m",
+        "marker": "x",
+    },
+    "L2_pyramidal": {
+        "morpho_type": "pyramidal",
+        "electro_type": "excitatory",
+        "layer": "2",
+        "measure_dipole": True,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "c",
+        "marker": "^",
+    },
+    "L5_basket": {
+        "morpho_type": "basket",
+        "electro_type": "inhibitory",
+        "layer": "5",
+        "measure_dipole": False,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "r",
+        "marker": "x",
+    },
+    "L5_pyramidal": {
+        "morpho_type": "pyramidal",
+        "electro_type": "excitatory",
+        "layer": "5",
+        "measure_dipole": True,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "b",
+        "marker": "^",
+    },
+}
+
 # ToDO -> direct _cell_L2Pyr calling
 
 
@@ -78,43 +117,19 @@ def jones_2009_model(
     cell_types = {
         "L2_basket": {
             "cell_object": basket(cell_name="L2_basket"),
-            "cell_metadata": {
-                "morpho_type": "basket",
-                "electro_type": "inhibitory",
-                "layer": "2",
-                "measure_dipole": False,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": default_cell_metadata["L2_basket"],
         },
         "L2_pyramidal": {
             "cell_object": pyramidal(cell_name="L2_pyramidal"),
-            "cell_metadata": {
-                "morpho_type": "pyramidal",
-                "electro_type": "excitatory",
-                "layer": "2",
-                "measure_dipole": True,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": default_cell_metadata["L2_pyramidal"],
         },
         "L5_basket": {
             "cell_object": basket(cell_name="L5_basket"),
-            "cell_metadata": {
-                "morpho_type": "basket",
-                "electro_type": "inhibitory",
-                "layer": "5",
-                "measure_dipole": False,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": default_cell_metadata["L5_basket"],
         },
         "L5_pyramidal": {
             "cell_object": pyramidal(cell_name="L5_pyramidal"),
-            "cell_metadata": {
-                "morpho_type": "pyramidal",
-                "electro_type": "excitatory",
-                "layer": "5",
-                "measure_dipole": True,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": default_cell_metadata["L5_pyramidal"],
         },
     }
 

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -399,13 +399,15 @@ class TestCellResponsePlotters:
             labels = [text.get_text() for text in fig.axes[0].legend_.get_texts()]
             return colors, labels
 
-        # Default colors should be the default color cycle
+        # Default colors should be from cell_metadata
         fig = net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
-        colors, _ = _get_line_hex_colors(fig)
-        default_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"][
-            0 : len(colors)
+        colors, labels = _get_line_hex_colors(fig)
+        from hnn_core.network_models import default_cell_metadata
+        expected_colors = [
+            matplotlib.colors.to_hex(default_cell_metadata[lbl.replace(" Spikes", "")]["color"])
+            for lbl in labels
         ]
-        assert colors == default_colors
+        assert colors == expected_colors
 
         # Custom hex colors as list
         custom_colors = ["#daf7a6", "#ffc300", "#ff5733", "#c70039"]

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -481,7 +481,8 @@ def plot_spikes_hist(
     spike_types_mask = {
         s_type: np.isin(spike_types_data, s_type) for s_type in unique_types
     }
-    cell_types = ["L5_pyramidal", "L5_basket", "L2_pyramidal", "L2_basket"]
+    from .network_models import default_cell_metadata
+    cell_types = list(default_cell_metadata.keys())
     input_types = np.setdiff1d(unique_types, cell_types)
 
     if isinstance(spike_types, str):
@@ -705,14 +706,21 @@ def plot_spikes_raster(
                 f"Got {cell_types}"
             )
     else:
-        # Use default cell types
-        cell_types = ["L2_basket", "L2_pyramidal", "L5_basket", "L5_pyramidal"]
+        # Use default cell types dynamically
+        cell_types = sorted(unique_spike_types)
 
     # Set default colors
-    default_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"][
-        : len(cell_types)
-    ]
-    cell_colors = {cell: color for cell, color in zip(cell_types, default_colors)}
+    from .network_models import default_cell_metadata
+
+    color_cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    color_cycler = cycle(color_cycle)
+
+    cell_colors = dict()
+    for cell in cell_types:
+        if cell in default_cell_metadata and "color" in default_cell_metadata[cell]:
+            cell_colors[cell] = default_cell_metadata[cell]["color"]
+        else:
+            cell_colors[cell] = next(color_cycler)
 
     # validate colors argument
     _validate_type(colors, (list, dict, None), "color", "list of str, or dict")
@@ -917,27 +925,16 @@ def plot_cells(net, ax=None, show=True):
             f"Expected 'ax' to be an instance of Axes3D, but got {type(ax).__name__}"
         )
 
-    colors = {
-        "L5_pyramidal": "b",
-        "L2_pyramidal": "c",
-        "L5_basket": "r",
-        "L2_basket": "m",
-    }
-    markers = {
-        "L5_pyramidal": "^",
-        "L2_pyramidal": "^",
-        "L5_basket": "x",
-        "L2_basket": "x",
-    }
-
     for cell_type in net.cell_types:
         x = [pos[0] for pos in net.pos_dict[cell_type]]
         y = [pos[1] for pos in net.pos_dict[cell_type]]
         z = [pos[2] for pos in net.pos_dict[cell_type]]
-        if cell_type in colors:
-            color = colors[cell_type]
-            marker = markers[cell_type]
+        if "cell_metadata" in net.cell_types[cell_type]:
+            color = net.cell_types[cell_type]["cell_metadata"].get("color", "k")
+            marker = net.cell_types[cell_type]["cell_metadata"].get("marker", "o")
             ax.scatter(x, y, z, c=color, s=50, marker=marker, label=cell_type)
+        else:
+            ax.scatter(x, y, z, c="k", s=50, marker="o", label=cell_type)
 
     if net.rec_arrays:
         cols = plt.get_cmap("inferno", len(net.rec_arrays) + 2)


### PR DESCRIPTION
fixes #1149

Previously, both `viz.py` and `cell_response.py` relied on fixed arrays like `["L2_basket", "L2_pyramidal", "L5_basket", "L5_pyramidal"]` for mapping colors, markers, and ordering. This made the code less flexible and caused issues when working with sub-sampled networks or custom cell types.

The goal here is to make visualization fully driven by metadata, so it becomes easier to extend and maintain.

---

### What I changed

#### 1. Global cell metadata

* Moved the default `cell_metadata` from inside `jones_2009_model()` to a module-level variable `default_cell_metadata` in `hnn_core/network_models.py`.
* Added `color` and `marker` fields directly into this metadata.
* Kept the existing color scheme (`m`, `c`, `r`, `b`) and markers (`^`, `x`) so current visual behavior remains unchanged.

---

#### 2. Updates in `viz.py`

* **`plot_cells()`**

  * Removed hardcoded color and marker dictionaries.
  * Now reads values dynamically from `cell_metadata`.

* **`plot_spikes_raster()`**

  * Removed fixed cell type ordering.
  * Uses `unique_spike_types` from the data.
  * Fetches colors from `default_cell_metadata`.
  * Falls back to matplotlib’s default color cycle if a cell type is not registered.

* **`plot_spikes_hist()`**

  * Removed hardcoded cell type arrays.
  * Now derives them dynamically from available metadata.

---

#### 3. Changes in `cell_response.py`

* Replaced hardcoded `network_cell_names` with dynamic retrieval from `default_cell_metadata.keys()`.
* This ensures consistency with the rest of the codebase and avoids duplication.

---
