### PR TITLE
[MRG] MAINT add coverage to local test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,5 +58,5 @@ spell:
 	fi;
 
 test: format-check lint spell
-	pytest ./hnn_core/tests/ -m "not uses_mpi" -n auto
-	pytest ./hnn_core/tests/ -m "uses_mpi"
+	pytest ./hnn_core/tests/ -m "not uses_mpi" -n auto --cov=hnn_core --cov-report=xml
+	pytest ./hnn_core/tests/ -m "uses_mpi" --cov=hnn_core --cov-report=xml --cov-append


### PR DESCRIPTION
This is a trivial change that updates the Makefile such that, when a developer runs `make test`, a local `coverage.xml` file is generated/updated identically to how this is done in our CI here https://github.com/jonescompneurolab/hnn-core/blob/master/.github/workflows/unix_unit_tests.yml

This is helpful for AI and local investigation of test coverage on various branches. The overhead is acceptable: estimated 1-3 seconds of additional time to run the `make test` command, and `make test` already has a habit of downloading and adding multiple files all across the repo already anytime that someone runs the tests.