### PR TITLE
[MRG] MAINT Refactor `test_viz.py`

### DIFF
--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -46,44 +46,6 @@ def setup_net():
     return net
 
 
-@pytest.fixture
-def run_simulation(setup_net):
-    net = setup_net
-    weights_ampa = {"L2_pyramidal": 5.4e-5, "L5_pyramidal": 5.4e-5}
-    syn_delays = {"L2_pyramidal": 0.1, "L5_pyramidal": 1.0}
-
-    net.add_bursty_drive(
-        "beta_prox",
-        tstart=0.0,
-        burst_rate=25,
-        burst_std=5,
-        numspikes=1,
-        spike_isi=0,
-        n_drive_cells=11,
-        location="proximal",
-        weights_ampa=weights_ampa,
-        synaptic_delays=syn_delays,
-        event_seed=14,
-    )
-
-    net.add_bursty_drive(
-        "beta_dist",
-        tstart=0.0,
-        burst_rate=25,
-        burst_std=5,
-        numspikes=1,
-        spike_isi=0,
-        n_drive_cells=11,
-        location="distal",
-        weights_ampa=weights_ampa,
-        synaptic_delays=syn_delays,
-        event_seed=14,
-    )
-
-    dpl = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
-    return net, dpl
-
-
 def _fake_click(fig, ax, point, button=1):
     """Fake a click at a point within axes."""
     x, y = ax.transData.transform_point(point)
@@ -195,6 +157,43 @@ def test_network_visualization(setup_net):
 
 
 class TestDipoleViz:
+    @pytest.fixture
+    def run_simulation(setup_net):
+        net = setup_net
+        weights_ampa = {"L2_pyramidal": 5.4e-5, "L5_pyramidal": 5.4e-5}
+        syn_delays = {"L2_pyramidal": 0.1, "L5_pyramidal": 1.0}
+
+        net.add_bursty_drive(
+            "beta_prox",
+            tstart=0.0,
+            burst_rate=25,
+            burst_std=5,
+            numspikes=1,
+            spike_isi=0,
+            n_drive_cells=11,
+            location="proximal",
+            weights_ampa=weights_ampa,
+            synaptic_delays=syn_delays,
+            event_seed=14,
+        )
+
+        net.add_bursty_drive(
+            "beta_dist",
+            tstart=0.0,
+            burst_rate=25,
+            burst_std=5,
+            numspikes=1,
+            spike_isi=0,
+            n_drive_cells=11,
+            location="distal",
+            weights_ampa=weights_ampa,
+            synaptic_delays=syn_delays,
+            event_seed=14,
+        )
+
+        dpl = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
+        return net, dpl
+
     def test_decimation_options(self, run_simulation):
         """Test basic dipole visualisations and decimation."""
         _, dpls = run_simulation

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -153,7 +153,6 @@ def test_network_visualization(setup_net):
     _fake_click(fig, ax_src, [pos[0], pos[1]])
     pos_in_plot = ax_target.collections[2].get_offsets().data[0]
     assert_allclose(pos[:2], pos_in_plot)
-    plt.close("all")
 
 
 class TestDipoleViz:
@@ -308,8 +307,6 @@ def test_drive_strength(setup_net):
 
     any_plot = any(ax.lines or ax.patches or ax.images for ax in figure.axes)
     assert any_plot  # At least one axis contains graphical elements
-
-    plt.close("all")
 
 
 class TestCellResponsePlotters:
@@ -801,8 +798,6 @@ class TestCellResponsePlotters:
         )
         _check_inverted_spike_axes(fig)
 
-        plt.close("all")
-
 
 def test_network_plotter_init(setup_net):
     """Test init keywords of NetworkPlotter class."""
@@ -829,7 +824,6 @@ def test_network_plotter_init(setup_net):
     assert net_plot.vsec_array.shape == (159, 1)
     assert net_plot.color_array.shape == (159, 1, 4)
     assert net_plot._vsec_recorded is False
-    plt.close("all")
 
 
 def test_network_plotter_simulation(setup_net):
@@ -864,7 +858,6 @@ def test_network_plotter_simulation(setup_net):
     assert net_plot.color_array.shape == (159, 21, 4)
     assert net_plot._vsec_recorded is True
     assert isinstance(net_plot._cbar, Colorbar)
-    plt.close("all")
 
 
 def test_network_plotter_setter(setup_net):
@@ -914,7 +907,6 @@ def test_network_plotter_setter(setup_net):
 
     with pytest.raises(RuntimeError, match="Network must be simulated"):
         net_plot.trial_idx = 1
-    plt.close("all")
 
 
 def test_network_plotter_export(tmp_path, setup_net):
@@ -931,5 +923,3 @@ def test_network_plotter_export(tmp_path, setup_net):
     net_plot.export_movie(path_out, dpi=200, decim=100, writer="pillow")
 
     assert path_out.is_file()
-
-    plt.close("all")

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -195,7 +195,7 @@ def test_network_visualization(setup_net):
 
 
 class TestDipoleViz:
-    def test_dipole_viz_decimation_options(self, run_simulation):
+    def test_decimation_options(self, run_simulation):
         """Test basic dipole visualisations and decimation."""
         _, dpls = run_simulation
         fig = dpls[0].plot()  # plot the first dipole alone
@@ -211,7 +211,7 @@ class TestDipoleViz:
             ):
                 plot_dipole(dpls[0], decim=dec, show=False)
 
-    def test_dipole_viz_dipole_mutiple_layers(self, run_simulation):
+    def test_dipole_mutiple_layers(self, run_simulation):
         """Test plotting dipoles across multiple trials and layers (L2, L5, agg) with matching axes."""
         _, dpls = run_simulation
         # test plotting multiple dipoles as overlay
@@ -240,7 +240,7 @@ class TestDipoleViz:
             _, axes = plt.subplots(nrows=3, ncols=1)
             _ = plot_dipole(dpls, show=False, ax=axes, layer=["L2", "L5"])
 
-    def test_dipole_viz_multiple_tfr(self, run_simulation):
+    def test_multiple_tfr(self, run_simulation):
         """Test TFR plotting of multiple dipoles and related scaling/sampling checks."""
         _, dpls = run_simulation
         # multiple TFRs get averaged
@@ -702,7 +702,7 @@ class TestCellResponsePlotters:
             f"{n_plotted_raster_overlay}"
         )
 
