### PR TITLE
[MRG] TEST add progressive installation tests

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -75,7 +75,7 @@ jobs:
         shell: bash -el {0}
         run: rm -rf build
 
-      - name: Install HNN-Core with Optimization dependencies
+      - name: Install HNN-Core with GUI dependencies
         shell: bash -el {0}
         run: pip install --verbose '.[gui]'
 

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -29,28 +29,74 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Python and Conda dependencies
+      - name: Update Python and install HNN-Core with minimal dependencies
         shell: bash -el {0}
         run: |
           python -m pip install --upgrade pip
+          pip install --verbose .
+
+      - name: Test API with minimal dependencies
+        shell: bash -el {0}
+        run: |
+          python -c "from hnn_core import neymotin_2020_model, simulate_dipole; simulate_dipole(neymotin_2020_model(), tstop=20); print('--> SUCCESS: The test worked!')"
+
+      - name: Clean minimal dependencies install
+        shell: bash -el {0}
+        run: rm -rf build
+
+      - name: Install HNN-Core with Optimization dependencies
+        shell: bash -el {0}
+        run: pip install --verbose '.[opt]'
+
+      - name: Test Optimization dependencies
+        shell: bash -el {0}
+        run: python -c "from hnn_core.optimization import Optimizer"
+
+      - name: Clean Optimization dependencies install
+        shell: bash -el {0}
+        run: rm -rf build
+
+      - name: Install HNN-Core with Optimization dependencies
+        shell: bash -el {0}
+        run: pip install --verbose '.[gui]'
+
+      - name: Test GUI dependencies
+        shell: bash -el {0}
+        run: |
+          hnn-gui --no-browser > /tmp/voila.log 2>&1 &
+          GUI_PID=$!
+          # Poll until voila server responds (timeout ~30 seconds)
+          SUCCESS=false
+          for i in $(seq 1 15); do
+            if grep -q "is running at" /tmp/voila.log 2>/dev/null; then
+              SUCCESS=true
+              break
+            fi
+            sleep 2
+          done
+          kill $GUI_PID 2>/dev/null || true
+          if [ "$SUCCESS" = "true" ]; then
+            echo "--> SUCCESS: GUI launched successfully"
+          else
+            echo "--> FAILURE: GUI did not launch within 30 seconds"
+            cat /tmp/voila.log
+            exit 1
+          fi
+
+      - name: Clean GUI dependencies install
+        shell: bash -el {0}
+        run: |
+          rm -rf build
+
+      - name: Install MPI dependencies
+        shell: bash -el {0}
+        run: |
           if [[ "${{ matrix.os }}" == macos* ]]; then
               echo "DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
               echo "LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           fi
           conda install --yes --quiet -c conda-forge mpi4py "openmpi >5"
-
-      - name: Install HNN-Core with minimal dependencies and test
-        shell: bash -el {0}
-        run: |
-          pip install --verbose .
-          python -c "from hnn_core import neymotin_2020_model, simulate_dipole; simulate_dipole(neymotin_2020_model(), tstop=20); print('--> SUCCESS: The test worked!')"
-
-      - name: Clean minimal dependencies install
-        shell: bash -el {0}
-        run: |
-          pip uninstall --yes hnn_core
-          rm -rf build
 
       - name: Install HNN-Core with full dependencies
         shell: bash -el {0}
@@ -83,7 +129,7 @@ jobs:
         run: |
           python -m pytest ./hnn_core/tests/ -m "uses_mpi" --cov=hnn_core --cov-report=xml --cov-append
 
-      - name: Upload coverage to Codecov 
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -65,9 +65,9 @@ jobs:
         run: |
           hnn-gui --no-browser > /tmp/voila.log 2>&1 &
           GUI_PID=$!
-          # Poll until voila server responds (timeout ~30 seconds)
+          # Poll until voila server responds (timeout ~60 seconds (30 * sleep 2)
           SUCCESS=false
-          for i in $(seq 1 15); do
+          for i in $(seq 1 30); do
             if grep -q "is running at" /tmp/voila.log 2>/dev/null; then
               SUCCESS=true
               break
@@ -78,7 +78,7 @@ jobs:
           if [ "$SUCCESS" = "true" ]; then
             echo "--> SUCCESS: GUI launched successfully"
           else
-            echo "--> FAILURE: GUI did not launch within 30 seconds"
+            echo "--> FAILURE: GUI did not launch within 60 seconds"
             cat /tmp/voila.log
             exit 1
           fi

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -29,10 +29,29 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Update Python and install HNN-Core with minimal dependencies
+      - name: Update pip
         shell: bash -el {0}
         run: |
           python -m pip install --upgrade pip
+
+      - name: Install ruff for use before ANY other tests
+        shell: bash -el {0}
+        run: |
+          pip install --verbose ruff
+
+      - name: Check ruff formatting
+        shell: bash -el {0}
+        run: |
+          ruff format hnn_core --check
+
+      - name: Lint with ruff
+        shell: bash -el {0}
+        run: |
+          ruff check hnn_core
+
+      - name: Install HNN-Core with minimal dependencies
+        shell: bash -el {0}
+        run: |
           pip install --verbose .
 
       - name: Test API with minimal dependencies
@@ -108,16 +127,6 @@ jobs:
           conda info
           conda list
         shell: bash -el {0}
