### PR TITLE
[MRG] MAINT Ignore pixi files for codespell

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=40.8.0", "NEURON >=7.7, <=8.2.7; platform_system != 'Windows'"]
 build-backend = "setuptools.build_meta:__legacy__"
 [tool.codespell]
-skip = '.git,*.pdf,*.svg,./hnn_core/mod,./doc/_build,./build,*venv*'
+skip = '.git,*.pdf,*.svg,./hnn_core/mod,./doc/_build,./build,*venv*,.pixi,pixi*'
 check-hidden = true
 # in jupyter notebooks - images and also some embedded outputs
 ignore-regex = '^\s*"image/\S+": ".*|.*%22%3A%20.*'


### PR DESCRIPTION
As the title states, I found that when using  a pixi environment the codespell during `make test` goes into every single file in the environment and takes wayyyy too long. This just adds the relevant files to the ignore list.