### PR TITLE
[MRG] MIGRATE os path utilities to pathlib

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -120,6 +120,7 @@ jobs:
       - name: Install HNN-Core with full dependencies
         shell: bash -el {0}
         run: |
+          pip install --upgrade --force-reinstall pip
           pip install --verbose '.[opt, parallel, test, gui]'
 
       - name: Print environment info

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -120,7 +120,6 @@ jobs:
       - name: Install HNN-Core with full dependencies
         shell: bash -el {0}
         run: |
-          conda install --yes --force-reinstall pip
           pip install --verbose '.[opt, parallel, test, gui]'
 
       - name: Print environment info

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install HNN-Core with full dependencies
         shell: bash -el {0}
         run: |
-          pip install --upgrade --force-reinstall pip
+          conda install --yes --force-reinstall pip
           pip install --verbose '.[opt, parallel, test, gui]'
 
       - name: Print environment info

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,19 +10,19 @@
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+# documentation root, use Path.resolve() to make it absolute, like shown here.
 #
-import os
 import sys
+from pathlib import Path
 from sphinx_gallery.sorting import ExampleTitleSortKey, ExplicitOrder
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-curdir = os.path.dirname(__file__)
-sys.path.append(os.path.abspath(os.path.join(curdir, "..", "hnn_core")))
-sys.path.append(os.path.abspath(os.path.join(curdir, "..")))
-sys.path.append(os.path.abspath(os.path.join(curdir, "sphinxext")))
+# documentation root, use Path.resolve() to make it absolute, like shown here.
+curdir = Path(__file__).parent
+sys.path.append(str((curdir / ".." / "hnn_core").resolve()))
+sys.path.append(str((curdir / "..").resolve()))
+sys.path.append(str((curdir / "sphinxext").resolve()))
 
 # -- Project information -----------------------------------------------------
 

--- a/hnn_core/batch_simulate.py
+++ b/hnn_core/batch_simulate.py
@@ -429,7 +429,6 @@ class BatchSimulate(object):
         }
         save_data["metadata"] = metadata
 
