### PR TITLE
[MRG] FIX attempt to fix failing CCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,18 +19,13 @@ jobs:
                   bash ~/miniconda.sh -b -p ~/miniconda;
                   
           - run:
-                name: Specify MPI-related environment variables
-                command: | 
-                    export PATH=~/miniconda/bin:$PATH
-                    echo 'export LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:$LD_LIBRARY_PATH' >> "$BASH_ENV"
-
-          - run:
               name: Setup Python environment including MPI
               command: |
                   export PATH=~/miniconda/bin:$PATH
                   conda update --yes --quiet conda
                   conda create -n testenv --yes pip python=3.11
                   source activate testenv
+                  echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH' >> "$BASH_ENV"
                   # necessary due to https://github.com/mpi4py/mpi4py/issues/335#issuecomment-1486366039
                   rm $CONDA_PREFIX/compiler_compat/ld
                   conda install --yes scipy numpy matplotlib "openmpi >5" -c conda-forge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,15 @@ jobs:
                   wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
                   chmod +x ~/miniconda.sh;
                   bash ~/miniconda.sh -b -p ~/miniconda;
+                  
+          - run:
+                name: Specify MPI-related environment variables
+                command: | 
+                    export PATH=~/miniconda/bin:$PATH
+                    echo 'export LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:$LD_LIBRARY_PATH' >> "$BASH_ENV"
 
           - run:
-              name: Install openmpi
-              command: |
-                  sudo apt-get install libopenmpi-dev openmpi-bin
-
-          - run:
-              name: Setup Python environment
+              name: Setup Python environment including MPI
               command: |
                   export PATH=~/miniconda/bin:$PATH
                   conda update --yes --quiet conda
@@ -32,7 +33,7 @@ jobs:
                   source activate testenv
                   # necessary due to https://github.com/mpi4py/mpi4py/issues/335#issuecomment-1486366039
                   rm $CONDA_PREFIX/compiler_compat/ld
-                  conda install --yes scipy numpy matplotlib
+                  conda install --yes scipy numpy matplotlib "openmpi >5" -c conda-forge
                   pip install mpi4py
 
           - run:
@@ -42,17 +43,22 @@ jobs:
                   sudo apt-get install pandoc
 
           - run:
-              name: Setup Neuron
-              command: |
-                  source ~/miniconda/bin/activate testenv
-                  pip install NEURON
-
-          - run:
               name: Setup hnn-core
               command: |
                   source ~/miniconda/bin/activate testenv
                   pip install -U pip setuptools virtualenv
                   pip install '.[parallel, docs, gui]'
+
+          - run:
+              name: Test that MPI works in the environment
+              command: |
+                  source ~/miniconda/bin/activate testenv
+                  python -c "
+                  from hnn_core import jones_2009_model, MPIBackend, simulate_dipole
+                  with MPIBackend():
+                      simulate_dipole(jones_2009_model(), tstop=20)
+                  print('--> SUCCESS: The test worked')
+                  "
 
           - restore_cache:
               keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
                   wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
                   chmod +x ~/miniconda.sh;
                   bash ~/miniconda.sh -b -p ~/miniconda;
-                  
+
           - run:
               name: Setup Python environment including MPI
               command: |
@@ -25,7 +25,7 @@ jobs:
                   conda update --yes --quiet conda
                   conda create -n testenv --yes pip python=3.11
                   source activate testenv
-                  echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH' >> "$BASH_ENV"
+                  export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
                   # necessary due to https://github.com/mpi4py/mpi4py/issues/335#issuecomment-1486366039
                   rm $CONDA_PREFIX/compiler_compat/ld
                   conda install --yes scipy numpy matplotlib "openmpi >5" -c conda-forge
@@ -35,12 +35,14 @@ jobs:
               name: Setup doc building stuff
               command: |
                   source ~/miniconda/bin/activate testenv
+                  export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
                   sudo apt-get install pandoc
 
           - run:
               name: Setup hnn-core
               command: |
                   source ~/miniconda/bin/activate testenv
+                  export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
                   pip install -U pip setuptools virtualenv
                   pip install '.[parallel, docs, gui]'
 
@@ -48,6 +50,7 @@ jobs:
               name: Test that MPI works in the environment
               command: |
                   source ~/miniconda/bin/activate testenv
+                  export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
                   python -c "
                   from hnn_core import jones_2009_model, MPIBackend, simulate_dipole
                   with MPIBackend():
@@ -63,6 +66,7 @@ jobs:
               name: Build the documentation
               command: |
                   source ~/miniconda/bin/activate testenv
+                  export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
                   cd doc/ && make html
 
           - persist_to_workspace:

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -27,7 +27,7 @@ interactive GUI is essential for all new users of HNN to develop an
 intuition on how to interact with the large-scale computational model to
 study the multi-scale neural dynamics underlying their MEG/EEG data.
 Once this intuition is gained, users who chose to can dive into the
-computational neural modeling code, where further command line utily can
+computational neural modeling code, where further command line utility can
 be developed. As such, an equal goal is to enable the neural modeling
 and coding community to participate in HNN development. We are
 prioritizing best practices in open-source software design and the

--- a/examples/howto/plot_simulate_mpi_backend.py
+++ b/examples/howto/plot_simulate_mpi_backend.py
@@ -33,11 +33,19 @@ from hnn_core import simulate_dipole, neymotin_2020_model
 # time with unique randomization.
 net = neymotin_2020_model()
 
-weights_ampa = {'L2_pyramidal': 5.4e-5, 'L5_pyramidal': 5.4e-5}
+weights_ampa = {"L2_pyramidal": 5.4e-5, "L5_pyramidal": 5.4e-5}
 net.add_bursty_drive(
-    'bursty', tstart=50., burst_rate=10, burst_std=20., numspikes=2,
-    spike_isi=10, n_drive_cells=10, location='distal',
-    weights_ampa=weights_ampa, event_seed=278)
+    "bursty",
+    tstart=50.0,
+    burst_rate=10,
+    burst_std=20.0,
+    numspikes=2,
+    spike_isi=10,
+    n_drive_cells=10,
+    location="distal",
+    weights_ampa=weights_ampa,
+    event_seed=278,
+)
 
 ###############################################################################
 # Finally, to simulate we use the
@@ -47,8 +55,8 @@ net.add_bursty_drive(
 # ``openmpi``, which must be installed on the system
 from hnn_core import MPIBackend
 
-with MPIBackend(n_procs=2, mpi_cmd='mpiexec'):
-    dpls = simulate_dipole(net, tstop=310., n_trials=1)
+with MPIBackend(n_procs=2, mpi_cmd="mpiexec"):
+    dpls = simulate_dipole(net, tstop=310.0, n_trials=1)
 
 trial_idx = 0
 dpls[trial_idx].plot()


### PR DESCRIPTION
Recently, all of our CircleCI builds have been failing due to an issue executing the `examples/howto/plot_simulate_mpi_backend.py` script, as seen here https://app.circleci.com/pipelines/github/jonescompneurolab/hnn-core/5345/workflows/e89acd09-9774-4276-baa4-c6a8dc9e1426/jobs/5704 . This seems to be affecting all builds across all PRs.

This is probably due to our CircleCI's unique environment build process in `.circleci/config.yml` which, for historical reasons, attempts to use the linux packages of MPI instead of Anaconda or Conda-forge MPI packages. This PR is attempt to change our CircleCI runner to use the now standard method of installing MPI for HNN, since I can at least run the same script successfully while CCI fails.