### PR TITLE
[MRG] FIX Add back and doc param fname handling

### DIFF
--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -171,15 +171,21 @@ def neymotin_2020_model(
 
     Parameters
     ----------
-    params : str | dict | None
-        The path to the parameter file for constructing the network.
-        If None, parameters loaded from default.json
-        Default: None
-    add_drives_from_params : bool
+    params : str | Path | dict | None, default=None
+        Custom Network parameters to use, if any. If string or Path, it is assumed to be
+        a path to a legacy "flat" JSON file containing the parameters in the style of
+        `hnn_core/param/default.json` (NOT a modern "hierarchical" JSON file like
+        `hnn_core/param/neymotin2020_base.json`). If dict, it is assumed to be a
+        dictionary of parameters in the "flat" JSON style. If None (the default), the
+        default parameters are used from `hnn_core/param/default.json`. Note that if you
+        have drive parameters included, but you ALSO set the deprecated
+        `add_drives_from_params` to True, the drives will be added twice if the drive
+        names are the same.
+    add_drives_from_params : bool, default=False
         If True, add drives as defined in the params-dict. NB this is mainly
         for backward-compatibility with HNN GUI, and will be deprecated in a
         future release. Default: False
-    legacy_mode : bool
+    legacy_mode : bool, default=False
         Set to False by default. Enables matching HNN GUI output when drives
         are added suitably. Will be deprecated in a future release.
     mesh_shape : tuple of int (default: (10, 10))
@@ -219,6 +225,8 @@ def neymotin_2020_model(
     if params is None:
         params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
+    elif isinstance(params, str) or isinstance(params, Path):
+        params = read_params(params)
 
     # Define cell types for Jones 2009 model
     # data is here in metaData format
@@ -405,16 +413,23 @@ def jones_2009_model(
 
     Parameters
     ----------
-    params : str | dict | None
-        The path to the parameter file for constructing the network. If None, parameters
-        loaded from default.json Default: None
-    add_drives_from_params : bool
-        If True, add drives as defined in the params-dict. NB this is mainly for
-        backward-compatibility with HNN GUI, and will be deprecated in a future release.
-        Default: False
-    legacy_mode : bool
-        Set to False by default. Enables matching HNN GUI output when drives are added
-        suitably. Will be deprecated in a future release.
+    params : str | Path | dict | None, default=None
+        Custom Network parameters to use, if any. If string or Path, it is assumed to be
+        a path to a legacy "flat" JSON file containing the parameters in the style of
+        `hnn_core/param/default.json` (NOT a modern "hierarchical" JSON file like
+        `hnn_core/param/neymotin2020_base.json`). If dict, it is assumed to be a
+        dictionary of parameters in the "flat" JSON style. If None (the default), the
+        default parameters are used from `hnn_core/param/default.json`. Note that if you
+        have drive parameters included, but you ALSO set the deprecated
+        `add_drives_from_params` to True, the drives will be added twice if the drive
+        names are the same.
+    add_drives_from_params : bool, default=False
+        If True, add drives as defined in the params-dict. NB this is mainly
+        for backward-compatibility with HNN GUI, and will be deprecated in a
+        future release. Default: False
+    legacy_mode : bool, default=False
+        Set to False by default. Enables matching HNN GUI output when drives
+        are added suitably. Will be deprecated in a future release.
     mesh_shape : tuple of int (default: (10, 10))
         Defines the (n_x, n_y) shape of the grid of pyramidal cells.
 
@@ -467,9 +482,32 @@ def law_2021_model(
     legacy_mode=False,
     mesh_shape=(10, 10),
 ):
-    """Instantiate the expansion of Jones 2009 model to study beta
-    modulated ERPs as described in
-    Law et al. Cereb. Cortex 2021 [1]_
+    """Instantiate the network model described in Law et al., 2021.
+
+    This creates a network that is the expansion of Jones 2009 model to study beta
+    modulated ERPs as described in Law et al. Cereb. Cortex 2021 [1]_ .
+
+    Parameters
+    ----------
+    params : str | Path | dict | None, default=None
+        Custom Network parameters to use, if any. If string or Path, it is assumed to be
+        a path to a legacy "flat" JSON file containing the parameters in the style of
+        `hnn_core/param/default.json` (NOT a modern "hierarchical" JSON file like
+        `hnn_core/param/neymotin2020_base.json`). If dict, it is assumed to be a
+        dictionary of parameters in the "flat" JSON style. If None (the default), the
+        default parameters are used from `hnn_core/param/default.json`. Note that if you
+        have drive parameters included, but you ALSO set the deprecated
+        `add_drives_from_params` to True, the drives will be added twice if the drive
+        names are the same.
+    add_drives_from_params : bool, default=False
+        If True, add drives as defined in the params-dict. NB this is mainly
+        for backward-compatibility with HNN GUI, and will be deprecated in a
+        future release. Default: False
+    legacy_mode : bool, default=False
+        Set to False by default. Enables matching HNN GUI output when drives
+        are added suitably. Will be deprecated in a future release.
+    mesh_shape : tuple of int (default: (10, 10))
+        Defines the (n_x, n_y) shape of the grid of pyramidal cells.
 
     Returns
     -------
@@ -504,6 +542,8 @@ def law_2021_model(
     if params is None:
         params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
+    elif isinstance(params, str) or isinstance(params, Path):
+        params = read_params(params)
 
     net = neymotin_2020_model(
         params,
@@ -571,6 +611,28 @@ def calcium_model(
     L5 pyramidal neurons. For more details on changes to calcium dynamics
     see Kohl et al. Brain Topragr 2022 [1]_
 
+    Parameters
+    ----------
+    params : str | Path | dict | None, default=None
+        Custom Network parameters to use, if any. If string or Path, it is assumed to be
+        a path to a legacy "flat" JSON file containing the parameters in the style of
+        `hnn_core/param/default.json` (NOT a modern "hierarchical" JSON file like
+        `hnn_core/param/neymotin2020_base.json`). If dict, it is assumed to be a
+        dictionary of parameters in the "flat" JSON style. If None (the default), the
+        default parameters are used from `hnn_core/param/default.json`. Note that if you
+        have drive parameters included, but you ALSO set the deprecated
+        `add_drives_from_params` to True, the drives will be added twice if the drive
+        names are the same.
+    add_drives_from_params : bool, default=False
+        If True, add drives as defined in the params-dict. NB this is mainly
+        for backward-compatibility with HNN GUI, and will be deprecated in a
+        future release. Default: False
+    legacy_mode : bool, default=False
+        Set to False by default. Enables matching HNN GUI output when drives
+        are added suitably. Will be deprecated in a future release.
+    mesh_shape : tuple of int (default: (10, 10))
+        Defines the (n_x, n_y) shape of the grid of pyramidal cells.
+
     Returns
     -------
     net : Instance of Network object
@@ -599,6 +661,8 @@ def calcium_model(
     if params is None:
         params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
+    elif isinstance(params, str) or isinstance(params, Path):
+        params = read_params(params)
 
     net = jones_2009_model(
         params,
@@ -622,14 +686,47 @@ def calcium_model(
 
 
 def duecker_ET_model(
-    params=None, add_drives_from_params=False, legacy_mode=False, mesh_shape=(10, 10)
+    params=None,
+    add_drives_from_params=False,
+    legacy_mode=False,
+    mesh_shape=(10, 10),
 ):
-    """ "Initiate like old calcium model and then replace with new cells"""
+    """Initiate the Duecker model (like old calcium model and then replace with new cells)
+
+    Parameters
+    ----------
+    params : str | Path | dict | None, default=None
+        Custom Network parameters to use, if any. If string or Path, it is assumed to be
+        a path to a legacy "flat" JSON file containing the parameters in the style of
+        `hnn_core/param/default.json` (NOT a modern "hierarchical" JSON file like
+        `hnn_core/param/neymotin2020_base.json`). If dict, it is assumed to be a
+        dictionary of parameters in the "flat" JSON style. If None (the default), the
+        default parameters are used from `hnn_core/param/default.json`. Note that if you
+        have drive parameters included, but you ALSO set the deprecated
+        `add_drives_from_params` to True, the drives will be added twice if the drive
+        names are the same.
+    add_drives_from_params : bool, default=False
+        If True, add drives as defined in the params-dict. NB this is mainly
+        for backward-compatibility with HNN GUI, and will be deprecated in a
+        future release. Default: False
+    legacy_mode : bool, default=False
+        Set to False by default. Enables matching HNN GUI output when drives
+        are added suitably. Will be deprecated in a future release.
+    mesh_shape : tuple of int (default: (10, 10))
+        Defines the (n_x, n_y) shape of the grid of pyramidal cells.
+
+    Returns
+    -------
+    net : Instance of Network object
+        Network object used to store
+    """
 
     hnn_core_root = Path(hnn_core.__file__).parent
     if params is None:
         params_fname = hnn_core_root / "param" / "default_duecker_ET.json"
         params = read_params(params_fname)
+    elif isinstance(params, str) or isinstance(params, Path):
+        params = read_params(params)
 
     cell_types = {
         "L2_inhibitory": {

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -222,11 +222,16 @@ def neymotin_2020_model(
 
     """
     hnn_core_root = Path(hnn_core.__file__).parent
+    _validate_type(
+        params, (str, Path, dict, type(None)), "params", "str | Path | dict | None"
+    )
     if params is None:
         params_fname = hnn_core_root / "param" / "default.json"
         params = read_params(params_fname)
     elif isinstance(params, str) or isinstance(params, Path):
         params = read_params(params)
+    # If the user has provided params as a dict, then we don't need to load it from
+    # file, and its correctness will be checked later inside the `Network` initializer.
 
     # Define cell types for Jones 2009 model
     # data is here in metaData format

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -445,8 +445,18 @@ def test_network_models():
             == 200.0
         )
 
-    # Check add_default_erp()
+    # Check add_default_erp() and input arguments to neymotin_2020_model
     net_default = neymotin_2020_model()
+
+    net_params_str = neymotin_2020_model(params=str(params_fname))
+    assert net_default == net_params_str
+    net_params_path = neymotin_2020_model(params=params_fname)
+    assert net_default == net_params_path
+    net_params_dict = neymotin_2020_model(params=read_params(params_fname))
+    assert net_default == net_params_dict
+    net_params_none = neymotin_2020_model(params=None)
+    assert net_default == net_params_none
+
     with pytest.raises(TypeError, match="net must be"):
         add_erp_drives_to_jones_model(net="invalid_input")
     with pytest.raises(TypeError, match="tstart must be"):


### PR DESCRIPTION
This adds back in something that was accidentally deleted in https://github.com/jonescompneurolab/hnn-core/commit/49f210fb41481ab859537e9b3e32a74117ae95fc which was the ability for network models functions (such as `neymotin_2020_model`) to take their argument `params` as a string or Path representing the location of a filename. You can compare the current `master` branch
https://github.com/jonescompneurolab/hnn-core/blob/e117514ec5fc41be5e4761be413fcffe4ba2638a/hnn_core/network_models.py#L219-L221 to stable v0.6.1 here
https://github.com/jonescompneurolab/hnn-core/blob/v0.6.1/hnn_core/network_models.py#L75-L76 to see that accepting `params` as a `str` was accidentally removed.

This was only surfaced by our CircleCI's running of `plot_simulate_somato.py` failing
https://app.circleci.com/pipelines/github/jonescompneurolab/hnn-core/5771/workflows/d9c91460-3004-49e7-bc50-1277ca3d3a6d/jobs/6164 since, surprisingly, we did not have any tests for this extremely important argument case! This PR also adds a test to make sure that the four ways of passing `params` work, and are identical.