-    def test_dipole_viz_no_data_in_raster_plt(self, base_simulation_spikes):
+    def test_no_data_in_raster_plt(self, base_simulation_spikes):
         """Test that the raster plot contains data for various trial_idx inputs."""
         net, _ = base_simulation_spikes
         net.cell_response.plot_spikes_raster()
@@ -713,7 +713,7 @@ class TestCellResponsePlotters:
         fig = net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
         assert len(fig.axes[0].collections) > 0, "No data plotted in raster plot"
 
-    def test_dipole_viz_cell_response_plot_spikes_hist(self, base_simulation_spikes):
+    def test_plot_spikes_hist(self, base_simulation_spikes):
         """Test spike histogram plotting across its arguments."""
         net, _ = base_simulation_spikes
         net.cell_response.plot_spikes_hist()

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -270,100 +270,6 @@ class TestDipoleViz:
         with pytest.warns(FutureWarning, match="tmin and tmax are deprecated"):
             plot_dipole(dpls[0], show=False, tmin=10, tmax=100)
 
-    def test_dipole_viz_no_data_in_raster_plt(self, run_simulation):
-        """Test that the raster plot contains data for various trial_idx inputs."""
-        net, _ = run_simulation
-        net.cell_response.plot_spikes_raster()
-        # test cell response plotting
-        with pytest.raises(TypeError, match="trial_idx must be an instance of"):
-            net.cell_response.plot_spikes_raster(trial_idx="blah", show=False)
-        net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
-        fig = net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
-        assert len(fig.axes[0].collections) > 0, "No data plotted in raster plot"
-
-    def test_dipole_viz_cell_response_plot_spikes_hist(self, run_simulation):
-        """Test spike histogram plotting across its arguments."""
-        net, _ = run_simulation
-        net.cell_response.plot_spikes_hist()
-        # simulation second run. first one it's in the run_simulation definition
-        simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
-
-        # Test trial_idx arg
-        with pytest.raises(TypeError, match="trial_idx must be an instance of"):
-            net.cell_response.plot_spikes_hist(trial_idx="blah")
-        net.cell_response.plot_spikes_hist(trial_idx=0, show=False)
-        net.cell_response.plot_spikes_hist(trial_idx=[0, 1], show=False)
-
-        # Test color arg
-        net.cell_response.plot_spikes_hist(color="r")
-        net.cell_response.plot_spikes_hist(color=["C0", "C1"])
-        net.cell_response.plot_spikes_hist(color={"beta_prox": "r", "beta_dist": "g"})
-        net.cell_response.plot_spikes_hist(
-            spike_types={"group1": ["beta_prox", "beta_dist"]}, color={"group1": "r"}
-        )
-        net.cell_response.plot_spikes_hist(
-            spike_types={"group1": ["beta"]}, color={"group1": "r"}
-        )
-
-        with pytest.raises(TypeError, match="color must be an instance of"):
-            net.cell_response.plot_spikes_hist(color=123)
-        with pytest.raises(ValueError):
-            net.cell_response.plot_spikes_hist(color="z")
-        with pytest.raises(ValueError):
-            net.cell_response.plot_spikes_hist(
-                color={"beta_prox": "z", "beta_dist": "g"}
-            )
-        with pytest.raises(TypeError, match="Dictionary values of color must"):
-            net.cell_response.plot_spikes_hist(
-                color={"beta_prox": 123, "beta_dist": "g"}
-            )
-        with pytest.raises(ValueError, match="'beta_dist' must be"):
-            net.cell_response.plot_spikes_hist(color={"beta_prox": "r"})
-
-        # Test invert_spike_types arg
-        def _check_inverted_spike_axes(fig):
-            # check that there are 2 y axes
-            assert len(fig.axes) == 2
-
-            # check for equivalency of both y axes
-            y1 = fig.axes[0]
-            y2 = fig.axes[1]
-
-            y1_max = max(y1.get_ylim())
-            y2_max = max(y2.get_ylim())
-
-            assert y1_max == y2_max
-
-            # check that data are plotted
-            assert y1_max > 1
-
-        # Test invert_spike_types
-        # str input
-        fig = net.cell_response.plot_spikes_hist(
-            spike_types=["beta_prox", "beta_dist"],
-            invert_spike_types="beta_prox",
-            show=False,
-        )
-        _check_inverted_spike_axes(fig)
-
-        # single-element list input
-        fig = net.cell_response.plot_spikes_hist(
-            spike_types=["beta_prox", "beta_dist"],
-            invert_spike_types=["beta_prox"],
-            show=False,
-        )
-        _check_inverted_spike_axes(fig)
-
-        # test case where all inputs are flipped
-        fig = net.cell_response.plot_spikes_hist(
-            spike_types=["beta_prox", "beta_dist"],
-            invert_spike_types=["beta_prox", "beta_dist"],
-            show=False,
-        )
-        _check_inverted_spike_axes(fig)
-
-        plt.close("all")
-
 
 def test_drive_strength(setup_net):
     """Adds empty external drives to check there strength across each cell types"""
@@ -795,6 +701,100 @@ class TestCellResponsePlotters:
             f"Expected {n_cell_spikes} spikes plotted in raster, got "
             f"{n_plotted_raster_overlay}"
         )
