### PR TITLE
[WIP] FEAT Add Network.diff() for user-friendly comparison of Network objects

### DIFF
--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -146,9 +146,9 @@ def _dict_diff(d1, d2):
     all_keys = set(d1.keys()).union(set(d2.keys()))
     for k in all_keys:
         if k in d1 and k not in d2:
-            diffs[k] = {'self': d1[k], 'other': None}
+            diffs[k] = {"self": d1[k], "other": None}
         elif k in d2 and k not in d1:
-            diffs[k] = {'self': None, 'other': d2[k]}
+            diffs[k] = {"self": None, "other": d2[k]}
         else:
             val1 = d1[k]
             val2 = d2[k]
@@ -156,7 +156,7 @@ def _dict_diff(d1, d2):
             are_equal = False
             try:
                 if isinstance(val1, dict) and isinstance(val2, dict):
-                    pass # We will handle dict diffing recursively below
+                    pass  # We will handle dict diffing recursively below
                 elif type(val1) is np.ndarray or type(val2) is np.ndarray:
                     are_equal = np.array_equal(val1, val2)
                 else:
@@ -170,7 +170,7 @@ def _dict_diff(d1, d2):
                     if nested_diff:
                         diffs[k] = nested_diff
                 else:
-                    diffs[k] = {'self': val1, 'other': val2}
+                    diffs[k] = {"self": val1, "other": val2}
     return diffs
 
 
@@ -700,7 +700,10 @@ class Network:
             _compare_lists(self.connectivity, other.connectivity)
         ):
             # Detailed connectivity diff is computationally heavy, simple representation is fine
-            diffs["connectivity"] = {"self_length": len(self.connectivity), "other_length": len(other.connectivity)}
+            diffs["connectivity"] = {
+                "self_length": len(self.connectivity),
+                "other_length": len(other.connectivity),
+            }
 
         # Check all other attributes
         attrs_to_ignore = ["connectivity"]
@@ -714,9 +717,11 @@ class Network:
 
                 if self_attr != other_attr:
                     # Special handling for cell_types to show template differences elegantly
-                    if attr == 'cell_types':
-                        nested_diff = _dict_diff(_cell_types_to_dict(self_attr), 
-                                                 _cell_types_to_dict(other_attr))
+                    if attr == "cell_types":
+                        nested_diff = _dict_diff(
+                            _cell_types_to_dict(self_attr),
+                            _cell_types_to_dict(other_attr),
+                        )
                         if nested_diff:
                             diffs[attr] = nested_diff
                     elif isinstance(self_attr, dict) and isinstance(other_attr, dict):
@@ -724,16 +729,16 @@ class Network:
                         if nested_diff:
                             diffs[attr] = nested_diff
                     else:
-                        diffs[attr] = {'self': self_attr, 'other': other_attr}
+                        diffs[attr] = {"self": self_attr, "other": other_attr}
             else:
-                diffs[attr] = {'self': getattr(self, attr), 'other': None}
+                diffs[attr] = {"self": getattr(self, attr), "other": None}
 
         # Check for attributes in other that are missing in self
         for attr in vars(other).keys():
             if attr.startswith("_") or attr in attrs_to_ignore:
                 continue
             if not hasattr(self, attr):
-                diffs[attr] = {'self': None, 'other': getattr(other, attr)}
+                diffs[attr] = {"self": None, "other": getattr(other, attr)}
 
         return diffs
 
@@ -1326,9 +1331,11 @@ class Network:
         drive["events"] = list()  # Will be populated during instantiation
 
         # Process spike_data into a standardized format
-        standardized_data, n_drive_cells, source_to_gid_map = (
-            self._standardize_spike_data(spike_data)
-        )
+        (
+            standardized_data,
+            n_drive_cells,
+            source_to_gid_map,
+        ) = self._standardize_spike_data(spike_data)
 
         # Set drive properties
         drive["dynamics"] = standardized_data
@@ -1336,9 +1343,9 @@ class Network:
         if source_to_gid_map is not None:
             drive["source_to_gid_map"] = source_to_gid_map
         drive["conn_seed"] = conn_seed
-        drive["event_seed"] = (
-            0  # Not used for spike train, but included for consistency
-        )
+        drive[
+            "event_seed"
+        ] = 0  # Not used for spike train, but included for consistency
 
         # Save connection parameters
         drive["weights_ampa"] = weights_ampa
