### PR TITLE
[MRG] MAINT separate names of unit tests

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Unix Unit Tests
 
 on:
   push:

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -1,4 +1,4 @@
-name: Unit test
+name: Windows Unit Tests
 
 on:
   push:


### PR DESCRIPTION
This makes it easier to tell which set of unit tests is for which set of OS's when I'm browsing the Github Actions and reviewing current CI runners.

Since this is trivial, I will probably self-merge