### PR TITLE
[MRG] FIX GUI preserve drive stop times

### DIFF
--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -55,6 +55,10 @@ merged into `master`! Use `git log` instead and cross-reference instead. -->
 
 ### Bug Fixes
 
+- Loading external drives in the GUI now extends the simulation duration when needed,
+  preserving configured drive and tonic-bias stop times,
+  by [William Kang][] in {gh}`1348`.
+
 - [Camilo Diaz][] did considerable work in fixing our long-standing MPI Timeout issues
   and putting in place a permanent solution that uses tempfiles instead of standard
   input/output/error streams. Thanks Camilo!

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -2268,6 +2268,23 @@ class HNNGUI:
         drive_specs = net.external_drives
         tonic_specs = net.external_biases
 
+        # Drive time widgets are bounded by the simulation duration. Increase that
+        # bound before creating the widgets so explicit drive times are not clipped.
+        configured_tstops = []
+        for drive in drive_specs.values():
+            tstop = drive["dynamics"].get("tstop")
+            if tstop is not None:
+                configured_tstops.append(tstop)
+        for bias in tonic_specs.values():
+            for cell_type_bias in bias.values():
+                tstop = cell_type_bias.get("tstop")
+                if tstop is not None:
+                    configured_tstops.append(tstop)
+        if configured_tstops:
+            self.widget_tstop.value = max(
+                self.widget_tstop.value, max(configured_tstops)
+            )
+
         # clear before adding drives
         self._drives_out.clear_output()
         while len(self.drive_widgets) > 0:

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -351,7 +351,7 @@ def test_gui_smart_gains_upload_connectivity(setup_gui):
     plt.close("all")
 
 
-def test_gui_upload_drives():
+def test_gui_upload_drives(tmp_path):
     """Test if gui handles uploaded drive parameters correctly"""
     gui = HNNGUI()
     _ = gui.compose()
@@ -378,12 +378,16 @@ def test_gui_upload_drives():
     assert len(gui.drive_widgets) == 1
     assert gui.drive_widgets[0]["type"] == "Poisson"
 
-    # tstop is currently set to the tstop widget because the Network configs
-    # do not currently save a universal tstop attribute. In this case
-    # the drive tstop gets set to the widget value if the drive stop is larger
-    # than the widget tstop. This may change in the future if tstop is saved to
-    # the network configs.
-    assert gui.drive_widgets[0]["tstop"].value == 170.0
+    # Loading a drive that outlasts the simulation extends the simulation before
+    # constructing the bounded drive widget, so the configured stop is preserved.
+    assert gui.widget_tstop.value == 250.0
+    assert gui.drive_widgets[0]["tstop"].value == 250.0
+
+    # Loading the same drive must not shorten an already-longer simulation.
+    gui.widget_tstop.value = 300.0
+    gui._simulate_upload_drives(file2_url)
+    assert gui.widget_tstop.value == 300.0
+    assert gui.drive_widgets[0]["tstop"].value == 250.0
 
     # Load connectivity and make sure drives did not change
     gui._simulate_upload_connectivity(file1_url)
@@ -406,7 +410,18 @@ def test_gui_upload_drives():
     assert gui.drive_widgets[5]["type"] == "Tonic"
     assert gui.drive_widgets[5]["amplitude"]["L2_pyramidal"].value == 1.0
     assert gui.drive_widgets[5]["amplitude"]["L5_basket"].value == 0.0
-    assert gui.drive_widgets[5]["tstop"].value == 170.0
+    assert gui.drive_widgets[5]["tstop"].value == 300.0
+
+    # Explicit tonic-bias stop times also extend the simulation duration.
+    with open(file3_url, "r") as file:
+        tonic_params = json.load(file)
+    tonic_params["external_biases"]["tonic"]["L2_pyramidal"]["tstop"] = 350.0
+    tonic_params_path = tmp_path / "tonic_tstop.json"
+    with open(tonic_params_path, "w") as file:
+        json.dump(tonic_params, file)
+    gui._simulate_upload_drives(tonic_params_path)
+    assert gui.widget_tstop.value == 350.0
+    assert gui.drive_widgets[5]["tstop"].value == 350.0
 
     plt.close("all")
 


### PR DESCRIPTION
Closes #1121

## Summary

- increase the GUI simulation duration before constructing bounded drive widgets
- preserve explicit `tstop` values from external drives and tonic biases
- keep an already-longer simulation duration unchanged and continue treating `None` as the simulation-duration default

This prevents an uploaded 250 ms drive from being silently clipped to the GUI default of 170 ms.

## Validation

- `make test`
  - non-MPI: 294 passed, 3 skipped
  - MPI-marked: 6 passed, 27 skipped (MPI-only cases skipped because `mpi4py` is unavailable)
- `pytest -q hnn_core/tests/test_gui.py`: 52 passed, 6 skipped
- Ruff format and lint checks passed
- codespell passed

## AI assistance

Codex assisted with implementation and testing. I reviewed the code paths, JSON structures, behavior, and test results.