@@ -1434,15 +1441,18 @@ class Network:
 
         _validate_type(probability, (float, dict), "probability", "float or dict")
         # allow passing weights as None, convert to dict here
-        (target_populations, weights_by_type, delays_by_type, probability_by_type) = (
-            _get_target_properties(
-                weights_ampa,
-                weights_nmda,
-                synaptic_delays,
-                location,
-                self.cell_types,
-                probability=probability,
-            )
+        (
+            target_populations,
+            weights_by_type,
+            delays_by_type,
+            probability_by_type,
+        ) = _get_target_properties(
+            weights_ampa,
+            weights_nmda,
+            synaptic_delays,
+            location,
+            self.cell_types,
+            probability=probability,
         )
 
         # weights passed must correspond to cells in the network

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -1343,9 +1343,9 @@ class Network:
         if source_to_gid_map is not None:
             drive["source_to_gid_map"] = source_to_gid_map
         drive["conn_seed"] = conn_seed
-        drive[
-            "event_seed"
-        ] = 0  # Not used for spike train, but included for consistency
+        drive["event_seed"] = (
+            0  # Not used for spike train, but included for consistency
+        )
 
         # Save connection parameters
         drive["weights_ampa"] = weights_ampa
@@ -2640,11 +2640,9 @@ def _check_global_synaptic_gains_uniformity(net):
                 )
             ):
                 output_indicator = False
-                print(
-                    """
+                print("""
                     WARNING: Your imported Network uses custom synaptic gain values. Global synaptic gain values such as "Excitatory-to-Inhibitory" etc. will NOT be read or displayed properly. This is because Global synaptic gain values assume that initially, all gains are the same. If you continue to modify your Global synaptic gain values, double-check each connection's final synaptic gain value. To stop this warning, change your synaptic weights instead of your synaptic gains.
-                    """
-                )
+                    """)
                 break
 
     return output_indicator

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -138,6 +138,58 @@ def _compare_lists(s, t):
     return not t
 
 