-
-      - name: Check ruff formatting
-        shell: bash -el {0}
-        run: |
-          ruff format hnn_core --check
-
-      - name: Lint with ruff
-        shell: bash -el {0}
-        run: |
-          ruff check hnn_core
 
       - name: Test non-MPI, embarrassingly parallel tests with pytest
         shell: bash -el {0}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -81,7 +81,8 @@ jobs:
             -RedirectStandardOutput $outFile -RedirectStandardError $errFile `
             -PassThru -NoNewWindow
           $success = $false
-          for ($i = 0; $i -lt 15; $i++) {
+          # Poll until voila server responds (timeout ~60 seconds (30 * sleep 2)
+          for ($i = 0; $i -lt 30; $i++) {
             $content = ""
             if (Test-Path $outFile) { $content += (Get-Content $outFile -Raw -ErrorAction SilentlyContinue) }
             if (Test-Path $errFile) { $content += (Get-Content $errFile -Raw -ErrorAction SilentlyContinue) }
@@ -95,7 +96,7 @@ jobs:
           if ($success) {
             Write-Output "--> SUCCESS: GUI launched successfully"
           } else {
-            Write-Output "--> FAILURE: GUI did not launch within 30 seconds"
+            Write-Output "--> FAILURE: GUI did not launch within 60 seconds"
             if (Test-Path $outFile) { Get-Content $outFile }
             if (Test-Path $errFile) { Get-Content $errFile }
             exit 1

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -41,18 +41,69 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install HNN-Core with minimal dependencies and test
+      - name: Update Python and install HNN-Core with minimal dependencies
         shell: cmd
         run: |
           python -m pip install --upgrade pip
           pip install --verbose .
+
+      - name: Test API with minimal dependencies
+        shell: cmd
+        run: |
           python -c "from hnn_core import neymotin_2020_model, simulate_dipole; simulate_dipole(neymotin_2020_model(), tstop=20); print('--> SUCCESS: The test worked!')"
 
       - name: Clean minimal dependencies install
         shell: cmd
+        run: rmdir /s /q build
+
+      - name: Install HNN-Core with Optimization dependencies
+        shell: cmd
+        run: pip install --verbose .[opt]
+
+      - name: Test Optimization dependencies
+        shell: cmd
+        run: python -c "from hnn_core.optimization import Optimizer"
+
+      - name: Clean Optimization dependencies install
+        shell: cmd
+        run: rmdir /s /q build
+
+      - name: Install HNN-Core with GUI dependencies
+        shell: cmd
+        run: pip install --verbose .[gui]
+
+      - name: Test GUI dependencies
+        shell: powershell
         run: |
-          pip uninstall --yes hnn_core
-          rmdir /s /q build
+          $outFile = "$env:TEMP\voila_out.log"
+          $errFile = "$env:TEMP\voila_err.log"
+          $proc = Start-Process -FilePath "hnn-gui" -ArgumentList "--no-browser" `
+            -RedirectStandardOutput $outFile -RedirectStandardError $errFile `
+            -PassThru -NoNewWindow
+          $success = $false
+          for ($i = 0; $i -lt 15; $i++) {
+            $content = ""
+            if (Test-Path $outFile) { $content += (Get-Content $outFile -Raw -ErrorAction SilentlyContinue) }
+            if (Test-Path $errFile) { $content += (Get-Content $errFile -Raw -ErrorAction SilentlyContinue) }
+            if ($content -match "is running at") {
+              $success = $true
+              break
+            }
+            Start-Sleep -Seconds 2
+          }
+          Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+          if ($success) {
+            Write-Output "--> SUCCESS: GUI launched successfully"
+          } else {
+            Write-Output "--> FAILURE: GUI did not launch within 30 seconds"
+            if (Test-Path $outFile) { Get-Content $outFile }
+            if (Test-Path $errFile) { Get-Content $errFile }
+            exit 1
+          }
+
+      - name: Clean GUI dependencies install
+        shell: cmd
+        run: rmdir /s /q build
 
       - name: Install HNN-Core with full dependencies
         shell: cmd

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -31,6 +31,26 @@ jobs:
           activate-environment: test
           python-version: ${{ matrix.python-version }}
 
+      - name: Update pip
+        shell: cmd
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Install ruff for use before ANY other tests
+        shell: cmd
+        run: |
+          pip install --verbose ruff
+
+      - name: Check ruff formatting
+        shell: cmd
+        run: |
+          ruff format hnn_core --check
+
+      - name: Lint with ruff
+        shell: cmd
+        run: |
+          ruff check hnn_core
+
       - name: Install Neuron on Windows separately
         shell: cmd
         run: |
@@ -41,10 +61,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update Python and install HNN-Core with minimal dependencies
+      - name: Install HNN-Core with minimal dependencies
         shell: cmd
         run: |
-          python -m pip install --upgrade pip
           pip install --verbose .
 
       - name: Test API with minimal dependencies
@@ -110,16 +129,6 @@ jobs:
         shell: cmd
         run: |
           pip install --verbose .[opt,parallel,test,gui]
-
-      - name: Check ruff formatting
-        shell: cmd
-        run: |
-          python -m ruff format hnn_core --check
-
-      - name: Lint with ruff
-        shell: cmd
-        run: |
-          python -m ruff check hnn_core
 
       - name: Test non-MPI, embarrassingly parallel tests with pytest
         shell: cmd


### PR DESCRIPTION
This adds a few new steps in both the Unix and Windows CI runners between the minimal install and the complete install with all packages. Now, the CI runners do the following in order:

1. test that the minimal install (API-only) works with a test simulation
2. test that the `[opt]` dependencies are sufficient to allow import of `Optimizer`
3. test that `[gui]` depdencies are sufficient to allow proper startup of the gui
4. continue with the remaining tests, where a complete install (except for `[doc]`) is installed, then various checkers are run, then finally the tests as a whole are run.