### PR TITLE
[MRG] FIX include CSS and JS files for GUI in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,9 @@ recursive-include hnn_core/mod *
 recursive-include hnn_core *.py
 recursive-include hnn_core *.ipynb
 
+recursive-include hnn_core *.css
+recursive-include hnn_core *.js
+
 ### Exclude
 
 exclude Makefile pytest.ini .circleci

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,9 +9,6 @@ recursive-include hnn_core/mod *
 recursive-include hnn_core *.py
 recursive-include hnn_core *.ipynb
 
-recursive-include hnn_core *.css
-recursive-include hnn_core *.js
-
 ### Exclude
 
 exclude Makefile pytest.ini .circleci

--- a/setup.py
+++ b/setup.py
@@ -10,23 +10,23 @@ from setuptools.command.build_py import build_py
 
 descr = """Code for biophysical simulation of a cortical column using Neuron"""
 
-DISTNAME = 'hnn-core'
+DISTNAME = "hnn-core"
 DESCRIPTION = descr
-MAINTAINER = 'Mainak Jas'
-MAINTAINER_EMAIL = 'mainakjas@gmail.com'
-URL = ''
-LICENSE = 'BSD (3-clause)'
-DOWNLOAD_URL = 'http://github.com/jonescompneurolab/hnn-core'
+MAINTAINER = "Mainak Jas"
+MAINTAINER_EMAIL = "mainakjas@gmail.com"
+URL = ""
+LICENSE = "BSD (3-clause)"
+DOWNLOAD_URL = "http://github.com/jonescompneurolab/hnn-core"
 
 # get the version
 version = None
-with open(os.path.join('hnn_core', '__init__.py'), 'r') as fid:
+with open(os.path.join("hnn_core", "__init__.py"), "r") as fid:
     for line in (line.strip() for line in fid):
-        if line.startswith('__version__'):
-            version = line.split('=')[1].strip().strip('\"')
+        if line.startswith("__version__"):
+            version = line.split("=")[1].strip().strip('"')
             break
 if version is None:
-    raise RuntimeError('Could not determine version')
+    raise RuntimeError("Could not determine version")
 
 
 # test install with:
@@ -50,15 +50,19 @@ class BuildMod(Command):
     def run(self):
         print("=> Building mod files ...")
 
-        if platform.system() == 'Windows':
+        if platform.system() == "Windows":
             shell = True
         else:
             shell = False
 
-        mod_path = op.join(op.dirname(__file__), 'hnn_core', 'mod')
-        process = subprocess.Popen(['nrnivmodl'], cwd=mod_path,
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE, shell=shell)
+        mod_path = op.join(op.dirname(__file__), "hnn_core", "mod")
+        process = subprocess.Popen(
+            ["nrnivmodl"],
+            cwd=mod_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=shell,
+        )
         outs, errs = process.communicate()
         print(outs)
 
@@ -67,8 +71,8 @@ class build_py_mod(build_py):
     def run(self):
         self.run_command("build_mod")
 
-        build_dir = op.join(self.build_lib, 'hnn_core', 'mod')
-        mod_path = op.join(op.dirname(__file__), 'hnn_core', 'mod')
+        build_dir = op.join(self.build_lib, "hnn_core", "mod")
+        mod_path = op.join(op.dirname(__file__), "hnn_core", "mod")
         shutil.copytree(mod_path, build_dir)
 
         build_py.run(self)
@@ -76,59 +80,80 @@ class build_py_mod(build_py):
 
 if __name__ == "__main__":
     extras = {
-        'opt': ['scikit-learn', 'cma'],
-        'parallel': ['joblib', 'psutil'],
-        'test': ['codespell', 'pytest', 'pytest-cov', 'pytest-xdist', 'ruff'],
-        'docs': ['mne', 'myst-parser', 'nibabel', 'numpydoc', 'pillow',
-                 'pooch<1.9.0', 'pydata-sphinx-theme', 'sphinx', 'sphinx-gallery',
-                 'sphinx-copybutton', 'tdqm'],
-        'gui': ['ipywidgets>=8.0.0', 'ipykernel', 'ipympl', 'voila'],
+        "opt": ["scikit-learn", "cma"],
+        "parallel": ["joblib", "psutil"],
+        "test": ["codespell", "pytest", "pytest-cov", "pytest-xdist", "ruff"],
+        "docs": [
+            "mne",
+            "myst-parser",
+            "nibabel",
+            "numpydoc",
+            "pillow",
+            "pooch<1.9.0",
+            "pydata-sphinx-theme",
+            "sphinx",
+            "sphinx-gallery",
+            "sphinx-copybutton",
+            "tdqm",
+        ],
+        "gui": ["ipywidgets>=8.0.0", "ipykernel", "ipympl", "voila"],
     }
