### PR TITLE
[MRG] FIX random failure of batch pll test

### DIFF
--- a/hnn_core/tests/test_batch_simulate.py
+++ b/hnn_core/tests/test_batch_simulate.py
@@ -302,6 +302,18 @@ def test_parallel_execution(batch_simulate_instance, param_grid):
     end_time = time.perf_counter()
     serial_time = end_time - start_time
 
+    # Run the parallel execution once WITHOUT measuring the time, in order to "warm up"
+    # the parallel pool. This is necessary because there is an approximate 0.5-1.5
+    # second overhead for the first parallel `loky` run of a given parallel
+    # configuration, but the serial case (above) does not have to pay this. Once the
+    # parallel pool is warmed up, we can run the parallel execution again to get its
+    # actual simulation execution time.
+    #
+    # Another solution would have been increasing the amount of compute work done in
+    # each simulation, but that is wasteful.
+    _ = batch_simulate_instance.simulate_batch(
+        param_combinations, n_jobs=2, backend="loky"
+    )
     start_time = time.perf_counter()
     _ = batch_simulate_instance.simulate_batch(
         param_combinations, n_jobs=2, backend="loky"

--- a/hnn_core/tests/test_batch_simulate.py
+++ b/hnn_core/tests/test_batch_simulate.py
@@ -51,7 +51,7 @@ def batch_simulate_instance(tmp_path):
     return BatchSimulate(
         net=net,
         set_params=set_params,
-        tstop=10,
+        tstop=30,
         save_folder=tmp_path,
         batch_size=3,
         n_trials=3,
@@ -309,14 +309,17 @@ def test_parallel_execution(batch_simulate_instance, param_grid):
     # parallel pool is warmed up, we can run the parallel execution again to get its
     # actual simulation execution time.
     #
-    # Another solution would have been increasing the amount of compute work done in
-    # each simulation, but that is wasteful.
+    # On older hardware such as Github Actions' macos-intel runners, warming up the
+    # parallel pool is still not enough to ensure that the parallel execution is faster,
+    # so AES has also increased the compute work needed to be done (increasing the
+    # length of the simulation to 30 ms) and also increasing the number of cores used to
+    # 3 since we always have access to at least 3 in Github Actions runners.
     _ = batch_simulate_instance.simulate_batch(
-        param_combinations, n_jobs=2, backend="loky"
+        param_combinations, n_jobs=3, backend="loky"
     )
     start_time = time.perf_counter()
     _ = batch_simulate_instance.simulate_batch(
-        param_combinations, n_jobs=2, backend="loky"
+        param_combinations, n_jobs=3, backend="loky"
     )
     end_time = time.perf_counter()
     parallel_time = end_time - start_time


### PR DESCRIPTION
This should hopefully fix the random test failures that we see occasionally where we stochastically get a single failure from

> FAILED hnn_core/tests/test_batch_simulate.py::test_parallel_execution - AssertionError: Parallel execution is not faster than serial execution!

I was able to reliably reproduce this test failure on my home linux laptop, and then able to investigate it. I first started increasing the amount of compute work needed for both simulations, but I had to increase it by quite a bit in order for the test to *mostly* pass. I then asked Claude for help. It said that,
since our batch simulations are so small, and the total batch time is on the order of 2-3 seconds, the main issue is that when `n_jobs = 1`, there is no parallel code run at all, but when there is any parallel use, then there is a startup cost to build the parallel process tool by Loky that is paid the first time it sees that configuration. After running several experiments, it found that the *first* time `n_jobs=2` is used, there is a 0.5-1.5 second overhead cost to construct the parallel pool, but on *subsequent* runs with `n_jobs=2`, this overhead is not paid.

Therefore, one solution (which I've implemented here) is to simply run a parallel `n_jobs=2` case once but NOT record the time spent for simulation, and then run it again but record only the second time it ran. This way, the pool is already warmed and we can properly measure the *simulation* time difference, which is the main thing we're interested in here (not the overhead time, which will always be approximately less than two seconds).

As I said in the comment, another way to fix this would to simply increase the amount of compute used for the test, but not only is that wasteful, it would also force us to run the test for longer. The current new approach in this PR is better, because it only increases the time of the test by however much it takes to rerun the same tiny simulations in parallel using a warmed-up pool (which on my local machine, is usually around 0.75 seconds).