+def _dict_diff(d1, d2):
+    """
+    Recursively compares two dictionaries and returns a dictionary of differences.
+    """
+    diffs = dict()
+    all_keys = set(d1.keys()).union(set(d2.keys()))
+    for k in all_keys:
+        if k in d1 and k not in d2:
+            diffs[k] = {'self': d1[k], 'other': None}
+        elif k in d2 and k not in d1:
+            diffs[k] = {'self': None, 'other': d2[k]}
+        else:
+            val1 = d1[k]
+            val2 = d2[k]
+
+            are_equal = False
+            try:
+                if isinstance(val1, dict) and isinstance(val2, dict):
+                    pass # We will handle dict diffing recursively below
+                elif type(val1) is np.ndarray or type(val2) is np.ndarray:
+                    are_equal = np.array_equal(val1, val2)
+                else:
+                    are_equal = bool(val1 == val2)
+            except Exception:
+                are_equal = False
+
+            if not are_equal:
+                if isinstance(val1, dict) and isinstance(val2, dict):
+                    nested_diff = _dict_diff(val1, val2)
+                    if nested_diff:
+                        diffs[k] = nested_diff
+                else:
+                    diffs[k] = {'self': val1, 'other': val2}
+    return diffs
+
+
+def _cell_types_to_dict(cell_types):
+    """
+    Converts Network.cell_types dictionaries containing Cell objects into regular dictionaries for diffing.
+    """
+    converted = dict()
+    for cell_name, cell_data in cell_types.items():
+        converted[cell_name] = dict()
+        if "cell_object" in cell_data and hasattr(cell_data["cell_object"], "to_dict"):
+            converted[cell_name]["cell_object"] = cell_data["cell_object"].to_dict()
+        else:
+            converted[cell_name]["cell_object"] = cell_data.get("cell_object")
+
+        converted[cell_name]["cell_metadata"] = cell_data.get("cell_metadata")
+    return converted
+
+
 def _connection_probability(conn, probability, conn_seed=None):
     """Remove/keep a random subset of connections.
 
@@ -622,6 +674,68 @@ class Network:
                 return False
 
         return True
+
+    def diff(self, other):
+        """Return a dictionary of differences between this Network and another.
+
+        Parameters
+        ----------
+        other : Network
+            The Network object to compare against.
+
+        Returns
+        -------
+        diffs : dict
+            A nested dictionary describing the differences. Keys are the names
+            of the varying attributes, and their values document the divergence
+            under 'self' and 'other'. Identical values are omitted.
+        """
+        if not isinstance(other, Network):
+            raise TypeError("Can only diff with another Network instance.")
+
+        diffs = dict()
+
+        # Check connectivity
+        if (len(self.connectivity) != len(other.connectivity)) or not (
+            _compare_lists(self.connectivity, other.connectivity)
+        ):
+            # Detailed connectivity diff is computationally heavy, simple representation is fine
+            diffs["connectivity"] = {"self_length": len(self.connectivity), "other_length": len(other.connectivity)}
+
+        # Check all other attributes
+        attrs_to_ignore = ["connectivity"]
+        for attr in vars(self).keys():
+            if attr.startswith("_") or attr in attrs_to_ignore:
+                continue
+
+            if hasattr(other, attr):
+                self_attr = getattr(self, attr)
+                other_attr = getattr(other, attr)
+
+                if self_attr != other_attr:
+                    # Special handling for cell_types to show template differences elegantly
+                    if attr == 'cell_types':
+                        nested_diff = _dict_diff(_cell_types_to_dict(self_attr), 
+                                                 _cell_types_to_dict(other_attr))
+                        if nested_diff:
+                            diffs[attr] = nested_diff
+                    elif isinstance(self_attr, dict) and isinstance(other_attr, dict):
+                        nested_diff = _dict_diff(self_attr, other_attr)
+                        if nested_diff:
+                            diffs[attr] = nested_diff
+                    else:
+                        diffs[attr] = {'self': self_attr, 'other': other_attr}
+            else:
+                diffs[attr] = {'self': getattr(self, attr), 'other': None}
+
+        # Check for attributes in other that are missing in self
+        for attr in vars(other).keys():
+            if attr.startswith("_") or attr in attrs_to_ignore:
+                continue
+            if not hasattr(self, attr):
+                diffs[attr] = {'self': None, 'other': getattr(other, attr)}
+
+        return diffs
 
     def set_cell_positions(self, *, inplane_distance=None, layer_separation=None):
         """Set relative positions of cells arranged in a square grid

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -611,13 +611,10 @@ def test_network_drives():
             ]:
                 assert kw in drive["dynamics"].keys()
             assert len(drive["events"][0]) == n_drive_cells
-            n_events = (
-                drive["dynamics"]["numspikes"]  # 2
-                * (
-                    1
-                    + (drive["dynamics"]["tstop"] - drive["dynamics"]["tstart"] - 1)
-                    // (1000.0 / drive["dynamics"]["burst_rate"])
-                )
+            n_events = drive["dynamics"]["numspikes"] * (  # 2
+                1
+                + (drive["dynamics"]["tstop"] - drive["dynamics"]["tstart"] - 1)
+                // (1000.0 / drive["dynamics"]["burst_rate"])
             )
             assert len(drive["events"][0][0]) == n_events  # 4
 
@@ -799,13 +796,10 @@ def test_network_drives_legacy():
             ]:
                 assert kw in drive["dynamics"].keys()
             assert len(drive["events"][0]) == n_drive_cells
