### PR TITLE
[MRG] MAINT cap ruff version due to breaking changes

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install ruff for use before ANY other tests
         shell: bash -el {0}
         run: |
-          pip install --verbose ruff
+          pip install --verbose "ruff<0.16.0"
 
       - name: Check ruff formatting
         shell: bash -el {0}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install ruff for use before ANY other tests
         shell: cmd
         run: |
-          pip install --verbose ruff
+          pip install --verbose "ruff<0.16.0"
 
       - name: Check ruff formatting
         shell: cmd

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,13 @@ if __name__ == "__main__":
     extras = {
         "opt": ["cma", "scikit-learn"],
         "parallel": ["joblib", "psutil"],
-        "test": ["codespell", "pytest", "pytest-cov", "pytest-xdist", "ruff"],
+        "test": [
+            "codespell",
+            "pytest",
+            "pytest-cov",
+            "pytest-xdist",
+            "ruff<0.16.0",
+        ],
         "docs": [
             "mne",
             "myst-parser",


### PR DESCRIPTION
This is a temporary dependency version block for `ruff`, which introduced many breaking changes in its latest update https://astral.sh/blog/ruff-v0.16.0 . Basically, `ruff` is expanding the list of rules which both their formatter and linter are checking, which is a good thing. However, it will take time for us to analyze how the new rules change our code, and whether we agree with all the rules or want to exclude some, etc.

It's best if this is tabled for now, since this season is particularly busy.

Edit: In testing, it seems the new ruff formatting doesn't require any changes. However, the linter, accessed via `ruff check hnn_core` reports 746 errors, most of which seem to be code-style (such as using the literal `[]` instead of `list()`).