-    extras['all'] = (extras['opt'] + extras['parallel'] + extras['gui'])
-    extras['dev'] = (extras['opt'] + extras['parallel'] + extras['test'] +
-                     extras['docs'] + extras['gui'])
+    extras["all"] = extras["opt"] + extras["parallel"] + extras["gui"]
+    extras["dev"] = (
+        extras["opt"]
+        + extras["parallel"]
+        + extras["test"]
+        + extras["docs"]
+        + extras["gui"]
+    )
 
-    setup(name=DISTNAME,
-          maintainer=MAINTAINER,
-          maintainer_email=MAINTAINER_EMAIL,
-          description=DESCRIPTION,
-          license=LICENSE,
-          url=URL,
-          version=version,
-          download_url=DOWNLOAD_URL,
-          long_description=open('README.md').read(),
-          long_description_content_type='text/markdown',
-          classifiers=[
-              'Intended Audience :: Science/Research',
-              'Intended Audience :: Developers',
-              'License :: OSI Approved',
-              'Programming Language :: Python',
-              'Topic :: Software Development',
-              'Topic :: Scientific/Engineering',
-              'Operating System :: Microsoft :: Windows',
-              'Operating System :: POSIX',
-              'Operating System :: Unix',
-              'Operating System :: MacOS',
-              'Programming Language :: Python :: 3.9',
-              'Programming Language :: Python :: 3.10',
-              'Programming Language :: Python :: 3.11',
-              'Programming Language :: Python :: 3.12',
-              'Programming Language :: Python :: 3.13',
-          ],
-          platforms='any',
-          install_requires=[
-              'numpy >=1.14',
-              'NEURON >=7.7, <=8.2.7; platform_system != "Windows"',
-              'matplotlib>=3.5.3',
-              'scipy',
-              'h5io',
-          ],
-          extras_require=extras,
-          python_requires='>=3.9, <3.14',
-          packages=find_packages(),
-          package_data={'hnn_core': [
-              'param/*.json',
-              'gui/*.ipynb']},
-          cmdclass={'build_py': build_py_mod, 'build_mod': BuildMod},
-          entry_points={'console_scripts': ['hnn-gui=hnn_core.gui.gui:launch']}
-          )
+    setup(
+        name=DISTNAME,
+        maintainer=MAINTAINER,
+        maintainer_email=MAINTAINER_EMAIL,
+        description=DESCRIPTION,
+        license=LICENSE,
+        url=URL,
+        version=version,
+        download_url=DOWNLOAD_URL,
+        long_description=open("README.md").read(),
+        long_description_content_type="text/markdown",
+        classifiers=[
+            "Intended Audience :: Science/Research",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved",
+            "Programming Language :: Python",
+            "Topic :: Software Development",
+            "Topic :: Scientific/Engineering",
+            "Operating System :: Microsoft :: Windows",
+            "Operating System :: POSIX",
+            "Operating System :: Unix",
+            "Operating System :: MacOS",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
+        ],
+        platforms="any",
+        install_requires=[
+            "numpy >=1.14",
+            'NEURON >=7.7, <=8.2.7; platform_system != "Windows"',
+            "matplotlib>=3.5.3",
+            "scipy",
+            "h5io",
+        ],
+        extras_require=extras,
+        python_requires=">=3.9, <3.14",
+        packages=find_packages(),
+        package_data={
+            "hnn_core": [
+                "param/*.json",
+                "gui/*.css",
+                "gui/*.ipynb",
+                "gui/*.js",
+            ]
+        },
+        cmdclass={"build_py": build_py_mod, "build_mod": BuildMod},
+        entry_points={"console_scripts": ["hnn-gui=hnn_core.gui.gui:launch"]},
+    )


### PR DESCRIPTION
This fixes an issue that Nick and I discovered when trying to install `master` and other new branches using `uv` and `pixi`: currently, the new CSS and JS files that are used in the GUI are not downloading at install time, breaking the GUI. 

The problem was that CSS and JS files are maybe considered package data, and more importantly were not being included in the list of files to include in `setup.py`. This fixes that, and now it appears that after this change, the files are properly being transmitted when there's an install. I'm not sure if including them in MANIFEST.in is necessary or not, but it does not seem to interfere with anything.