### PR TITLE
[MRG] FIX failure to remove colorbar

### DIFF
--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -685,6 +685,13 @@ def _clear_axis(
     existing_plots,
     add_plot_button,
 ):
+    # remove attached colorbar if exists; must happen before ax.clear()
+    # since that removes some kind of global axes reference, which
+    # Colorbar.remove() relies on to restore the original axes position
+    if hasattr(fig, f"_cbar-ax-{id(ax)}"):
+        getattr(fig, f"_cbar-ax-{id(ax)}").remove()
+        delattr(fig, f"_cbar-ax-{id(ax)}")
+
     ax.clear()
 
     # Remove "plot_spikes_hist"'s inverted second axes object, if exists, and
@@ -693,11 +700,6 @@ def _clear_axis(
         for axis in fig.axes:
             if axis._label == "Inverted spike histogram":
                 axis.remove()
-
-    # remove attached colorbar if exists
-    if hasattr(fig, f"_cbar-ax-{id(ax)}"):
-        getattr(fig, f"_cbar-ax-{id(ax)}").ax.remove()
-        delattr(fig, f"_cbar-ax-{id(ax)}")
 
     ax.set_facecolor("w")
     ax.set_aspect("auto")


### PR DESCRIPTION
The investigation was done by me, but the simple solution of removing the colorbar before Axes are cleared was suggested by Claude. The failing test now passes. Additionally, for our colorbar removal, we now use the suggested `<colorbar>.remove()` instead of `<colorbar>.ax.remove()` (see matplotlib threads below).

Context:

By default, when matplotlib creates a colorbar, it creates the colorbar as another entry in the `Figure`'s `Axes` list, which you can see when you inspect `fig.axes` at this code location:
https://github.com/jonescompneurolab/hnn-core/blob/ff5c6083be9d0a7e1220a34381bacbaacbf0b6d2/hnn_core/viz.py#L1107-L1114

However, when we use `plot_tfr_morlet()` with `colorbar_inside=True` here: https://github.com/jonescompneurolab/hnn-core/blob/ff5c6083be9d0a7e1220a34381bacbaacbf0b6d2/hnn_core/viz.py#L1115-L1147 which we use in the GUI especially, the colorbar is NOT included in the general Figure's Axes list, and instead is "packaged" as a hidden attribute inside the Figure at `fig._cbar-ax-{id(ax)}`.

Later, when we are trying to clear the axes of a current plot in the GUI, at:
https://github.com/jonescompneurolab/hnn-core/blob/ff5c6083be9d0a7e1220a34381bacbaacbf0b6d2/hnn_core/gui/_viz_manager.py#L677 we try to delete this Colorbar by first calling `.ax.remove()` on it, then deleting the attribute entirely.

The reason this test started to fail is that in the recent Matplotlib 3.11 update, how colorbars remove themselves changed in the library code; see https://github.com/matplotlib/matplotlib/issues/31330 for bug and https://github.com/matplotlib/matplotlib/pull/31555 for fix. The new approach to removing colorbars now seems to rely more heavily on information in the governing `Axes` object, when it didn't before. The problem in our case, then, is that we were clearing the `Axes` object before Colorbar's new removal code path was trying to access in order to complete its removal.

Claude made a great suggestion that simply removing our hidden Colorbar `Axes` before clearing the general `ax` object would allow the Colorbar's self-removal to work, which it does. This appears to solve the problem from this sort of "global dependency" between Axes objects when we're dealing with both a Figure's top-level Axes and our own, "hidden" Colorbar Axes.