-        save_folder = Path(self.save_folder)
         file_path = save_folder / f"sim_run_{start_idx}-{end_idx}.npz"
         if file_path.exists() and not self.overwrite:
             raise FileExistsError(

--- a/hnn_core/batch_simulate.py
+++ b/hnn_core/batch_simulate.py
@@ -5,9 +5,8 @@
 #          Ryan Thorpe <ryan_thorpe@brown.edu>
 #          Mainak Jas <mjas@mgh.harvard.edu>
 
-import os
 from itertools import product
-
+from pathlib import Path
 import numpy as np
 from joblib import Parallel, delayed, parallel_config
 
@@ -406,9 +405,8 @@ class BatchSimulate(object):
         _validate_type(start_idx, types="int", item_name="start_idx")
         _validate_type(end_idx, types="int", item_name="end_idx")
 
-        if not os.path.exists(self.save_folder):
-            os.makedirs(self.save_folder)
-
+        save_folder = Path(self.save_folder)
+        save_folder.mkdir(parents=True, exist_ok=True)
         save_data = {"param_values": [result["param_values"] for result in results]}
 
         attributes_to_save = [
@@ -431,8 +429,9 @@ class BatchSimulate(object):
         }
         save_data["metadata"] = metadata
 
-        file_name = os.path.join(self.save_folder, f"sim_run_{start_idx}-{end_idx}.npz")
-        if os.path.exists(file_name) and not self.overwrite:
+        save_folder = Path(self.save_folder)
+        file_name = save_folder / f"sim_run_{start_idx}-{end_idx}.npz"
+        if file_name.exists() and not self.overwrite:
             raise FileExistsError(
                 f"File {file_name} already exists and overwrite is set to False."
             )
@@ -487,9 +486,8 @@ class BatchSimulate(object):
             List of dictionaries containing all loaded simulation results.
         """
         all_results = []
-        for file_name in os.listdir(self.save_folder):
-            if file_name.startswith("sim_run_") and file_name.endswith(".npz"):
-                file_path = os.path.join(self.save_folder, file_name)
-                results = self.load_results(file_path)
-                all_results.append(results)
+        save_folder=Path(self.save_folder)
+        for file_path in save_folder.glob("sim_run_*.npz"):
+            results = self.load_results(file_path)
+            all_results.append(results)
         return all_results

--- a/hnn_core/batch_simulate.py
+++ b/hnn_core/batch_simulate.py
@@ -486,7 +486,7 @@ class BatchSimulate(object):
             List of dictionaries containing all loaded simulation results.
         """
         all_results = []
-        save_folder=Path(self.save_folder)
+        save_folder = Path(self.save_folder)
         for file_path in save_folder.glob("sim_run_*.npz"):
             results = self.load_results(file_path)
             all_results.append(results)

--- a/hnn_core/batch_simulate.py
+++ b/hnn_core/batch_simulate.py
@@ -430,13 +430,13 @@ class BatchSimulate(object):
         save_data["metadata"] = metadata
 
         save_folder = Path(self.save_folder)
-        file_name = save_folder / f"sim_run_{start_idx}-{end_idx}.npz"
-        if file_name.exists() and not self.overwrite:
+        file_path = save_folder / f"sim_run_{start_idx}-{end_idx}.npz"
+        if file_path.exists() and not self.overwrite:
             raise FileExistsError(
-                f"File {file_name} already exists and overwrite is set to False."
+                f"File {file_path} already exists and overwrite is set to False."
             )
 
-        np.savez(file_name, **save_data)
+        np.savez(file_path, **save_data)
 
     def load_results(self, file_path, return_data=None):
         """Load simulation results from a file.

--- a/hnn_core/dipole.py
+++ b/hnn_core/dipole.py
@@ -3,7 +3,7 @@
 # Authors: Mainak Jas <mjas@mgh.harvard.edu>
 #          Sam Neymotin <samnemo@gmail.com>
 
-import os
+from pathlib import Path
 import warnings
 from copy import deepcopy
 from io import StringIO
@@ -215,10 +215,10 @@ def read_dipole(fname):
         The instance of Dipole class
     """
 
-    fname = str(fname)
-    if not os.path.exists(fname):
-        raise FileNotFoundError("File not found at path %s." % (fname,))
-    file_extension = os.path.splitext(fname)[-1]
+    fname = Path(fname)
+    if not fname.exists():
+        raise FileNotFoundError(f"File not found at path {fname}.")
+    file_extension = fname.suffix
     if file_extension == ".txt":
         return _read_dipole_txt(fname)
     elif file_extension == ".hdf5":
@@ -226,7 +226,7 @@ def read_dipole(fname):
     else:
         raise NameError(
             "File extension should be either txt or hdf5, but the "
-            "given extension is %s" % (file_extension,)
+            f"given extension is {file_extension}."
         )
 
 
@@ -854,13 +854,13 @@ class Dipole(object):
         if isinstance(fname, StringIO):
             return self._write_txt(fname)
 
-        fname = str(fname)
-        if overwrite is False and os.path.exists(fname):
+        fname = Path(fname)
+        if overwrite is False and fname.exists():
             raise FileExistsError(
                 "File already exists at path %s. Rename "
                 "the file or set overwrite=True." % (fname,)
             )
-        file_extension = os.path.splitext(fname)[-1]
+        file_extension = fname.suffix
         if file_extension == ".txt":
             self._write_txt(fname)
         elif file_extension == ".hdf5":
@@ -868,5 +868,5 @@ class Dipole(object):
         else:
             raise NameError(
                 "File extension should be either txt or hdf5, but "
-                "the given extension is %s." % (file_extension,)
+                f"the given extension is {file_extension}."
             )

--- a/hnn_core/hnn_io.py
+++ b/hnn_core/hnn_io.py
@@ -452,9 +452,9 @@ def write_network_configuration(net, output, overwrite=True):
 
     net_data = net.to_dict(write_output=False)
     net_data_converted = _convert_np_array_to_list(net_data)
-    
+
     if isinstance(output, (str, Path)):
-        output=Path(output)
+        output = Path(output)
         if overwrite is False and output.exists():
             raise FileExistsError(
                 f"File already exists at path {output}. Rename "

--- a/hnn_core/hnn_io.py
+++ b/hnn_core/hnn_io.py
@@ -4,7 +4,6 @@
 #          Nick Tolley <nicholas_tolley@brown.edu>
 #          George Dang <george_dang@brown.edu>
 
-import os
 import json
 import numpy as np
 
@@ -453,12 +452,13 @@ def write_network_configuration(net, output, overwrite=True):
 
     net_data = net.to_dict(write_output=False)
     net_data_converted = _convert_np_array_to_list(net_data)
-
+    
     if isinstance(output, (str, Path)):
-        if overwrite is False and os.path.exists(output):
+        output=Path(output)
+        if overwrite is False and output.exists():
             raise FileExistsError(
-                "File already exists at path %s. Rename "
-                "the file or set overwrite=True." % (output,)
+                f"File already exists at path {output}. Rename "
+                f"the file or set overwrite=True."
             )
         # Saving file
         with open(output, "w", encoding="utf-8") as f:

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -5,9 +5,8 @@
 #          Blake Caldwell <blake_caldwell@brown.edu>
 
 import os
-import os.path as op
 from copy import deepcopy
-
+from pathlib import Path
 import numpy as np
 from neuron import h
 
@@ -184,11 +183,11 @@ def load_custom_mechanisms(net_verbose=True):
 
     # recursively find the .so / .dll library
     mech_fname = list()
-    mod_dir = op.join(op.dirname(__file__), "mod")
+    mod_dir = Path(__file__).parent / "mod"
     for root, dirnames, filenames in os.walk(mod_dir):
         for filename in filenames:
             if filename.endswith((".so", ".dll")):
-                mech_fname.append(os.path.join(root, filename))
+                mech_fname.append(Path(root) / filename)
                 break
 
     if len(mech_fname) == 0:

--- a/hnn_core/network_builder.py
+++ b/hnn_core/network_builder.py
@@ -187,7 +187,7 @@ def load_custom_mechanisms(net_verbose=True):
     for root, dirnames, filenames in os.walk(mod_dir):
         for filename in filenames:
             if filename.endswith((".so", ".dll")):
-                mech_fname.append(Path(root) / filename)
+                mech_fname.append(str(Path(root) / filename))
                 break
 
     if len(mech_fname) == 0:

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -2,7 +2,7 @@
 
 # Authors: Nick Tolley <nicholas_tolley@brown.edu>
 
-import os.path as op
+from pathlib import Path
 from copy import deepcopy
 import warnings
 
@@ -120,9 +120,9 @@ def neymotin_2020_model(
            MEG/EEG Data." eLife 9 (January):e51214. https://doi.org/10.7554/eLife.51214
 
     """
-    hnn_core_root = op.dirname(hnn_core.__file__)
+    hnn_core_root = Path(hnn_core.__file__).parent
     if params is None:
-        params = op.join(hnn_core_root, "param", "default.json")
+        params = hnn_core_root/ "param"/ "default.json"
     if isinstance(params, str):
         params = read_params(params)
 
@@ -490,8 +490,8 @@ def calcium_model(
            Evoked Responses Revealed By Human Neocortical Neurosolver."
            Brain Topography, 35, 19–35 (2022).
     """
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root/ "param"/ "default.json"
     if params is None:
         params = read_params(params_fname)
 

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -122,7 +122,7 @@ def neymotin_2020_model(
     """
     hnn_core_root = Path(hnn_core.__file__).parent
     if params is None:
-        params = hnn_core_root/ "param"/ "default.json"
+        params = hnn_core_root / "param" / "default.json"
     if isinstance(params, (str, Path)):
         params = read_params(params)
 
@@ -491,7 +491,7 @@ def calcium_model(
            Brain Topography, 35, 19–35 (2022).
     """
     hnn_core_root = Path(hnn_core.__file__).parent
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     if params is None:
         params = read_params(params_fname)
 

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -123,7 +123,7 @@ def neymotin_2020_model(
     hnn_core_root = Path(hnn_core.__file__).parent
     if params is None:
         params = hnn_core_root/ "param"/ "default.json"
-    if isinstance(params, str):
+    if isinstance(params, (str, Path)):
         params = read_params(params)
 
     # Define cell types for Jones 2009 model

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -528,10 +528,7 @@ def _get_procs_running(proc_name):
     for p in process_iter(attrs=["name", "exe", "cmdline"]):
         if (
             proc_name == p.info["name"]
-            or (
-                p.info["exe"] is not None
-                and Path(p.info["exe"]).name == proc_name
-            )
+            or (p.info["exe"] is not None and Path(p.info["exe"]).name == proc_name)
             or (p.info["cmdline"] and p.info["cmdline"][0] == proc_name)
         ):
             process_list.append(p)

--- a/hnn_core/parallel_backends.py
+++ b/hnn_core/parallel_backends.py
@@ -14,7 +14,7 @@ from warnings import warn
 from subprocess import Popen, PIPE, TimeoutExpired
 from queue import Queue, Empty
 from threading import Thread, Event
-
+from pathlib import Path
 from typing import Union
 
 from .cell_response import CellResponse
@@ -530,7 +530,7 @@ def _get_procs_running(proc_name):
             proc_name == p.info["name"]
             or (
                 p.info["exe"] is not None
-                and os.path.basename(p.info["exe"]) == proc_name
+                and Path(p.info["exe"]).name == proc_name
             )
             or (p.info["cmdline"] and p.info["cmdline"][0] == proc_name)
         ):
@@ -670,7 +670,7 @@ class JoblibBackend(object):
 def _determine_cores_hwthreading(
     use_hwthreading_if_found: bool = True,
     sensible_default_cores: bool = True,
-) -> [int, bool]:
+) -> tuple[int, bool]:
     """Return the available core number and if hardware-threading is detected.
 
     If the first argument 'use_hwthreading_if_found' is 'True', then the
@@ -1013,9 +1013,7 @@ class MPIBackend(object):
             " nrniv -python -mpi -nobanner "
             + sys.executable
             + " "
-            + os.path.join(
-                os.path.dirname(sys.modules[__name__].__file__), "mpi_child.py"
-            )
+            + str(Path(sys.modules[__name__].__file__).parent / "mpi_child.py")
         )
 
         # Split the command into shell arguments for passing to Popen

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -85,7 +85,6 @@ def read_params(params_fname, file_contents=None):
         Params containing parameter values from file
     """
 
-    
     ext = Path(params_fname).suffix
 
     if ext not in [".json", ".param"]:

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -5,7 +5,6 @@
 
 import json
 import fnmatch
-import os.path as op
 from pathlib import Path
 from copy import deepcopy
 
@@ -86,8 +85,8 @@ def read_params(params_fname, file_contents=None):
         Params containing parameter values from file
     """
 
-    split_fname = op.splitext(params_fname)
-    ext = split_fname[1]
+    
+    ext = Path(params_fname).suffix
 
     if ext not in [".json", ".param"]:
         raise ValueError(
@@ -103,7 +102,7 @@ def read_params(params_fname, file_contents=None):
 
     if len(params_dict) == 0:
         raise ValueError(
-            "Failed to read parameters from file: %s" % op.normpath(params_fname)
+            "Failed to read parameters from file: %s" % Path(params_fname).resolve()
         )
 
     params = Params(params_dict)

--- a/hnn_core/tests/conftest.py
+++ b/hnn_core/tests/conftest.py
@@ -85,7 +85,7 @@ def run_hnn_core_fixture():
         hnn_core_root = Path(hnn_core.__file__).parent
 
         # default params
-        params_fname = hnn_core_root/ "param"/ "default.json"
+        params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
 
         tstop = 170.0

--- a/hnn_core/tests/conftest.py
+++ b/hnn_core/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import Dict, Tuple
 import pytest
 import pickle
 
-import os.path as op
+from pathlib import Path
 import hnn_core
 from hnn_core import read_params, neymotin_2020_model, simulate_dipole
 from hnn_core import MPIBackend, JoblibBackend
@@ -82,10 +82,10 @@ def run_hnn_core_fixture():
         postproc=False,
         electrode_array=None,
     ):
-        hnn_core_root = op.dirname(hnn_core.__file__)
+        hnn_core_root = Path(hnn_core.__file__).parent
 
         # default params
-        params_fname = op.join(hnn_core_root, "param", "default.json")
+        params_fname = hnn_core_root/ "param"/ "default.json"
         params = read_params(params_fname)
 
         tstop = 170.0

--- a/hnn_core/tests/test_batch_simulate.py
+++ b/hnn_core/tests/test_batch_simulate.py
@@ -206,7 +206,7 @@ def test_save_load_and_overwrite(batch_simulate_instance, param_grid, tmp_path):
 
     batch_simulate_instance._save(results, start_idx, end_idx)
 
-    file_name = tmp_path/ f"sim_run_{start_idx}-{end_idx}.npz"
+    file_name = tmp_path / f"sim_run_{start_idx}-{end_idx}.npz"
     assert file_name.exists()
 
     loaded_data = np.load(file_name, allow_pickle=True)
@@ -257,7 +257,7 @@ def test_load_results(batch_simulate_instance, param_grid, tmp_path):
     end_idx = len(results)
     batch_simulate_instance._save(results, start_idx, end_idx)
 
-    file_name = tmp_path/ f"sim_run_{start_idx}-{end_idx}.npz"
+    file_name = tmp_path / f"sim_run_{start_idx}-{end_idx}.npz"
     assert file_name.exists()
 
     # single result file

--- a/hnn_core/tests/test_batch_simulate.py
+++ b/hnn_core/tests/test_batch_simulate.py
@@ -206,10 +206,10 @@ def test_save_load_and_overwrite(batch_simulate_instance, param_grid, tmp_path):
 
     batch_simulate_instance._save(results, start_idx, end_idx)
 
-    file_name = tmp_path / f"sim_run_{start_idx}-{end_idx}.npz"
-    assert file_name.exists()
+    file_path = tmp_path / f"sim_run_{start_idx}-{end_idx}.npz"
+    assert file_path.exists()
 
-    loaded_data = np.load(file_name, allow_pickle=True)
+    loaded_data = np.load(file_path, allow_pickle=True)
     loaded_results = {key: loaded_data[key].tolist() for key in loaded_data.files}
 
     original_data = np.stack([result["dpl"][0].data["agg"] for result in results])
@@ -227,7 +227,7 @@ def test_save_load_and_overwrite(batch_simulate_instance, param_grid, tmp_path):
     batch_simulate_instance.overwrite = True
     batch_simulate_instance._save(results, start_idx, end_idx)
 
-    loaded_data = np.load(file_name, allow_pickle=True)
+    loaded_data = np.load(file_path, allow_pickle=True)
     loaded_results = {key: loaded_data[key].tolist() for key in loaded_data.files}
 
     original_data = np.stack([result["dpl"][0].data["agg"] for result in results])
@@ -257,11 +257,11 @@ def test_load_results(batch_simulate_instance, param_grid, tmp_path):
     end_idx = len(results)
     batch_simulate_instance._save(results, start_idx, end_idx)
 
-    file_name = tmp_path / f"sim_run_{start_idx}-{end_idx}.npz"
-    assert file_name.exists()
+    file_path = tmp_path / f"sim_run_{start_idx}-{end_idx}.npz"
+    assert file_path.exists()
 
     # single result file
-    loaded_results = batch_simulate_instance.load_results(file_name)
+    loaded_results = batch_simulate_instance.load_results(file_path)
     assert "param_values" in loaded_results
     assert "dpl" in loaded_results
     assert len(loaded_results["dpl"]) == len(results)

--- a/hnn_core/tests/test_batch_simulate.py
+++ b/hnn_core/tests/test_batch_simulate.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import time
 import pytest
 import numpy as np
-import os
 
 from hnn_core.batch_simulate import BatchSimulate
 from hnn_core import neymotin_2020_model
@@ -207,8 +206,8 @@ def test_save_load_and_overwrite(batch_simulate_instance, param_grid, tmp_path):
 
     batch_simulate_instance._save(results, start_idx, end_idx)
 
-    file_name = os.path.join(tmp_path, f"sim_run_{start_idx}-{end_idx}.npz")
-    assert os.path.exists(file_name)
+    file_name = tmp_path/ f"sim_run_{start_idx}-{end_idx}.npz"
+    assert file_name.exists()
 
     loaded_data = np.load(file_name, allow_pickle=True)
     loaded_results = {key: loaded_data[key].tolist() for key in loaded_data.files}
@@ -258,8 +257,8 @@ def test_load_results(batch_simulate_instance, param_grid, tmp_path):
     end_idx = len(results)
     batch_simulate_instance._save(results, start_idx, end_idx)
 
-    file_name = os.path.join(tmp_path, f"sim_run_{start_idx}-{end_idx}.npz")
-    assert os.path.exists(file_name)
+    file_name = tmp_path/ f"sim_run_{start_idx}-{end_idx}.npz"
+    assert file_name.exists()
 
     # single result file
     loaded_results = batch_simulate_instance.load_results(file_name)

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -21,7 +21,7 @@ matplotlib.use("agg")
 def test_dipole(tmp_path, run_hnn_core_fixture):
     """Test dipole object."""
     hnn_core_root = Path(hnn_core.__file__).parent
-    params_fname = hnn_core_root/ "param" / "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     dpl_out_fname = tmp_path / "dpl1.txt"
     dpl_out_hdf5_fname = tmp_path / "dpl.hdf5"
     params = read_params(params_fname)
@@ -187,7 +187,7 @@ def test_dipole(tmp_path, run_hnn_core_fixture):
 def test_dipole_simulation():
     """Test data produced from simulate_dipole() call."""
     hnn_core_root = Path(hnn_core.__file__).parent
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     params.update(
         {"dipole_smooth_win": 5, "t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20}
@@ -328,7 +328,7 @@ def test_rmse():
     )
 
     hnn_core_root = Path(hnn_core.__file__).resolve().parent
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
 
     expected_rmse = 0.1

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -327,7 +327,7 @@ def test_rmse():
         times=extdata[:, 0], data=np.c_[extdata[:, 1], extdata[:, 1], extdata[:, 1]]
     )
 
-    hnn_core_root = Path(hnn_core.__file__).resolve().parent
+    hnn_core_root = Path(hnn_core.__file__).parent
     params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
 

--- a/hnn_core/tests/test_dipole.py
+++ b/hnn_core/tests/test_dipole.py
@@ -1,4 +1,3 @@
-import os.path as op
 from urllib.request import urlretrieve
 from pathlib import Path
 
@@ -21,8 +20,8 @@ matplotlib.use("agg")
 
 def test_dipole(tmp_path, run_hnn_core_fixture):
     """Test dipole object."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root/ "param" / "default.json"
     dpl_out_fname = tmp_path / "dpl1.txt"
     dpl_out_hdf5_fname = tmp_path / "dpl.hdf5"
     params = read_params(params_fname)
@@ -187,8 +186,8 @@ def test_dipole(tmp_path, run_hnn_core_fixture):
 
 def test_dipole_simulation():
     """Test data produced from simulate_dipole() call."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
     params.update(
         {"dipole_smooth_win": 5, "t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20}
@@ -320,7 +319,7 @@ def test_rmse():
         "https://raw.githubusercontent.com/jonescompneurolab/hnn/"
         "master/data/MEG_detection_data/yes_trial_S1_ERP_all_avg.txt"
     )
-    if not op.exists("yes_trial_S1_ERP_all_avg.txt"):
+    if not Path("yes_trial_S1_ERP_all_avg.txt").exists():
         urlretrieve(data_url, "yes_trial_S1_ERP_all_avg.txt")
     extdata = np.loadtxt("yes_trial_S1_ERP_all_avg.txt")
 
@@ -328,8 +327,8 @@ def test_rmse():
         times=extdata[:, 0], data=np.c_[extdata[:, 1], extdata[:, 1], extdata[:, 1]]
     )
 
-    hnn_core_root = op.join(op.dirname(hnn_core.__file__))
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).resolve().parent
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
 
     expected_rmse = 0.1

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -24,7 +24,7 @@ hnn_core_root = Path(hnn_core.__file__).parent
 @pytest.fixture
 def setup_net():
     hnn_core_root = Path(hnn_core.__file__).parent
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     net = neymotin_2020_model(params, mesh_shape=(3, 3))
 
@@ -220,7 +220,7 @@ def test_clear_drives(setup_net):
 def test_add_drives():
     """Test methods for adding drives to a Network."""
     hnn_core_root = Path(hnn_core.__file__).parent
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     net = Network(params, legacy_mode=False)
 

--- a/hnn_core/tests/test_drives.py
+++ b/hnn_core/tests/test_drives.py
@@ -2,7 +2,7 @@
 #          Christopher Bailey <bailey.cj@gmail.com>
 
 import pytest
-import os.path as op
+from pathlib import Path
 
 import numpy as np
 
@@ -18,13 +18,13 @@ from hnn_core.network import pick_connection
 from hnn_core.network_models import neymotin_2020_model
 from hnn_core import simulate_dipole
 
-hnn_core_root = op.dirname(hnn_core.__file__)
+hnn_core_root = Path(hnn_core.__file__).parent
 
 
 @pytest.fixture
 def setup_net():
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
     net = neymotin_2020_model(params, mesh_shape=(3, 3))
 
@@ -219,8 +219,8 @@ def test_clear_drives(setup_net):
 
 def test_add_drives():
     """Test methods for adding drives to a Network."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
     net = Network(params, legacy_mode=False)
 

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 
 
 hnn_core_root = Path(hnn_core.__file__).parent
-params_fname = hnn_core_root/ "param"/ "default.json"
+params_fname = hnn_core_root / "param" / "default.json"
 params = read_params(params_fname)
 
 
@@ -267,7 +267,7 @@ def test_extracellular_backends(run_hnn_core_fixture):
 def test_rec_array_calculation():
     """Test LFP/CSD calculation."""
     hnn_core_root = Path(hnn_core.__file__).parent
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     params.update({"t_evprox_1": 7, "t_evdist_1": 17})
     net = neymotin_2020_model(params, mesh_shape=(3, 3), add_drives_from_params=True)
@@ -324,7 +324,7 @@ def test_rec_array_calculation():
 def test_extracellular_viz():
     """Test if deprecation warning is raised in plot_laminar_lfp."""
     hnn_core_root = Path(hnn_core.__file__).parent
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     params.update({"t_evprox_1": 7, "t_evdist_1": 17})
     net = neymotin_2020_model(params, mesh_shape=(3, 3), add_drives_from_params=True)

--- a/hnn_core/tests/test_extracellular.py
+++ b/hnn_core/tests/test_extracellular.py
@@ -2,7 +2,7 @@
 #          Christopher Bailey <cjb@cfin.au.dk>
 
 from copy import deepcopy
-import os.path as op
+from pathlib import Path
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
@@ -19,8 +19,8 @@ from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
 import matplotlib.pyplot as plt
 
 
-hnn_core_root = op.dirname(hnn_core.__file__)
-params_fname = op.join(hnn_core_root, "param", "default.json")
+hnn_core_root = Path(hnn_core.__file__).parent
+params_fname = hnn_core_root/ "param"/ "default.json"
 params = read_params(params_fname)
 
 
@@ -266,8 +266,8 @@ def test_extracellular_backends(run_hnn_core_fixture):
 
 def test_rec_array_calculation():
     """Test LFP/CSD calculation."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
     params.update({"t_evprox_1": 7, "t_evdist_1": 17})
     net = neymotin_2020_model(params, mesh_shape=(3, 3), add_drives_from_params=True)
@@ -323,8 +323,8 @@ def test_rec_array_calculation():
 
 def test_extracellular_viz():
     """Test if deprecation warning is raised in plot_laminar_lfp."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
     params.update({"t_evprox_1": 7, "t_evdist_1": 17})
     net = neymotin_2020_model(params, mesh_shape=(3, 3), add_drives_from_params=True)

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -3,6 +3,7 @@
 #          George Dang <george_dang@brown.edu>
 import codecs
 import io
+import os
 import json
 import logging
 import os

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -6,7 +6,6 @@ import io
 import os
 import json
 import logging
-import os
 import sys
 import tempfile
 import time

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -2,7 +2,6 @@
 #          Rajat Partani <rajatpartani@gmail.com>
 
 import json
-import os.path as op
 from pathlib import Path
 from time import sleep
 from urllib.request import urlretrieve
@@ -384,8 +383,8 @@ def test_read_run_tutorial_json():
         "hnn-data/refs/heads/main/"
         "network-configurations/ERPYes100Trials.json"
     )
-    net_fname = op.join(hnn_core_root, "param", "ERPYes100Trials.json")
-    if not op.exists(net_fname):
+    net_fname = hnn_core_root/ "param"/ "ERPYes100Trials.json"
+    if not net_fname.exists():
         urlretrieve(net_url, net_fname)
 
     # Test that Network can be created without error.

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -383,7 +383,7 @@ def test_read_run_tutorial_json():
         "hnn-data/refs/heads/main/"
         "network-configurations/ERPYes100Trials.json"
     )
-    net_fname = hnn_core_root/ "param"/ "ERPYes100Trials.json"
+    net_fname = hnn_core_root / "param" / "ERPYes100Trials.json"
     if not net_fname.exists():
         urlretrieve(net_url, net_fname)
 

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -1,4 +1,4 @@
-import os.path as op
+from pathlib import Path
 import io
 from contextlib import redirect_stdout, redirect_stderr
 from queue import Queue
@@ -85,10 +85,10 @@ def test_extract_data_length():
 def test_str_to_net():
     """Test reading the network via a string"""
 
-    hnn_core_root = op.dirname(hnn_core.__file__)
+    hnn_core_root = Path(hnn_core.__file__).parent
 
     # prepare network
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
     net = neymotin_2020_model(params, add_drives_from_params=True)
 
@@ -122,10 +122,10 @@ def test_str_to_net():
 def test_child_run():
     """Test running the child process without MPI"""
 
-    hnn_core_root = op.dirname(hnn_core.__file__)
+    hnn_core_root = Path(hnn_core.__file__).parent
 
     # prepare params
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
     params_reduced = params.copy()
     params_reduced.update({"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20})

--- a/hnn_core/tests/test_mpi_child.py
+++ b/hnn_core/tests/test_mpi_child.py
@@ -88,7 +88,7 @@ def test_str_to_net():
     hnn_core_root = Path(hnn_core.__file__).parent
 
     # prepare network
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     net = neymotin_2020_model(params, add_drives_from_params=True)
 
@@ -125,7 +125,7 @@ def test_child_run():
     hnn_core_root = Path(hnn_core.__file__).parent
 
     # prepare params
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     params_reduced = params.copy()
     params_reduced.update({"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20})

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -2,7 +2,7 @@
 
 from contextlib import redirect_stdout
 import io
-import os.path as op
+from pathlib import Path
 import tempfile
 
 import numpy as np
@@ -32,14 +32,14 @@ from hnn_core.network_builder import NetworkBuilder
 from hnn_core.network_models import add_erp_drives_to_jones_model
 from hnn_core.viz import plot_dipole
 
-hnn_core_root = op.dirname(hnn_core.__file__)
-params_fname = op.join(hnn_core_root, "param", "default.json")
+hnn_core_root = Path(hnn_core.__file__).parent
+params_fname = hnn_core_root/ "param"/ "default.json"
 
 
 @pytest.fixture(scope="class")
 def base_network():
     """Base Network with connections and drives"""
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
     net = Network(params, legacy_mode=False)
     # add some basic local network connectivity
@@ -1095,10 +1095,10 @@ def test_add_cell_type():
 
 def test_tonic_biases():
     """Test tonic biases."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
+    hnn_core_root = Path(hnn_core.__file__).parent
 
     # default params
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
 
     net = Network(params)
@@ -1235,10 +1235,10 @@ def test_tonic_biases():
 
 def test_network_mesh():
     """Test mesh for defining cell positions biases."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
+    hnn_core_root = Path(hnn_core.__file__).parent
 
     # default params
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
 
     # Test custom mesh_shape
@@ -1660,8 +1660,9 @@ def test_rename_cell_types(base_network):
 
     # Test the other main network we use for testing
     net4 = hnn_core.hnn_io.read_network_configuration(
-        op.join(hnn_core_root, "tests", "assets", "neymotin2020_3x3_drives.json")
-    )
+        hnn_core_root/ "tests"/ "assets"/ "neymotin2020_3x3_drives.json"
+        )
+    
     net4._rename_cell_types(cell_type_rename_mapping)
     dpls4 = simulate_dipole(net4, tstop=10.0, n_trials=1)
     plot_dipole(dpls4, show=False)
@@ -1719,9 +1720,9 @@ def test_spike_train_drive_formats_and_simulation():
         )
 
         # Write spike data to file
-        spike_file_pattern = op.join(tmp_dir, "spk_%d.txt")
+        spike_file_pattern = str(tmp_dir / "spk_%d.txt")
         cell_response.write(spike_file_pattern)
-        file_format = op.join(tmp_dir, "spk_*.txt")
+        file_format = str(tmp_dir / "spk_*.txt")
 
         # Add drives to networks with different formats
         net_dict.add_spike_train_drive(

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -33,13 +33,13 @@ from hnn_core.network_models import add_erp_drives_to_jones_model
 from hnn_core.viz import plot_dipole
 
 hnn_core_root = Path(hnn_core.__file__).parent
-params_fname = hnn_core_root/ "param"/ "default.json"
+params_fname = hnn_core_root / "param" / "default.json"
 
 
 @pytest.fixture(scope="class")
 def base_network():
     """Base Network with connections and drives"""
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     net = Network(params, legacy_mode=False)
     # add some basic local network connectivity
@@ -1098,7 +1098,7 @@ def test_tonic_biases():
     hnn_core_root = Path(hnn_core.__file__).parent
 
     # default params
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
 
     net = Network(params)
@@ -1238,7 +1238,7 @@ def test_network_mesh():
     hnn_core_root = Path(hnn_core.__file__).parent
 
     # default params
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
 
     # Test custom mesh_shape
@@ -1660,9 +1660,9 @@ def test_rename_cell_types(base_network):
 
     # Test the other main network we use for testing
     net4 = hnn_core.hnn_io.read_network_configuration(
-        hnn_core_root/ "tests"/ "assets"/ "neymotin2020_3x3_drives.json"
-        )
-    
+        hnn_core_root / "tests" / "assets" / "neymotin2020_3x3_drives.json"
+    )
+
     net4._rename_cell_types(cell_type_rename_mapping)
     dpls4 = simulate_dipole(net4, tstop=10.0, n_trials=1)
     plot_dipole(dpls4, show=False)
@@ -1720,9 +1720,9 @@ def test_spike_train_drive_formats_and_simulation():
         )
 
         # Write spike data to file
-        spike_file_pattern = str(tmp_dir / "spk_%d.txt")
+        spike_file_pattern = str(Path(tmp_dir) / "spk_%d.txt")
         cell_response.write(spike_file_pattern)
-        file_format = str(tmp_dir / "spk_*.txt")
+        file_format = str(Path(tmp_dir) / "spk_*.txt")
 
         # Add drives to networks with different formats
         net_dict.add_spike_train_drive(

--- a/hnn_core/tests/test_optimize_evoked.py
+++ b/hnn_core/tests/test_optimize_evoked.py
@@ -1,6 +1,6 @@
 # Authors: Mainak Jas <mainakjas@gmail.com>
 
-import os.path as op
+from pathlib import Path
 import numpy as np
 import pytest
 
@@ -90,8 +90,8 @@ def test_split_by_evinput():
 
 def test_optimize_evoked():
     """Test running the full routine in a reduced network."""
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
 
     tstop = 10.0

--- a/hnn_core/tests/test_optimize_evoked.py
+++ b/hnn_core/tests/test_optimize_evoked.py
@@ -91,7 +91,7 @@ def test_split_by_evinput():
 def test_optimize_evoked():
     """Test running the full routine in a reduced network."""
     hnn_core_root = Path(hnn_core.__file__).parent
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
 
     tstop = 10.0

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -170,7 +170,7 @@ class TestParallelBackends:
     def test_terminate_mpibackend(self, run_hnn_core_fixture):
         """Test terminating MPIBackend from thread"""
         hnn_core_root = Path(hnn_core.__file__).parent
-        params_fname = hnn_core_root/ "param"/ "default.json"
+        params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
         params.update(
             {"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20, "N_trials": 2}
@@ -206,7 +206,7 @@ class TestParallelBackends:
     def test_run_mpibackend_oversubscribed(self, use_hwthreading_if_found):
         """Test running MPIBackend with oversubscribed number of procs"""
         hnn_core_root = Path(hnn_core.__file__).parent
-        params_fname = hnn_core_root/ "param"/ "default.json"
+        params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
         params.update(
             {"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20, "N_trials": 2}
@@ -308,7 +308,7 @@ class TestParallelBackends:
     ):
         """Test running MPIBackend with oversubscribed number of procs"""
         hnn_core_root = Path(hnn_core.__file__).parent
-        params_fname = hnn_core_root/ "param"/ "default.json"
+        params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
         params.update(
             {"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20, "N_trials": 2}

--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -1,4 +1,4 @@
-import os.path as op
+from pathlib import Path
 from os import environ
 import io
 import itertools
@@ -169,8 +169,8 @@ class TestParallelBackends:
     @requires_psutil
     def test_terminate_mpibackend(self, run_hnn_core_fixture):
         """Test terminating MPIBackend from thread"""
-        hnn_core_root = op.dirname(hnn_core.__file__)
-        params_fname = op.join(hnn_core_root, "param", "default.json")
+        hnn_core_root = Path(hnn_core.__file__).parent
+        params_fname = hnn_core_root/ "param"/ "default.json"
         params = read_params(params_fname)
         params.update(
             {"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20, "N_trials": 2}
@@ -205,8 +205,8 @@ class TestParallelBackends:
     @pytest.mark.parametrize("use_hwthreading_if_found", [True, False])
     def test_run_mpibackend_oversubscribed(self, use_hwthreading_if_found):
         """Test running MPIBackend with oversubscribed number of procs"""
-        hnn_core_root = op.dirname(hnn_core.__file__)
-        params_fname = op.join(hnn_core_root, "param", "default.json")
+        hnn_core_root = Path(hnn_core.__file__).parent
+        params_fname = hnn_core_root/ "param"/ "default.json"
         params = read_params(params_fname)
         params.update(
             {"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20, "N_trials": 2}
@@ -307,8 +307,8 @@ class TestParallelBackends:
         override_oversubscribe_option,
     ):
         """Test running MPIBackend with oversubscribed number of procs"""
-        hnn_core_root = op.dirname(hnn_core.__file__)
-        params_fname = op.join(hnn_core_root, "param", "default.json")
+        hnn_core_root = Path(hnn_core.__file__).parent
+        params_fname = hnn_core_root/ "param"/ "default.json"
         params = read_params(params_fname)
         params.update(
             {"t_evprox_1": 5, "t_evdist_1": 10, "t_evprox_2": 20, "N_trials": 2}
@@ -387,7 +387,7 @@ class TestParallelBackends:
             "https://raw.githubusercontent.com/jonescompneurolab/"
             "hnn-core/test_data/dpl.txt"
         )
-        if not op.exists("dpl.txt"):
+        if not Path("dpl.txt").exists():
             urlretrieve(data_url, "dpl.txt")
         dpl_master = loadtxt("dpl.txt")
 

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -1,7 +1,6 @@
 # Authors: Mainak Jas <mainakjas@gmail.com>
 #          Blake Caldwell <blake_caldwell@brown.edu>
 
-import os.path as op
 import json
 from pathlib import Path
 from urllib.request import urlretrieve
@@ -19,7 +18,7 @@ hnn_core_root = Path(__file__).parents[1]
 
 def test_read_params():
     """Test reading of params object."""
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
     # Smoke test that network loads params
     _ = neymotin_2020_model(params, add_drives_from_params=True, legacy_mode=False)
@@ -30,7 +29,7 @@ def test_read_params():
     # unsupported extension
     pytest.raises(ValueError, read_params, "params.txt")
     # empty file
-    empty_fname = op.join(hnn_core_root, "param", "empty.json")
+    empty_fname = hnn_core_root/ "param" /"empty.json"
     with open(empty_fname, "w") as json_data:
         json.dump({}, json_data)
     pytest.raises(ValueError, read_params, empty_fname)
@@ -44,11 +43,11 @@ def test_read_legacy_params():
     param_url = (
         "https://raw.githubusercontent.com/hnnsolver/hnn-core/test_data/default.param"
     )
-    params_legacy_fname = op.join(hnn_core_root, "param", "default.param")
-    if not op.exists(params_legacy_fname):
+    params_legacy_fname = hnn_core_root/ "param"/ "default.param"
+    if not Path(params_legacy_fname).exists():
         urlretrieve(param_url, params_legacy_fname)
 
-    params_new_fname = op.join(hnn_core_root, "param", "default.json")
+    params_new_fname = hnn_core_root/ "param"/ "default.json"
     params_legacy = read_params(params_legacy_fname)
     params_new = read_params(params_new_fname)
 
@@ -71,8 +70,8 @@ def test_base_params():
         "https://raw.githubusercontent.com/jonescompneurolab/"
         "hnn-core/test_data/base.json"
     )
-    params_base_fname = op.join(hnn_core_root, "param", "base.json")
-    if not op.exists(params_base_fname):
+    params_base_fname = hnn_core_root/ "param"/ "base.json"
+    if not Path(params_base_fname).exists():
         urlretrieve(param_url, params_base_fname)
 
     params_base = read_params(params_base_fname)
@@ -90,7 +89,7 @@ def test_remove_nulled_drives(tmp_path):
         "master/param/ERPYes100Trials.param"
     )
     params_fname = Path(hnn_core_root, "param", "ERPYes100Trials.param")
-    if not op.exists(params_fname):
+    if not Path(params_fname).exists():
         urlretrieve(param_url, params_fname)
 
     net = neymotin_2020_model(
@@ -158,7 +157,7 @@ class TestConvertToJson:
             "hnn-core/test_data/default.param"
         )
         params_base_fname = Path(hnn_core_root, "param", "default.param")
-        if not op.exists(params_base_fname):
+        if not Path(params_base_fname).exists():
             urlretrieve(param_url, params_base_fname)
         net_params = neymotin_2020_model(
             read_params(params_base_fname),

--- a/hnn_core/tests/test_params.py
+++ b/hnn_core/tests/test_params.py
@@ -18,7 +18,7 @@ hnn_core_root = Path(__file__).parents[1]
 
 def test_read_params():
     """Test reading of params object."""
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     # Smoke test that network loads params
     _ = neymotin_2020_model(params, add_drives_from_params=True, legacy_mode=False)
@@ -29,7 +29,7 @@ def test_read_params():
     # unsupported extension
     pytest.raises(ValueError, read_params, "params.txt")
     # empty file
-    empty_fname = hnn_core_root/ "param" /"empty.json"
+    empty_fname = hnn_core_root / "param" / "empty.json"
     with open(empty_fname, "w") as json_data:
         json.dump({}, json_data)
     pytest.raises(ValueError, read_params, empty_fname)
@@ -43,11 +43,11 @@ def test_read_legacy_params():
     param_url = (
         "https://raw.githubusercontent.com/hnnsolver/hnn-core/test_data/default.param"
     )
-    params_legacy_fname = hnn_core_root/ "param"/ "default.param"
+    params_legacy_fname = hnn_core_root / "param" / "default.param"
     if not Path(params_legacy_fname).exists():
         urlretrieve(param_url, params_legacy_fname)
 
-    params_new_fname = hnn_core_root/ "param"/ "default.json"
+    params_new_fname = hnn_core_root / "param" / "default.json"
     params_legacy = read_params(params_legacy_fname)
     params_new = read_params(params_new_fname)
 
@@ -70,7 +70,7 @@ def test_base_params():
         "https://raw.githubusercontent.com/jonescompneurolab/"
         "hnn-core/test_data/base.json"
     )
-    params_base_fname = hnn_core_root/ "param"/ "base.json"
+    params_base_fname = hnn_core_root / "param" / "base.json"
     if not Path(params_base_fname).exists():
         urlretrieve(param_url, params_base_fname)
 

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -1,4 +1,4 @@
-import os.path as op
+from pathlib import Path
 
 import matplotlib
 from matplotlib import backend_bases
@@ -36,8 +36,8 @@ def cleanup_matplotlib():
 
 @pytest.fixture
 def setup_net():
-    hnn_core_root = op.dirname(hnn_core.__file__)
-    params_fname = op.join(hnn_core_root, "param", "default.json")
+    hnn_core_root = Path(hnn_core.__file__).parent
+    params_fname = hnn_core_root/ "param"/ "default.json"
     params = read_params(params_fname)
     net = neymotin_2020_model(params, mesh_shape=(3, 3))
 
@@ -325,8 +325,8 @@ class TestCellResponsePlotters:
     @pytest.fixture(scope="class")
     def class_setup_net(self):
         """Creates a base network for tests within this class"""
-        hnn_core_root = op.dirname(hnn_core.__file__)
-        params_fname = op.join(hnn_core_root, "param", "default.json")
+        hnn_core_root = Path(hnn_core.__file__).parent
+        params_fname = hnn_core_root/ "param"/ "default.json"
         params = read_params(params_fname)
         net = neymotin_2020_model(params, mesh_shape=(3, 3))
 

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -37,7 +37,7 @@ def cleanup_matplotlib():
 @pytest.fixture
 def setup_net():
     hnn_core_root = Path(hnn_core.__file__).parent
-    params_fname = hnn_core_root/ "param"/ "default.json"
+    params_fname = hnn_core_root / "param" / "default.json"
     params = read_params(params_fname)
     net = neymotin_2020_model(params, mesh_shape=(3, 3))
 
@@ -326,7 +326,7 @@ class TestCellResponsePlotters:
     def class_setup_net(self):
         """Creates a base network for tests within this class"""
         hnn_core_root = Path(hnn_core.__file__).parent
-        params_fname = hnn_core_root/ "param"/ "default.json"
+        params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
         net = neymotin_2020_model(params, mesh_shape=(3, 3))
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 import platform
-import os.path as op
+from pathlib import Path
 import os
 import subprocess
 import shutil
@@ -20,7 +20,7 @@ DOWNLOAD_URL = "http://github.com/jonescompneurolab/hnn-core"
 
 # get the version
 version = None
-with open(os.path.join("hnn_core", "__init__.py"), "r") as fid:
+with open(Path("hnn_core") / "__init__.py", "r") as fid:
     for line in (line.strip() for line in fid):
         if line.startswith("__version__"):
             version = line.split("=")[1].strip().strip('"')
@@ -55,7 +55,7 @@ class BuildMod(Command):
         else:
             shell = False
 
-        mod_path = op.join(op.dirname(__file__), "hnn_core", "mod")
+        mod_path = Path(__file__).parent / "hnn_core" / "mod"
         process = subprocess.Popen(
             ["nrnivmodl"],
             cwd=mod_path,
@@ -71,8 +71,8 @@ class build_py_mod(build_py):
     def run(self):
         self.run_command("build_mod")
 
-        build_dir = op.join(self.build_lib, "hnn_core", "mod")
-        mod_path = op.join(op.dirname(__file__), "hnn_core", "mod")
+        build_dir = self.build_lib/ "hnn_core"/ "mod"
+        mod_path = Path(__file__).parent / "hnn_core" / "mod"
         shutil.copytree(mod_path, build_dir)
 
         build_py.run(self)

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ class build_py_mod(build_py):
     def run(self):
         self.run_command("build_mod")
 
-        build_dir = self.build_lib/ "hnn_core"/ "mod"
+        build_dir = Path(self.build_lib)/ "hnn_core"/ "mod"
         mod_path = Path(__file__).parent / "hnn_core" / "mod"
         shutil.copytree(mod_path, build_dir)
 


### PR DESCRIPTION
Builds on #1247 and fixes a small subproblem of #1118 by replacing relevant os path utilities with pathlib equivalents.

For reference on the os.path → pathlib equivalents: [pathlib correspondence to os module tools](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)