### PR TITLE
[MRG] ENH Control Bayesian optimizer seed

### DIFF
--- a/hnn_core/externals/bayesopt.py
+++ b/hnn_core/externals/bayesopt.py
@@ -13,6 +13,7 @@ Adopted from http://atpassos.me/post/44900091837/bayesian-optimization
 
 import warnings
 from sklearn import gaussian_process
+from sklearn.utils import check_random_state
 import numpy as np
 
 import scipy.stats as st
@@ -63,7 +64,7 @@ def bayes_opt(func, x0, cons, acquisition, maxfun=200, debug=False, random_state
     debug : bool, optional
         The default is False.
     random_state : int, optional
-        Random state of the GaussianProcessRegressor. The default is None.
+        Random state of the optimizer. The default is None.
 
     Returns
     -------
@@ -83,13 +84,14 @@ def bayes_opt(func, x0, cons, acquisition, maxfun=200, debug=False, random_state
     best_x = X[np.argmin(y)]
     best_f = y[np.argmin(y)]
     gp = gaussian_process.GaussianProcessRegressor(random_state=random_state)
+    rng = check_random_state(random_state)
 
     if debug:
         print("iter", -1, "best_x", best_x, best_f)
 
     for i in range(maxfun):
         # draw samples from distribution
-        all_x = np.random.uniform(
+        all_x = rng.uniform(
             low=[idx[0] for idx in cons],
             high=[idx[1] for idx in cons],
             size=(10000, len(cons)),

--- a/hnn_core/optimization/general_optimization.py
+++ b/hnn_core/optimization/general_optimization.py
@@ -194,7 +194,7 @@ class Optimizer:
         n_jobs : int (Only used if solver='cma')
             The number of jobs to start in parallel. If None, then 1 trial will be
             started without parallelism.
-        seed : int, optional (Only used if solver='cma')
+        seed : int, optional (Only used if solver='bayesian' or solver='cma')
             Optional seed for random number generator of optimizer.
         tolfun : float (Only used if solver='cma')
             Termination criteria. Stops if the range of the best objective function
@@ -480,6 +480,7 @@ def _run_opt_bayesian(
         cons=constraints,
         acquisition=expected_improvement,
         maxfun=max_iter,
+        random_state=obj_fun_kwargs.get("seed"),
     )
 
     # get optimized params

--- a/hnn_core/tests/test_general_optimization.py
+++ b/hnn_core/tests/test_general_optimization.py
@@ -476,6 +476,58 @@ def test_cma_seed():
     assert not np.allclose(optim_seed1.opt_params_, optim_seed2.opt_params_)
 
 
+def test_bayesian_seed():
+    """Test random seed control during Bayesian optimization."""
+
+    class DummyNet:
+        def copy(self):
+            return DummyNet()
+
+    def set_params(net, params):
+        pass
+
+    def objective(
+        initial_net,
+        initial_params,
+        set_params,
+        predicted_params,
+        update_params,
+        obj_values,
+        tstop,
+        obj_fun_kwargs,
+    ):
+        predicted_params = np.asarray(predicted_params)
+        obj = np.sum((predicted_params - 0.25) ** 2)
+        obj_values.append(obj)
+        return obj
+
+    def run_optimizer(seed):
+        samples = list()
+
+        def recording_objective(**kwargs):
+            samples.append(np.asarray(kwargs["predicted_params"]))
+            return objective(**kwargs)
+
+        optim = Optimizer(
+            initial_net=DummyNet(),
+            tstop=1.0,
+            constraints={"x": (-1.0, 1.0), "y": (-1.0, 1.0)},
+            set_params=set_params,
+            solver="bayesian",
+            obj_fun=recording_objective,
+            max_iter=2,
+        )
+        optim.fit(seed=seed)
+        return np.asarray(samples)
+
+    samples_seed1 = run_optimizer(seed=111)
+    samples_seed1_repeat = run_optimizer(seed=111)
+    samples_seed2 = run_optimizer(seed=999999)
+
+    assert np.allclose(samples_seed1, samples_seed1_repeat)
+    assert not np.allclose(samples_seed1, samples_seed2)
+
+
 @pytest.mark.parametrize("solver", ["bayesian", "cma", "cobyla"])
 def test_custom_loss_fun(solver):
     """Test optimization routines with a user-defined loss function."""


### PR DESCRIPTION
## Summary

- Forward the seed passed to Optimizer.fit into Bayesian optimization.
- Use that random state for candidate sampling as well as the Gaussian process.
- Document Bayesian seed support and cover repeated and distinct seeds with a regression test.

Fixes #1294

## Validation

- pytest -q hnn_core/tests/test_general_optimization.py (34 passed)
- make format-check lint spell