### PR TITLE
add macos-15-intel runner for Python 3.9 tests

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -15,8 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest,macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.9, 3.11, 3.13]
+        include:
+          - os: macos-15-intel
+            python-version: 3.9
 
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +33,7 @@ jobs:
         shell: bash -el {0}
         run: |
           python -m pip install --upgrade pip
-          if [ ${{ matrix.os }} == "macos-latest" ]; then
+          if [[ "${{ matrix.os }}" == macos* ]]; then
               echo "DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
               echo "LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -39,6 +39,9 @@ merged into `master`! Use `git log` instead and cross-reference instead. -->
 
 ### Changelog
 
+- Enable MacOS Intel-CPU runners in CI,
+  by [Vaishnavi Baghel][] in {gh}`1287`.
+
 - Update and re-enable Codecov usage in CI,
   by [Vaishnavi Baghel][] in {gh}`1272`. This was their first PR, thanks Vaishnavi!
 


### PR DESCRIPTION
fixes #1134

### Changes made

* Updated `.github/workflows/unix_unit_tests.yml` to include `macos-15-intel`
* Restricted the Intel runner to Python 3.9 only using `include:` instead of expanding the full matrix
* Updated macOS-specific `DYLD_FALLBACK_LIBRARY_PATH` handling from a hardcoded `macos-latest` check to pattern matching with `macos*`, so both Apple Silicon and Intel runners are supported correctly