+
+    def test_dipole_viz_no_data_in_raster_plt(self, base_simulation_spikes):
+        """Test that the raster plot contains data for various trial_idx inputs."""
+        net, _ = base_simulation_spikes
+        net.cell_response.plot_spikes_raster()
+        # test cell response plotting
+        with pytest.raises(TypeError, match="trial_idx must be an instance of"):
+            net.cell_response.plot_spikes_raster(trial_idx="blah", show=False)
+        net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
+        fig = net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
+        assert len(fig.axes[0].collections) > 0, "No data plotted in raster plot"
+
+    def test_dipole_viz_cell_response_plot_spikes_hist(self, base_simulation_spikes):
+        """Test spike histogram plotting across its arguments."""
+        net, _ = base_simulation_spikes
+        net.cell_response.plot_spikes_hist()
+        # simulation second run. first one it's in the base_simulation_spikes definition
+        simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
+
+        # Test trial_idx arg
+        with pytest.raises(TypeError, match="trial_idx must be an instance of"):
+            net.cell_response.plot_spikes_hist(trial_idx="blah")
+        net.cell_response.plot_spikes_hist(trial_idx=0, show=False)
+        net.cell_response.plot_spikes_hist(trial_idx=[0, 1], show=False)
+
+        # Test color arg
+        net.cell_response.plot_spikes_hist(color="r")
+        net.cell_response.plot_spikes_hist(color=["C0", "C1"])
+        net.cell_response.plot_spikes_hist(color={"beta_prox": "r", "beta_dist": "g"})
+        net.cell_response.plot_spikes_hist(
+            spike_types={"group1": ["beta_prox", "beta_dist"]}, color={"group1": "r"}
+        )
+        net.cell_response.plot_spikes_hist(
+            spike_types={"group1": ["beta"]}, color={"group1": "r"}
+        )
+
+        with pytest.raises(TypeError, match="color must be an instance of"):
+            net.cell_response.plot_spikes_hist(color=123)
+        with pytest.raises(ValueError):
+            net.cell_response.plot_spikes_hist(color="z")
+        with pytest.raises(ValueError):
+            net.cell_response.plot_spikes_hist(
+                color={"beta_prox": "z", "beta_dist": "g"}
+            )
+        with pytest.raises(TypeError, match="Dictionary values of color must"):
+            net.cell_response.plot_spikes_hist(
+                color={"beta_prox": 123, "beta_dist": "g"}
+            )
+        with pytest.raises(ValueError, match="'beta_dist' must be"):
+            net.cell_response.plot_spikes_hist(color={"beta_prox": "r"})
+
+        # Test invert_spike_types arg
+        def _check_inverted_spike_axes(fig):
+            # check that there are 2 y axes
+            assert len(fig.axes) == 2
+
+            # check for equivalency of both y axes
+            y1 = fig.axes[0]
+            y2 = fig.axes[1]
+
+            y1_max = max(y1.get_ylim())
+            y2_max = max(y2.get_ylim())
+
+            assert y1_max == y2_max
+
+            # check that data are plotted
+            assert y1_max > 1
+
+        # Test invert_spike_types
+        # str input
+        fig = net.cell_response.plot_spikes_hist(
+            spike_types=["beta_prox", "beta_dist"],
+            invert_spike_types="beta_prox",
+            show=False,
+        )
+        _check_inverted_spike_axes(fig)
+
+        # single-element list input
+        fig = net.cell_response.plot_spikes_hist(
+            spike_types=["beta_prox", "beta_dist"],
+            invert_spike_types=["beta_prox"],
+            show=False,
+        )
+        _check_inverted_spike_axes(fig)
+
+        # test case where all inputs are flipped
+        fig = net.cell_response.plot_spikes_hist(
+            spike_types=["beta_prox", "beta_dist"],
+            invert_spike_types=["beta_prox", "beta_dist"],
+            show=False,
+        )
+        _check_inverted_spike_axes(fig)
+
+        plt.close("all")
 
 
 def test_network_plotter_init(setup_net):

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -46,6 +46,44 @@ def setup_net():
     return net
 
 
+@pytest.fixture
+def run_simulation(setup_net):
+    net = setup_net
+    weights_ampa = {"L2_pyramidal": 5.4e-5, "L5_pyramidal": 5.4e-5}
+    syn_delays = {"L2_pyramidal": 0.1, "L5_pyramidal": 1.0}
+
+    net.add_bursty_drive(
+        "beta_prox",
+        tstart=0.0,
+        burst_rate=25,
+        burst_std=5,
+        numspikes=1,
+        spike_isi=0,
+        n_drive_cells=11,
+        location="proximal",
+        weights_ampa=weights_ampa,
+        synaptic_delays=syn_delays,
+        event_seed=14,
+    )
+
+    net.add_bursty_drive(
+        "beta_dist",
+        tstart=0.0,
+        burst_rate=25,
+        burst_std=5,
+        numspikes=1,
+        spike_isi=0,
+        n_drive_cells=11,
+        location="distal",
+        weights_ampa=weights_ampa,
+        synaptic_delays=syn_delays,
+        event_seed=14,
+    )
+
+    dpl = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
+    return net, dpl
+
+
 def _fake_click(fig, ax, point, button=1):
     """Fake a click at a point within axes."""
     x, y = ax.transData.transform_point(point)
@@ -156,10 +194,9 @@ def test_network_visualization(setup_net):
     plt.close("all")
 
 
-def test_dipole_viz_decimation_options(setup_net):
+def test_dipole_viz_decimation_options(run_simulation):
     """Test dipole visualisations."""
-    net = setup_net
-    dpls = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
+    _, dpls = run_simulation
     fig = dpls[0].plot()  # plot the first dipole alone
     axes = fig.get_axes()[0]
     dpls[0].copy().smooth(window_len=10).plot(ax=axes)  # add smoothed versions
@@ -174,143 +211,113 @@ def test_dipole_viz_decimation_options(setup_net):
             plot_dipole(dpls[0], decim=dec, show=False)
 
 
-def test_dipole_viz_dipole_mutiple_layers(setup_net):
-    """Test plotting dipoles across multiple layers (L2, L5, agg) with matching axes."""
-    net = setup_net
-    dpls = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
-    # test plotting multiple dipoles as overlay
-    plot_dipole(dpls, show=False)
+class TestDipoleViz:
+    def test_dipole_viz_dipole_mutiple_layers(self, run_simulation):
+        """Test plotting dipoles across multiple layers (L2, L5, agg) with matching axes."""
+        _, dpls = run_simulation
+        # test plotting multiple dipoles as overlay
+        plot_dipole(dpls, show=False)
 
-    # test plotting multiple dipoles with average
-    plot_dipole(dpls, average=True, show=False)
-    plt.close("all")
+        # test plotting multiple dipoles with average
+        plot_dipole(dpls, average=True, show=False)
+        plt.close("all")
 
