### PR TITLE
HOTFIX expand gui deps to include opt deps

### DIFF
--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -28,12 +28,17 @@ merged into `master`! Use `git log` instead and cross-reference instead. -->
 
 ## 0.6.1 Patch Release Notes
 
-This is an emergency patch release to fix several install misconfigurations (see
-{gh}`1302`). Recent changes to `Optimizer` from the new CMA optimization solver require
-the `[parallel]` extra in order to run, so `pip install "hnn-core[opt]"` now requires
-installation of the `[parallel]` extra packages too. In addition, since the GUI can now
-support optimization including CMA, its installation also requires both the `[opt]` and
-`[parallel]` extra packages as well. This has been fixed.
+This is an emergency patch release to fix an install misconfiguration (see
+{gh}`1302`).
+
+Recent changes to `Optimizer` from the new CMA optimization solver require `joblib` to
+be installed for any Optimization to be run. Since `joblib` is a required dependency of
+`scikit-learn`, installing with `pip install "hnn-core[opt]"` is sufficient, even
+though `[opt]` installs some, but not all, of HNN-Core's `[parallel]` install extras,
+which are `joblib` and `psutil`.
+
+Relatedly, since the GUI can now support optimization, its installation now requires
+the `[opt]` packages to be installed as well. This has been fixed.
 
 ## 0.6.0 Release Notes
 

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -26,9 +26,14 @@ merged into `master`! Use `git log` instead and cross-reference instead. -->
 
 <!-- ### Changelog -->
 
-## 0.6.1.dev0 In-progress updates
+## 0.6.1 Patch Release Notes
 
-### Changelog
+This is an emergency patch release to fix several install misconfigurations (see
+{gh}`1302`). Recent changes to `Optimizer` from the new CMA optimization solver require
+the `[parallel]` extra in order to run, so `pip install "hnn-core[opt]"` now requires
+installation of the `[parallel]` extra packages too. In addition, since the GUI can now
+support optimization including CMA, its installation also requires both the `[opt]` and
+`[parallel]` extra packages as well. This has been fixed.
 
 ## 0.6.0 Release Notes
 

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -26,20 +26,6 @@ merged into `master`! Use `git log` instead and cross-reference instead. -->
 
 <!-- ### Changelog -->
 
-## 0.6.1 Patch Release Notes
-
-This is an emergency patch release to fix an install misconfiguration (see
-{gh}`1302`).
-
-Recent changes to `Optimizer` from the new CMA optimization solver require `joblib` to
-be installed for any Optimization to be run. Since `joblib` is a required dependency of
-`scikit-learn`, installing with `pip install "hnn-core[opt]"` is sufficient, even
-though `[opt]` installs some, but not all, of HNN-Core's `[parallel]` install extras,
-which are `joblib` and `psutil`.
-
-Relatedly, since the GUI can now support optimization, its installation now requires
-the `[opt]` packages to be installed as well. This has been fixed.
-
 ## 0.6.0 Release Notes
 
 ### Important Deprecations

--- a/setup.py
+++ b/setup.py
@@ -96,8 +96,15 @@ if __name__ == "__main__":
             "sphinx-copybutton",
             "tdqm",
         ],
-        "gui": ["ipywidgets>=8.0.0", "ipykernel", "ipympl", "voila"],
     }
+    extras["gui"] = (
+        extras["opt"]
+        + extras["parallel"]
+        + "ipywidgets>=8.0.0"
+        + "ipykernel"
+        + "ipympl"
+        + "voila"
+    )
     extras["all"] = extras["opt"] + extras["parallel"] + extras["gui"]
     extras["dev"] = (
         extras["opt"]

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ class build_py_mod(build_py):
 
 if __name__ == "__main__":
     extras = {
-        "opt": ["scikit-learn", "cma"],
         "parallel": ["joblib", "psutil"],
         "test": ["codespell", "pytest", "pytest-cov", "pytest-xdist", "ruff"],
         "docs": [
@@ -97,6 +96,7 @@ if __name__ == "__main__":
             "tdqm",
         ],
     }
+    extras["opt"] = extras["parallel"] + ["cma", "scikit-learn"]
     extras["gui"] = (
         extras["opt"]
         + extras["parallel"]

--- a/setup.py
+++ b/setup.py
@@ -100,10 +100,7 @@ if __name__ == "__main__":
     extras["gui"] = (
         extras["opt"]
         + extras["parallel"]
-        + "ipywidgets>=8.0.0"
-        + "ipykernel"
-        + "ipympl"
-        + "voila"
+        + ["ipywidgets>=8.0.0", "ipykernel", "ipympl", "voila"]
     )
     extras["all"] = extras["opt"] + extras["parallel"] + extras["gui"]
     extras["dev"] = (

--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,14 @@ class build_py_mod(build_py):
         build_py.run(self)
 
 
+# `scikit-learn` requires installation of `joblib`, so technically, running optimization
+# code does not strictly require installation of the `[parallel]` extras. However, it
+# *does* require some of the same packages that are installed in the `[parallel]`
+# extras. `joblib` will thus be installed in the `[gui]` extras case, but via the
+# `scikit-learn` dependency, not via the `[parallel]` extras.
 if __name__ == "__main__":
     extras = {
+        "opt": ["cma", "scikit-learn"],
         "parallel": ["joblib", "psutil"],
         "test": ["codespell", "pytest", "pytest-cov", "pytest-xdist", "ruff"],
         "docs": [
@@ -96,12 +102,12 @@ if __name__ == "__main__":
             "tdqm",
         ],
     }
-    extras["opt"] = extras["parallel"] + ["cma", "scikit-learn"]
-    extras["gui"] = (
-        extras["opt"]
-        + extras["parallel"]
-        + ["ipywidgets>=8.0.0", "ipykernel", "ipympl", "voila"]
-    )
+    extras["gui"] = extras["opt"] + [
+        "ipywidgets>=8.0.0",
+        "ipykernel",
+        "ipympl",
+        "voila",
+    ]
     extras["all"] = extras["opt"] + extras["parallel"] + extras["gui"]
     extras["dev"] = (
         extras["opt"]


### PR DESCRIPTION
Since we currently never test the GUI install without other extras installed, we missed something. Since the GUI now includes optimization abilities, it requires the `opt` extras to be installed as well before loading properly. Additionally, because the CMA solver requires `BatchSimulate` to be loaded, which requires `joblib` installation, therefore the GUI now also requires `parallel` extras to be installed as well.

In short, for `pip install "hnn-core[gui]"` to work properly, `gui` also needs `opt` and `parallel` packages to also be installed. This commit changes that.