-            n_events = (
-                drive["dynamics"]["numspikes"]  # 2
-                * (
-                    1
-                    + (drive["dynamics"]["tstop"] - drive["dynamics"]["tstart"] - 1)
-                    // (1000.0 / drive["dynamics"]["burst_rate"])
-                )
+            n_events = drive["dynamics"]["numspikes"] * (  # 2
+                1
+                + (drive["dynamics"]["tstop"] - drive["dynamics"]["tstart"] - 1)
+                // (1000.0 / drive["dynamics"]["burst_rate"])
             )
             assert len(drive["events"][0][0]) == n_events  # 4
 
@@ -900,14 +894,14 @@ def test_network_connectivity(base_network):
 
     # Check basket-basket connection where allow_autapses=False
     assert "L2Pyr_L2Pyr_nmda" in network_builder.ncs
-    n_connections = 3 * (n_pyr**2 - n_pyr)  # 3 synapses / cell
+    n_connections = 3 * (n_pyr ** 2 - n_pyr)  # 3 synapses / cell
     assert len(network_builder.ncs["L2Pyr_L2Pyr_nmda"]) == n_connections
     nc = network_builder.ncs["L2Pyr_L2Pyr_nmda"][0]
     assert nc.threshold == params["threshold"]
 
     # Check basket-basket connection where allow_autapses=True
     assert "L2Basket_L2Basket_gabaa" in network_builder.ncs
-    n_connections = n_basket**2  # 1 synapse / cell
+    n_connections = n_basket ** 2  # 1 synapse / cell
     assert len(network_builder.ncs["L2Basket_L2Basket_gabaa"]) == n_connections
     nc = network_builder.ncs["L2Basket_L2Basket_gabaa"][0]
     assert nc.threshold == params["threshold"]
@@ -1209,8 +1203,7 @@ def test_tonic_biases():
     assert net.external_biases["tonic"]["L2_pyramidal"]["t0"] == 0
     with pytest.raises(
         ValueError,
-        match=r"Bias named tonic already defined "
-        r"for.*$",
+        match=r"Bias named tonic already defined " r"for.*$",
     ):
         net.add_tonic_bias(amplitude=tonic_bias_2)
 
@@ -1224,10 +1217,7 @@ def test_tonic_biases():
 
     with pytest.raises(
         ValueError,
-        match=(
-            r"section must be one of .*"
-            " Got apical_4."
-        ),
+        match=(r"section must be one of .*" " Got apical_4."),
     ):
         net.add_tonic_bias(amplitude={"L2_pyramidal": 0.5}, section="apical_4")
 
@@ -2106,24 +2096,26 @@ def test_network_diff():
     net1.threshold = -10.0
     net2.threshold = -20.0
     diffs = net1.diff(net2)
-    assert 'threshold' in diffs
-    assert diffs['threshold']['self'] == -10.0
-    assert diffs['threshold']['other'] == -20.0
+    assert "threshold" in diffs
+    assert diffs["threshold"]["self"] == -10.0
+    assert diffs["threshold"]["other"] == -20.0
 
     # Test cell_object diffs
     # We modify one synapse tau in L5_pyramidal for net1
-    net1.cell_types['L5_pyramidal']['cell_object'].synapses['ampa']['tau1'] += 10.0
-    
+    net1.cell_types["L5_pyramidal"]["cell_object"].synapses["ampa"]["tau1"] += 10.0
+
     diffs = net1.diff(net2)
-    assert 'cell_types' in diffs
-    assert 'L5_pyramidal' in diffs['cell_types']
-    assert 'cell_object' in diffs['cell_types']['L5_pyramidal']
-    assert 'synapses' in diffs['cell_types']['L5_pyramidal']['cell_object']
-    assert 'ampa' in diffs['cell_types']['L5_pyramidal']['cell_object']['synapses']
-    assert 'tau1' in diffs['cell_types']['L5_pyramidal']['cell_object']['synapses']['ampa']
-    
+    assert "cell_types" in diffs
+    assert "L5_pyramidal" in diffs["cell_types"]
+    assert "cell_object" in diffs["cell_types"]["L5_pyramidal"]
+    assert "synapses" in diffs["cell_types"]["L5_pyramidal"]["cell_object"]
+    assert "ampa" in diffs["cell_types"]["L5_pyramidal"]["cell_object"]["synapses"]
+    assert (
+        "tau1" in diffs["cell_types"]["L5_pyramidal"]["cell_object"]["synapses"]["ampa"]
+    )
+
     # Revert to keep looking clean
-    net1.cell_types['L5_pyramidal']['cell_object'].synapses['ampa']['tau1'] -= 10.0
+    net1.cell_types["L5_pyramidal"]["cell_object"].synapses["ampa"]["tau1"] -= 10.0
 
     # Add external drive to net1 but not net2
     net1.add_poisson_drive(
@@ -2138,6 +2130,6 @@ def test_network_diff():
     )
     diffs = net1.diff(net2)
     # The external drive should be flagged
-    assert 'external_drives' in diffs
-    assert 'test_poisson' in diffs['external_drives']
-    assert diffs['external_drives']['test_poisson']['other'] is None
+    assert "external_drives" in diffs
+    assert "test_poisson" in diffs["external_drives"]
+    assert diffs["external_drives"]["test_poisson"]["other"] is None

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -2091,3 +2091,53 @@ def test_verbose():
     with io.StringIO() as buf, redirect_stdout(buf):
         simulate_dipole(net, dt=0.5, tstop=20.0, verbose=False)
         assert buf.getvalue() == ""
+
+
+def test_network_diff():
+    """Test Network.diff returns correct dictionary describing differences."""
+    net1 = jones_2009_model(mesh_shape=(2, 2))
+    net2 = jones_2009_model(mesh_shape=(2, 2))
+
+    # They should be identical
+    diffs = net1.diff(net2)
+    assert diffs == {}
+
+    # Change a threshold in one and verify diff captures it
+    net1.threshold = -10.0
+    net2.threshold = -20.0
+    diffs = net1.diff(net2)
+    assert 'threshold' in diffs
+    assert diffs['threshold']['self'] == -10.0
+    assert diffs['threshold']['other'] == -20.0
+
+    # Test cell_object diffs
+    # We modify one synapse tau in L5_pyramidal for net1
+    net1.cell_types['L5_pyramidal']['cell_object'].synapses['ampa']['tau1'] += 10.0
+    
+    diffs = net1.diff(net2)
+    assert 'cell_types' in diffs
+    assert 'L5_pyramidal' in diffs['cell_types']
+    assert 'cell_object' in diffs['cell_types']['L5_pyramidal']
+    assert 'synapses' in diffs['cell_types']['L5_pyramidal']['cell_object']
+    assert 'ampa' in diffs['cell_types']['L5_pyramidal']['cell_object']['synapses']
+    assert 'tau1' in diffs['cell_types']['L5_pyramidal']['cell_object']['synapses']['ampa']
+    
+    # Revert to keep looking clean
+    net1.cell_types['L5_pyramidal']['cell_object'].synapses['ampa']['tau1'] -= 10.0
+
+    # Add external drive to net1 but not net2
+    net1.add_poisson_drive(
+        "test_poisson",
+        tstart=0,
+        tstop=40.0,
+        rate_constant=10.0,
+        location="proximal",
+        weights_ampa={"L2_pyramidal": 0.001, "L5_pyramidal": 0.001},
+        synaptic_delays=0.1,
+        event_seed=45,
+    )
+    diffs = net1.diff(net2)
+    # The external drive should be flagged
+    assert 'external_drives' in diffs
+    assert 'test_poisson' in diffs['external_drives']
+    assert diffs['external_drives']['test_poisson']['other'] is None

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -894,14 +894,14 @@ def test_network_connectivity(base_network):
 
     # Check basket-basket connection where allow_autapses=False
     assert "L2Pyr_L2Pyr_nmda" in network_builder.ncs
-    n_connections = 3 * (n_pyr ** 2 - n_pyr)  # 3 synapses / cell
+    n_connections = 3 * (n_pyr**2 - n_pyr)  # 3 synapses / cell
     assert len(network_builder.ncs["L2Pyr_L2Pyr_nmda"]) == n_connections
     nc = network_builder.ncs["L2Pyr_L2Pyr_nmda"][0]
     assert nc.threshold == params["threshold"]
 
     # Check basket-basket connection where allow_autapses=True
     assert "L2Basket_L2Basket_gabaa" in network_builder.ncs
-    n_connections = n_basket ** 2  # 1 synapse / cell
+    n_connections = n_basket**2  # 1 synapse / cell
     assert len(network_builder.ncs["L2Basket_L2Basket_gabaa"]) == n_connections
     nc = network_builder.ncs["L2Basket_L2Basket_gabaa"][0]
     assert nc.threshold == params["threshold"]


### PR DESCRIPTION
fixes #1139

This PR introduces a `Network.diff()` method to provide a clear and structured way to identify differences between two `Network` objects, addressing issue.

### Features

* Added `Network.diff()` method to compare two `Network` instances beyond simple equality checks
* Implemented recursive `_dict_diff()` helper for deep comparison of nested attributes
* Introduced `_cell_types_to_dict()` to convert `Cell` templates into dictionaries for meaningful comparison
* Avoided redundant per-cell differences by comparing at the `cell_types` template level
* Focused on highlighting significant differences (e.g., thresholds, synaptic parameters)

### Tests

* Added `test_network_diff` in `test_network.py`
* Verified detection of changes in nested attributes such as cell thresholds and synaptic mechanisms