-    # test plotting dipoles with multiple layers
-    _, ax = plt.subplots()
-    _ = plot_dipole(dpls, show=False, ax=[ax], layer=["L2"])
-    _ = plot_dipole(dpls, show=False, layer=["L2", "L5", "agg"])
-    _, axes = plt.subplots(nrows=3, ncols=1)
-    _ = plot_dipole(dpls, show=False, ax=axes, layer=["L2", "L5", "agg"])
-    _, axes = plt.subplots(nrows=3, ncols=1)
-    _ = plot_dipole(
-        dpls, show=False, ax=[axes[0], axes[1], axes[2]], layer=["L2", "L5", "agg"]
-    )
-
-    plt.close("all")
-
-    with pytest.raises(AssertionError, match="ax and layer should have the same size"):
+        # test plotting dipoles with multiple layers
+        _, ax = plt.subplots()
+        _ = plot_dipole(dpls, show=False, ax=[ax], layer=["L2"])
+        _ = plot_dipole(dpls, show=False, layer=["L2", "L5", "agg"])
         _, axes = plt.subplots(nrows=3, ncols=1)
-        _ = plot_dipole(dpls, show=False, ax=axes, layer=["L2", "L5"])
+        _ = plot_dipole(dpls, show=False, ax=axes, layer=["L2", "L5", "agg"])
+        _, axes = plt.subplots(nrows=3, ncols=1)
+        _ = plot_dipole(
+            dpls, show=False, ax=[axes[0], axes[1], axes[2]], layer=["L2", "L5", "agg"]
+        )
 
+        plt.close("all")
 
-def test_dipole_viz_multiple_tfr(setup_net):
-    """Test TFR plotting of multiple dipoles and related scaling/sampling checks."""
-    net = setup_net
-    dpls = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
-    # multiple TFRs get averaged
-    fig = plot_tfr_morlet(dpls, freqs=np.arange(23, 26, 1.0), n_cycles=3, show=False)
-    # when min_freq > max_freq (y-axis inversion)
-    fig = plot_tfr_morlet(dpls, freqs=np.array([30, 20, 10]), n_cycles=3, show=False)
-    ax = fig.get_axes()[0]
-    y_limits = ax.get_ylim()
-    assert y_limits[0] > y_limits[1], (
-        "Y-axis should be inverted when min_freq > max_freq"
-    )
+        with pytest.raises(
+            AssertionError, match="ax and layer should have the same size"
+        ):
+            _, axes = plt.subplots(nrows=3, ncols=1)
+            _ = plot_dipole(dpls, show=False, ax=axes, layer=["L2", "L5"])
 
-    with pytest.raises(RuntimeError, match="All dipoles must be scaled equally!"):
-        plot_dipole([dpls[0].copy().scale(10), dpls[1].copy().scale(20)])
-    with pytest.raises(RuntimeError, match="All dipoles must be scaled equally!"):
-        plot_psd([dpls[0].copy().scale(10), dpls[1].copy().scale(20)])
-    with pytest.raises(RuntimeError, match="All dipoles must be sampled equally!"):
-        dpl_sfreq = dpls[0].copy()
-        dpl_sfreq.sfreq /= 10
-        plot_psd([dpls[0], dpl_sfreq])
+    def test_dipole_viz_multiple_tfr(self, run_simulation):
+        """Test TFR plotting of multiple dipoles and related scaling/sampling checks."""
+        _, dpls = run_simulation
+        # multiple TFRs get averaged
+        fig = plot_tfr_morlet(
+            dpls, freqs=np.arange(23, 26, 1.0), n_cycles=3, show=False
+        )
+        # when min_freq > max_freq (y-axis inversion)
+        fig = plot_tfr_morlet(
+            dpls, freqs=np.array([30, 20, 10]), n_cycles=3, show=False
+        )
+        ax = fig.get_axes()[0]
+        y_limits = ax.get_ylim()
+        assert y_limits[0] > y_limits[1], (
+            "Y-axis should be inverted when min_freq > max_freq"
+        )
 
-    # pytest deprecation warning for tmin and tmax
-    with pytest.warns(FutureWarning, match="tmin and tmax are deprecated"):
-        plot_dipole(dpls[0], show=False, tmin=10, tmax=100)
+        with pytest.raises(RuntimeError, match="All dipoles must be scaled equally!"):
+            plot_dipole([dpls[0].copy().scale(10), dpls[1].copy().scale(20)])
+        with pytest.raises(RuntimeError, match="All dipoles must be scaled equally!"):
+            plot_psd([dpls[0].copy().scale(10), dpls[1].copy().scale(20)])
+        with pytest.raises(RuntimeError, match="All dipoles must be sampled equally!"):
+            dpl_sfreq = dpls[0].copy()
+            dpl_sfreq.sfreq /= 10
+            plot_psd([dpls[0], dpl_sfreq])
 
+        # pytest deprecation warning for tmin and tmax
+        with pytest.warns(FutureWarning, match="tmin and tmax are deprecated"):
+            plot_dipole(dpls[0], show=False, tmin=10, tmax=100)
 
-def test_dipole_viz_no_data_in_raster_plt(setup_net):
-    """Test that the raster plot contains data for various trial_idx inputs."""
-    net = setup_net
-    simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
-    net.cell_response.plot_spikes_raster()
-    # test cell response plotting
-    with pytest.raises(TypeError, match="trial_idx must be an instance of"):
-        net.cell_response.plot_spikes_raster(trial_idx="blah", show=False)
-    net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
-    fig = net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
-    assert len(fig.axes[0].collections) > 0, "No data plotted in raster plot"
+    def test_dipole_viz_no_data_in_raster_plt(self, run_simulation):
+        """Test that the raster plot contains data for various trial_idx inputs."""
+        net, _ = run_simulation
+        net.cell_response.plot_spikes_raster()
+        # test cell response plotting
+        with pytest.raises(TypeError, match="trial_idx must be an instance of"):
+            net.cell_response.plot_spikes_raster(trial_idx="blah", show=False)
+        net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
+        fig = net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
+        assert len(fig.axes[0].collections) > 0, "No data plotted in raster plot"
 
+    def test_dipole_viz_cell_response_plot_spikes_hist(self, run_simulation):
+        """Test spike histogram plotting with trial_idx and color argument variations."""
+        net, _ = run_simulation
+        net.cell_response.plot_spikes_hist()
+        # simulation second run. first one it's in the run_simulation definition
+        simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
 
-def test_dipole_viz_cell_response_plot_spikes_hist(setup_net):
-    """Test spike histogram plotting with trial_idx and color argument variations."""
-    net = setup_net
+        with pytest.raises(TypeError, match="trial_idx must be an instance of"):
+            net.cell_response.plot_spikes_hist(trial_idx="blah")
+        net.cell_response.plot_spikes_hist(trial_idx=0, show=False)
+        net.cell_response.plot_spikes_hist(trial_idx=[0, 1], show=False)
+        net.cell_response.plot_spikes_hist(color="r")
+        net.cell_response.plot_spikes_hist(color=["C0", "C1"])
+        net.cell_response.plot_spikes_hist(color={"beta_prox": "r", "beta_dist": "g"})
+        net.cell_response.plot_spikes_hist(
+            spike_types={"group1": ["beta_prox", "beta_dist"]}, color={"group1": "r"}
+        )
+        net.cell_response.plot_spikes_hist(
+            spike_types={"group1": ["beta"]}, color={"group1": "r"}
+        )
 
-    # simulation first run
-    simulate_dipole(net, tstop=100.0, n_trials=1)
-
-    net.cell_response.plot_spikes_hist()
-    weights_ampa = {"L2_pyramidal": 5.4e-5, "L5_pyramidal": 5.4e-5}
-    syn_delays = {"L2_pyramidal": 0.1, "L5_pyramidal": 1.0}
-
-    net.add_bursty_drive(
-        "beta_prox",
-        tstart=0.0,
-        burst_rate=25,
-        burst_std=5,
-        numspikes=1,
-        spike_isi=0,
-        n_drive_cells=11,
-        location="proximal",
-        weights_ampa=weights_ampa,
-        synaptic_delays=syn_delays,
-        event_seed=14,
-    )
-
-    net.add_bursty_drive(
-        "beta_dist",
-        tstart=0.0,
-        burst_rate=25,
-        burst_std=5,
-        numspikes=1,
-        spike_isi=0,
-        n_drive_cells=11,
-        location="distal",
-        weights_ampa=weights_ampa,
-        synaptic_delays=syn_delays,
-        event_seed=14,
-    )
-
-    # simulation second run
-    simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
-
-    with pytest.raises(TypeError, match="trial_idx must be an instance of"):
-        net.cell_response.plot_spikes_hist(trial_idx="blah")
-    net.cell_response.plot_spikes_hist(trial_idx=0, show=False)
-    net.cell_response.plot_spikes_hist(trial_idx=[0, 1], show=False)
-    net.cell_response.plot_spikes_hist(color="r")
-    net.cell_response.plot_spikes_hist(color=["C0", "C1"])
-    net.cell_response.plot_spikes_hist(color={"beta_prox": "r", "beta_dist": "g"})
-    net.cell_response.plot_spikes_hist(
-        spike_types={"group1": ["beta_prox", "beta_dist"]}, color={"group1": "r"}
-    )
-    net.cell_response.plot_spikes_hist(
-        spike_types={"group1": ["beta"]}, color={"group1": "r"}
-    )
-
-    with pytest.raises(TypeError, match="color must be an instance of"):
-        net.cell_response.plot_spikes_hist(color=123)
-    with pytest.raises(ValueError):
-        net.cell_response.plot_spikes_hist(color="z")
-    with pytest.raises(ValueError):
-        net.cell_response.plot_spikes_hist(color={"beta_prox": "z", "beta_dist": "g"})
-    with pytest.raises(TypeError, match="Dictionary values of color must"):
-        net.cell_response.plot_spikes_hist(color={"beta_prox": 123, "beta_dist": "g"})
-    with pytest.raises(ValueError, match="'beta_dist' must be"):
-        net.cell_response.plot_spikes_hist(color={"beta_prox": "r"})
-    plt.close("all")
+        with pytest.raises(TypeError, match="color must be an instance of"):
+            net.cell_response.plot_spikes_hist(color=123)
+        with pytest.raises(ValueError):
+            net.cell_response.plot_spikes_hist(color="z")
+        with pytest.raises(ValueError):
+            net.cell_response.plot_spikes_hist(
+                color={"beta_prox": "z", "beta_dist": "g"}
+            )
+        with pytest.raises(TypeError, match="Dictionary values of color must"):
+            net.cell_response.plot_spikes_hist(
+                color={"beta_prox": 123, "beta_dist": "g"}
+            )
+        with pytest.raises(ValueError, match="'beta_dist' must be"):
+            net.cell_response.plot_spikes_hist(color={"beta_prox": "r"})
+        plt.close("all")
 
 
 def test_drive_strength(setup_net):

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -282,16 +282,19 @@ class TestDipoleViz:
         assert len(fig.axes[0].collections) > 0, "No data plotted in raster plot"
 
     def test_dipole_viz_cell_response_plot_spikes_hist(self, run_simulation):
-        """Test spike histogram plotting with trial_idx and color argument variations."""
+        """Test spike histogram plotting across its arguments."""
         net, _ = run_simulation
         net.cell_response.plot_spikes_hist()
         # simulation second run. first one it's in the run_simulation definition
         simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
 
+        # Test trial_idx arg
         with pytest.raises(TypeError, match="trial_idx must be an instance of"):
             net.cell_response.plot_spikes_hist(trial_idx="blah")
         net.cell_response.plot_spikes_hist(trial_idx=0, show=False)
         net.cell_response.plot_spikes_hist(trial_idx=[0, 1], show=False)
+
+        # Test color arg
         net.cell_response.plot_spikes_hist(color="r")
         net.cell_response.plot_spikes_hist(color=["C0", "C1"])
         net.cell_response.plot_spikes_hist(color={"beta_prox": "r", "beta_dist": "g"})
@@ -316,6 +319,49 @@ class TestDipoleViz:
             )
         with pytest.raises(ValueError, match="'beta_dist' must be"):
             net.cell_response.plot_spikes_hist(color={"beta_prox": "r"})
+
+        # Test invert_spike_types arg
+        def _check_inverted_spike_axes(fig):
+            # check that there are 2 y axes
+            assert len(fig.axes) == 2
+
+            # check for equivalency of both y axes
+            y1 = fig.axes[0]
+            y2 = fig.axes[1]
+
+            y1_max = max(y1.get_ylim())
+            y2_max = max(y2.get_ylim())
+
+            assert y1_max == y2_max
+
+            # check that data are plotted
+            assert y1_max > 1
+
+        # Test invert_spike_types
+        # str input
+        fig = net.cell_response.plot_spikes_hist(
+            spike_types=["beta_prox", "beta_dist"],
+            invert_spike_types="beta_prox",
+            show=False,
+        )
+        _check_inverted_spike_axes(fig)
+
+        # single-element list input
+        fig = net.cell_response.plot_spikes_hist(
+            spike_types=["beta_prox", "beta_dist"],
+            invert_spike_types=["beta_prox"],
+            show=False,
+        )
+        _check_inverted_spike_axes(fig)
+
+        # test case where all inputs are flipped
+        fig = net.cell_response.plot_spikes_hist(
+            spike_types=["beta_prox", "beta_dist"],
+            invert_spike_types=["beta_prox", "beta_dist"],
+            show=False,
+        )
+        _check_inverted_spike_axes(fig)
+
         plt.close("all")
 
 
@@ -878,75 +924,5 @@ def test_network_plotter_export(tmp_path, setup_net):
     net_plot.export_movie(path_out, dpi=200, decim=100, writer="pillow")
 
     assert path_out.is_file()
-
-    plt.close("all")
-
-
-def test_invert_spike_types(setup_net):
-    """Test plotting a histogram with an inverted external drive"""
-    net = setup_net
-
-    weights_ampa = {"L2_pyramidal": 0.15, "L5_pyramidal": 0.15}
-    syn_delays = {"L2_pyramidal": 0.1, "L5_pyramidal": 1.0}
-
-    net.add_evoked_drive(
-        "evdist1",
-        mu=63.53,
-        sigma=3.85,
-        numspikes=1,
-        weights_ampa=weights_ampa,
-        location="distal",
-        synaptic_delays=syn_delays,
-        event_seed=274,
-    )
-
-    net.add_evoked_drive(
-        "evprox1",
-        mu=26.61,
-        sigma=2.47,
-        numspikes=1,
-        weights_ampa=weights_ampa,
-        location="proximal",
-        synaptic_delays=syn_delays,
-        event_seed=274,
-    )
-
-    _ = simulate_dipole(net, dt=0.5, tstop=80.0, n_trials=1)
-
-    # test string input
-    net.cell_response.plot_spikes_hist(
-        spike_types=["evprox", "evdist"],
-        invert_spike_types="evdist",
-        show=False,
-    )
-
-    # test case where all inputs are flipped
-    net.cell_response.plot_spikes_hist(
-        spike_types=["evprox", "evdist"],
-        invert_spike_types=["evprox", "evdist"],
-        show=False,
-    )
-
-    # test case where some inputs are flipped
-    fig = net.cell_response.plot_spikes_hist(
-        spike_types=["evprox", "evdist"],
-        invert_spike_types=["evdist"],
-        show=False,
-    )
-
-    # check that there are 2 y axes
-    assert len(fig.axes) == 2
-
-    # check for equivalency of both y axes
-    y1 = fig.axes[0]
-    y2 = fig.axes[1]
-
-    y1_max = max(y1.get_ylim())
-    y2_max = max(y2.get_ylim())
-
-    assert y1_max == y2_max
-
-    # check that data are plotted
-    assert y1_max > 1
 
     plt.close("all")

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -157,7 +157,7 @@ def test_network_visualization(setup_net):
 
 class TestDipoleViz:
     @pytest.fixture
-    def run_simulation(setup_net):
+    def run_simulation(self, setup_net):
         net = setup_net
         weights_ampa = {"L2_pyramidal": 5.4e-5, "L5_pyramidal": 5.4e-5}
         syn_delays = {"L2_pyramidal": 0.1, "L5_pyramidal": 1.0}

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -713,20 +713,26 @@ class TestCellResponsePlotters:
         fig = net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
         assert len(fig.axes[0].collections) > 0, "No data plotted in raster plot"
 
-    def test_plot_spikes_hist(self, base_simulation_spikes):
-        """Test spike histogram plotting across its arguments."""
+    def test_spikes_hist_default(self, base_simulation_spikes):
+        """Test basic spike histogram plotting."""
         net, _ = base_simulation_spikes
         net.cell_response.plot_spikes_hist()
         # simulation second run. first one it's in the base_simulation_spikes definition
         simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
 
-        # Test trial_idx arg
+    def test_spikes_hist_trial_idx(self, base_simulation_spikes):
+        """Test spike histogram with different trial arguments."""
+        net, _ = base_simulation_spikes
+
         with pytest.raises(TypeError, match="trial_idx must be an instance of"):
             net.cell_response.plot_spikes_hist(trial_idx="blah")
         net.cell_response.plot_spikes_hist(trial_idx=0, show=False)
         net.cell_response.plot_spikes_hist(trial_idx=[0, 1], show=False)
 
-        # Test color arg
+    def test_spikes_hist_color(self, base_simulation_spikes):
+        """Test spike histogram with different color arguments."""
+        net, _ = base_simulation_spikes
+
         net.cell_response.plot_spikes_hist(color="r")
         net.cell_response.plot_spikes_hist(color=["C0", "C1"])
         net.cell_response.plot_spikes_hist(color={"beta_prox": "r", "beta_dist": "g"})
@@ -752,7 +758,10 @@ class TestCellResponsePlotters:
         with pytest.raises(ValueError, match="'beta_dist' must be"):
             net.cell_response.plot_spikes_hist(color={"beta_prox": "r"})
 
-        # Test invert_spike_types arg
+    def test_spikes_hist_invert_spike_types(self, base_simulation_spikes):
+        """Test spike histogram with different invert_spike_types arguments."""
+        net, _ = base_simulation_spikes
+
         def _check_inverted_spike_axes(fig):
             # check that there are 2 y axes
             assert len(fig.axes) == 2
@@ -769,7 +778,6 @@ class TestCellResponsePlotters:
             # check that data are plotted
             assert y1_max > 1
 
-        # Test invert_spike_types
         # str input
         fig = net.cell_response.plot_spikes_hist(
             spike_types=["beta_prox", "beta_dist"],

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -175,6 +175,7 @@ def test_dipole_viz_decimation_options(setup_net):
 
 
 def test_dipole_viz_dipole_mutiple_layers(setup_net):
+    """Test plotting dipoles across multiple layers (L2, L5, agg) with matching axes."""
     net = setup_net
     dpls = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
     # test plotting multiple dipoles as overlay
@@ -203,6 +204,7 @@ def test_dipole_viz_dipole_mutiple_layers(setup_net):
 
 
 def test_dipole_viz_multiple_tfr(setup_net):
+    """Test TFR plotting of multiple dipoles and related scaling/sampling checks."""
     net = setup_net
     dpls = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
     # multiple TFRs get averaged
@@ -230,6 +232,7 @@ def test_dipole_viz_multiple_tfr(setup_net):
 
 
 def test_dipole_viz_no_data_in_raster_plt(setup_net):
+    """Test that the raster plot contains data for various trial_idx inputs."""
     net = setup_net
     simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
     net.cell_response.plot_spikes_raster()
@@ -242,6 +245,7 @@ def test_dipole_viz_no_data_in_raster_plt(setup_net):
 
 
 def test_dipole_viz_cell_response_plot_spikes_hist(setup_net):
+    """Test spike histogram plotting with trial_idx and color argument variations."""
     net = setup_net
 
     # simulation first run

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -194,26 +194,25 @@ def test_network_visualization(setup_net):
     plt.close("all")
 
 
-def test_dipole_viz_decimation_options(run_simulation):
-    """Test dipole visualisations."""
-    _, dpls = run_simulation
-    fig = dpls[0].plot()  # plot the first dipole alone
-    axes = fig.get_axes()[0]
-    dpls[0].copy().smooth(window_len=10).plot(ax=axes)  # add smoothed versions
-    dpls[0].copy().savgol_filter(h_freq=30).plot(ax=axes)  # on top
-
-    # test decimation options
-    plot_dipole(dpls[0], decim=2, show=False)
-    for dec in [-1, [2, 2.0]]:
-        with pytest.raises(
-            ValueError, match="each decimation factor must be a positive"
-        ):
-            plot_dipole(dpls[0], decim=dec, show=False)
-
-
 class TestDipoleViz:
+    def test_dipole_viz_decimation_options(self, run_simulation):
+        """Test basic dipole visualisations and decimation."""
+        _, dpls = run_simulation
+        fig = dpls[0].plot()  # plot the first dipole alone
+        axes = fig.get_axes()[0]
+        dpls[0].copy().smooth(window_len=10).plot(ax=axes)  # add smoothed versions
+        dpls[0].copy().savgol_filter(h_freq=30).plot(ax=axes)  # on top
+
+        # test decimation options
+        plot_dipole(dpls[0], decim=2, show=False)
+        for dec in [-1, [2, 2.0]]:
+            with pytest.raises(
+                ValueError, match="each decimation factor must be a positive"
+            ):
+                plot_dipole(dpls[0], decim=dec, show=False)
+
     def test_dipole_viz_dipole_mutiple_layers(self, run_simulation):
-        """Test plotting dipoles across multiple layers (L2, L5, agg) with matching axes."""
+        """Test plotting dipoles across multiple trials and layers (L2, L5, agg) with matching axes."""
         _, dpls = run_simulation
         # test plotting multiple dipoles as overlay
         plot_dipole(dpls, show=False)

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -156,15 +156,98 @@ def test_network_visualization(setup_net):
     plt.close("all")
 
 
-def test_dipole_visualization(setup_net):
+def test_dipole_viz_decimation_options(setup_net):
     """Test dipole visualisations."""
     net = setup_net
+    dpls = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
+    fig = dpls[0].plot()  # plot the first dipole alone
+    axes = fig.get_axes()[0]
+    dpls[0].copy().smooth(window_len=10).plot(ax=axes)  # add smoothed versions
+    dpls[0].copy().savgol_filter(h_freq=30).plot(ax=axes)  # on top
 
-    # Test plotting of simulations with no spiking
-    dpls = simulate_dipole(net, tstop=100.0, n_trials=1)
+    # test decimation options
+    plot_dipole(dpls[0], decim=2, show=False)
+    for dec in [-1, [2, 2.0]]:
+        with pytest.raises(
+            ValueError, match="each decimation factor must be a positive"
+        ):
+            plot_dipole(dpls[0], decim=dec, show=False)
+
+
+def test_dipole_viz_dipole_mutiple_layers(setup_net):
+    net = setup_net
+    dpls = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
+    # test plotting multiple dipoles as overlay
+    plot_dipole(dpls, show=False)
+
+    # test plotting multiple dipoles with average
+    plot_dipole(dpls, average=True, show=False)
+    plt.close("all")
+
+    # test plotting dipoles with multiple layers
+    _, ax = plt.subplots()
+    _ = plot_dipole(dpls, show=False, ax=[ax], layer=["L2"])
+    _ = plot_dipole(dpls, show=False, layer=["L2", "L5", "agg"])
+    _, axes = plt.subplots(nrows=3, ncols=1)
+    _ = plot_dipole(dpls, show=False, ax=axes, layer=["L2", "L5", "agg"])
+    _, axes = plt.subplots(nrows=3, ncols=1)
+    _ = plot_dipole(
+        dpls, show=False, ax=[axes[0], axes[1], axes[2]], layer=["L2", "L5", "agg"]
+    )
+
+    plt.close("all")
+
+    with pytest.raises(AssertionError, match="ax and layer should have the same size"):
+        _, axes = plt.subplots(nrows=3, ncols=1)
+        _ = plot_dipole(dpls, show=False, ax=axes, layer=["L2", "L5"])
+
+
+def test_dipole_viz_multiple_tfr(setup_net):
+    net = setup_net
+    dpls = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
+    # multiple TFRs get averaged
+    fig = plot_tfr_morlet(dpls, freqs=np.arange(23, 26, 1.0), n_cycles=3, show=False)
+    # when min_freq > max_freq (y-axis inversion)
+    fig = plot_tfr_morlet(dpls, freqs=np.array([30, 20, 10]), n_cycles=3, show=False)
+    ax = fig.get_axes()[0]
+    y_limits = ax.get_ylim()
+    assert y_limits[0] > y_limits[1], (
+        "Y-axis should be inverted when min_freq > max_freq"
+    )
+
+    with pytest.raises(RuntimeError, match="All dipoles must be scaled equally!"):
+        plot_dipole([dpls[0].copy().scale(10), dpls[1].copy().scale(20)])
+    with pytest.raises(RuntimeError, match="All dipoles must be scaled equally!"):
+        plot_psd([dpls[0].copy().scale(10), dpls[1].copy().scale(20)])
+    with pytest.raises(RuntimeError, match="All dipoles must be sampled equally!"):
+        dpl_sfreq = dpls[0].copy()
+        dpl_sfreq.sfreq /= 10
+        plot_psd([dpls[0], dpl_sfreq])
+
+    # pytest deprecation warning for tmin and tmax
+    with pytest.warns(FutureWarning, match="tmin and tmax are deprecated"):
+        plot_dipole(dpls[0], show=False, tmin=10, tmax=100)
+
+
+def test_dipole_viz_no_data_in_raster_plt(setup_net):
+    net = setup_net
+    simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
     net.cell_response.plot_spikes_raster()
-    net.cell_response.plot_spikes_hist()
+    # test cell response plotting
+    with pytest.raises(TypeError, match="trial_idx must be an instance of"):
+        net.cell_response.plot_spikes_raster(trial_idx="blah", show=False)
+    net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
+    fig = net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
+    assert len(fig.axes[0].collections) > 0, "No data plotted in raster plot"
 
+
+def test_dipole_viz_cell_response_plot_spikes_hist(setup_net):
+    net = setup_net
+
+    # simulation first run
+    simulate_dipole(net, tstop=100.0, n_trials=1)
+
+    net.cell_response.plot_spikes_hist()
     weights_ampa = {"L2_pyramidal": 5.4e-5, "L5_pyramidal": 5.4e-5}
     syn_delays = {"L2_pyramidal": 0.1, "L5_pyramidal": 1.0}
 
@@ -196,73 +279,8 @@ def test_dipole_visualization(setup_net):
         event_seed=14,
     )
 
-    dpls = simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
-    fig = dpls[0].plot()  # plot the first dipole alone
-    axes = fig.get_axes()[0]
-    dpls[0].copy().smooth(window_len=10).plot(ax=axes)  # add smoothed versions
-    dpls[0].copy().savgol_filter(h_freq=30).plot(ax=axes)  # on top
-
-    # test decimation options
-    plot_dipole(dpls[0], decim=2, show=False)
-    for dec in [-1, [2, 2.0]]:
-        with pytest.raises(
-            ValueError, match="each decimation factor must be a positive"
-        ):
-            plot_dipole(dpls[0], decim=dec, show=False)
-
-    # test plotting multiple dipoles as overlay
-    fig = plot_dipole(dpls, show=False)
-
-    # test plotting multiple dipoles with average
-    fig = plot_dipole(dpls, average=True, show=False)
-    plt.close("all")
-
-    # test plotting dipoles with multiple layers
-    fig, ax = plt.subplots()
-    fig = plot_dipole(dpls, show=False, ax=[ax], layer=["L2"])
-    fig = plot_dipole(dpls, show=False, layer=["L2", "L5", "agg"])
-    fig, axes = plt.subplots(nrows=3, ncols=1)
-    fig = plot_dipole(dpls, show=False, ax=axes, layer=["L2", "L5", "agg"])
-    fig, axes = plt.subplots(nrows=3, ncols=1)
-    fig = plot_dipole(
-        dpls, show=False, ax=[axes[0], axes[1], axes[2]], layer=["L2", "L5", "agg"]
-    )
-
-    plt.close("all")
-
-    with pytest.raises(AssertionError, match="ax and layer should have the same size"):
-        fig, axes = plt.subplots(nrows=3, ncols=1)
-        fig = plot_dipole(dpls, show=False, ax=axes, layer=["L2", "L5"])
-
-    # multiple TFRs get averaged
-    fig = plot_tfr_morlet(dpls, freqs=np.arange(23, 26, 1.0), n_cycles=3, show=False)
-    # when min_freq > max_freq (y-axis inversion)
-    fig = plot_tfr_morlet(dpls, freqs=np.array([30, 20, 10]), n_cycles=3, show=False)
-    ax = fig.get_axes()[0]
-    y_limits = ax.get_ylim()
-    assert y_limits[0] > y_limits[1], (
-        "Y-axis should be inverted when min_freq > max_freq"
-    )
-
-    with pytest.raises(RuntimeError, match="All dipoles must be scaled equally!"):
-        plot_dipole([dpls[0].copy().scale(10), dpls[1].copy().scale(20)])
-    with pytest.raises(RuntimeError, match="All dipoles must be scaled equally!"):
-        plot_psd([dpls[0].copy().scale(10), dpls[1].copy().scale(20)])
-    with pytest.raises(RuntimeError, match="All dipoles must be sampled equally!"):
-        dpl_sfreq = dpls[0].copy()
-        dpl_sfreq.sfreq /= 10
-        plot_psd([dpls[0], dpl_sfreq])
-
-    # pytest deprecation warning for tmin and tmax
-    with pytest.warns(FutureWarning, match="tmin and tmax are deprecated"):
-        plot_dipole(dpls[0], show=False, tmin=10, tmax=100)
-
-    # test cell response plotting
-    with pytest.raises(TypeError, match="trial_idx must be an instance of"):
-        net.cell_response.plot_spikes_raster(trial_idx="blah", show=False)
-    net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
-    fig = net.cell_response.plot_spikes_raster(trial_idx=[0, 1], show=False)
-    assert len(fig.axes[0].collections) > 0, "No data plotted in raster plot"
+    # simulation second run
+    simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
 
     with pytest.raises(TypeError, match="trial_idx must be an instance of"):
         net.cell_response.plot_spikes_hist(trial_idx="blah")

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -713,8 +713,6 @@ class TestCellResponsePlotters:
         """Test basic spike histogram plotting."""
         net, _ = base_simulation_spikes
         net.cell_response.plot_spikes_hist()
-        # simulation second run. first one it's in the base_simulation_spikes definition
-        simulate_dipole(net, tstop=100.0, n_trials=2, record_vsec="all")
 
     def test_spikes_hist_trial_idx(self, base_simulation_spikes):
         """Test spike histogram with different trial arguments."""


### PR DESCRIPTION
In this PR.

1. Test function` test_viz.py::est_dipole_visualization ` has been split in 5 different functions:
- `test_dipole_viz_decimation_options`
- `test_dipole_viz_dipole_mutiple_layers`
- `test_dipole_viz_multiple_tfr`
- `test_dipole_viz_no_data_in_raster_plt`
- `test_dipole_viz_cell_response_plot_spikes_hist`

The last function `test_dipole_viz_cell_response_plot_spikes_hist` has been also refactored running a number of simulations needed  to complete the test.